### PR TITLE
Add Godot project skeleton with initial scripts

### DIFF
--- a/main.tscn
+++ b/main.tscn
@@ -1,0 +1,5 @@
+[gd_scene format=3]
+
+[node name="Main" type="Node"]
+
+[node name="GameManager" parent="." instance=ExtResource("res://scenes/GameManager.tscn")]

--- a/project.godot
+++ b/project.godot
@@ -1,0 +1,9 @@
+; Engine configuration file.
+; It's not advised to edit this file manually, as it can be
+; automatically replaced by the engine.
+
+config_version=5
+
+[application]
+config/name="Bang Multiplayer"
+run/main_scene="res://main.tscn"

--- a/scenes/GameManager.tscn
+++ b/scenes/GameManager.tscn
@@ -1,0 +1,4 @@
+[gd_scene format=3]
+
+[node name="GameManager" type="Node"]
+script = ExtResource("res://scripts/GameManager.gd")

--- a/scenes/Player.tscn
+++ b/scenes/Player.tscn
@@ -1,0 +1,4 @@
+[gd_scene format=3]
+
+[node name="Player" type="Node"]
+script = ExtResource("res://scripts/Player.gd")

--- a/scripts/GameManager.gd
+++ b/scripts/GameManager.gd
@@ -1,0 +1,76 @@
+extends Node
+
+class_name GameManager
+
+signal player_damaged(player)
+signal player_healed(player)
+signal turn_started(player)
+
+var players: Array[Player] = []
+var current_turn: int = 0
+var turn_order: Array[int] = []
+
+func _ready() -> void:
+    multiplayer.connected_to_server.connect(_on_connected_to_server)
+    if multiplayer.is_server():
+        _setup_signals()
+    add_to_group("game_manager")
+
+func _setup_signals() -> void:
+    get_tree().get_root().connect("player_damaged", self, "_on_player_damaged")
+    get_tree().get_root().connect("player_healed", self, "_on_player_healed")
+
+func _on_connected_to_server() -> void:
+    if multiplayer.is_server():
+        start_game()
+
+func start_game() -> void:
+    turn_order = []
+    for id in multiplayer.get_peers():
+        turn_order.append(id)
+    current_turn = 0
+    _begin_turn()
+
+func _begin_turn() -> void:
+    var id = turn_order[current_turn]
+    rpc_id(id, "start_turn")
+    emit_signal("turn_started", _get_player_by_id(id))
+
+@rpc
+func start_turn() -> void:
+    # Client side start of turn
+    pass
+
+func end_turn() -> void:
+    if multiplayer.is_server():
+        current_turn = (current_turn + 1) % turn_order.size()
+        _begin_turn()
+
+func add_player(player: Player) -> void:
+    players.append(player)
+
+func _get_player_by_id(id: int) -> Player:
+    for p in players:
+        if p.get_multiplayer_authority() == id:
+            return p
+    return null
+
+func _on_player_damaged(player: Player) -> void:
+    if player.health <= 0:
+        _check_win_conditions()
+
+func _on_player_healed(player: Player) -> void:
+    pass
+
+func _check_win_conditions() -> void:
+    var alive = [p for p in players if p.is_alive()]
+    var sheriff_alive = alive.any(lambda p: p.role == Player.Role.SHERIFF)
+    var outlaws_alive = alive.any(lambda p: p.role == Player.Role.OUTLAW)
+    var renegade_alive = alive.any(lambda p: p.role == Player.Role.RENEGADE)
+    if not sheriff_alive:
+        if alive.size() == 1 and alive[0].role == Player.Role.RENEGADE:
+            print("Renegade wins!")
+        else:
+            print("Outlaws win!")
+    elif not outlaws_alive and not renegade_alive:
+        print("Sheriff and Deputies win!")

--- a/scripts/Player.gd
+++ b/scripts/Player.gd
@@ -1,0 +1,26 @@
+extends Node
+
+class_name Player
+
+enum Role {SHERIFF, DEPUTY, OUTLAW, RENEGADE}
+
+var name: String
+var role: int = Role.OUTLAW
+var health: int = 4
+var max_health: int = 4
+var metadata: Dictionary = {}
+
+func _init(_name: String="", _role: int=Role.OUTLAW, _max_health: int=4):
+    name = _name
+    role = _role
+    max_health = _max_health
+    health = max_health
+
+func take_damage(amount: int) -> void:
+    health = max(0, health - amount)
+
+func heal(amount: int) -> void:
+    health = min(max_health, health + amount)
+
+func is_alive() -> bool:
+    return health > 0

--- a/scripts/cards/Bang.gd
+++ b/scripts/cards/Bang.gd
@@ -1,0 +1,14 @@
+extends Card
+
+class_name BangCard
+
+func _init():
+    card_name = "Bang!"
+
+func play(target: Player) -> void:
+    if not target:
+        return
+    target.take_damage(1)
+    var gm = get_tree().get_first_node_in_group("game_manager")
+    if gm:
+        gm.emit_signal("player_damaged", target)

--- a/scripts/cards/Beer.gd
+++ b/scripts/cards/Beer.gd
@@ -1,0 +1,14 @@
+extends Card
+
+class_name BeerCard
+
+func _init():
+    card_name = "Beer"
+
+func play(target: Player) -> void:
+    if not target:
+        return
+    target.heal(1)
+    var gm = get_tree().get_first_node_in_group("game_manager")
+    if gm:
+        gm.emit_signal("player_healed", target)

--- a/scripts/cards/Card.gd
+++ b/scripts/cards/Card.gd
@@ -1,0 +1,8 @@
+extends Resource
+
+class_name Card
+
+var card_name: String = "Card"
+
+func play(target: Player) -> void:
+    pass

--- a/scripts/cards/Missed.gd
+++ b/scripts/cards/Missed.gd
@@ -1,0 +1,12 @@
+extends Card
+
+class_name MissedCard
+
+func _init():
+    card_name = "Missed!"
+
+func play(target: Player) -> void:
+    if not target:
+        return
+    # mark target as having dodged the last Bang
+    target.metadata["dodged"] = true


### PR DESCRIPTION
## Summary
- initialize basic Godot project
- add core scenes: GameManager and Player
- implement GameManager with turn order and win/lose logic
- add Player script and card scripts (Bang!, Missed!, Beer)
- basic multiplayer stubs using Godot high level API

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cc46b476c832394fcecd13665d4d8