### PR TITLE
Host screenshot externally

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,15 @@ python3 -m bang_py.network.client
 You will be prompted for a name and then receive updates about the game state.
 
 This networking layer is experimental and only demonstrates joining the game and ending turns over websockets.
+
+## Screenshot
+
+![Game screenshot](https://files.catbox.moe/tzvm7f.png)
+
+The screenshot is hosted externally to keep the repository free of binary assets.
+
+## Updating screenshots
+
+1. Capture a new screenshot of the game.
+2. Upload the image to an image hosting service or attach it to a GitHub issue.
+3. Replace the image URL in this README so it points to the new screenshot.


### PR DESCRIPTION
## Summary
- link to screenshot hosted on catbox
- document how to update the screenshot

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686df825950c832386f04fe7da781d88