### PR TITLE
Add equipment range and distance modifiers

### DIFF
--- a/bang_py/cards/__init__.py
+++ b/bang_py/cards/__init__.py
@@ -1,0 +1,31 @@
+from .bang import BangCard
+from .beer import BeerCard
+from .missed import MissedCard
+from .equipment import EquipmentCard
+from .volcanic import VolcanicCard
+from .schofield import SchofieldCard
+from .remington import RemingtonCard
+from .carbine import CarbineCard
+from .winchester import WinchesterCard
+from .barrel import BarrelCard
+from .scope import ScopeCard
+from .mustang import MustangCard
+from .jail import JailCard
+from .dynamite import DynamiteCard
+
+__all__ = [
+    'BangCard',
+    'BeerCard',
+    'MissedCard',
+    'EquipmentCard',
+    'VolcanicCard',
+    'SchofieldCard',
+    'RemingtonCard',
+    'CarbineCard',
+    'WinchesterCard',
+    'BarrelCard',
+    'ScopeCard',
+    'MustangCard',
+    'JailCard',
+    'DynamiteCard',
+]

--- a/bang_py/cards/barrel.py
+++ b/bang_py/cards/barrel.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from .equipment import EquipmentCard
+
+
+class BarrelCard(EquipmentCard):
+    card_name = "Barrel"
+    description = "Draw when targeted by Bang!; on Heart, ignore it."

--- a/bang_py/cards/carbine.py
+++ b/bang_py/cards/carbine.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from .equipment import EquipmentCard
+
+
+class CarbineCard(EquipmentCard):
+    card_name = "Carbine"
+    slot = "Gun"
+    range = 4
+    description = "Gun with range 4."

--- a/bang_py/cards/dynamite.py
+++ b/bang_py/cards/dynamite.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from .equipment import EquipmentCard
+
+
+class DynamiteCard(EquipmentCard):
+    card_name = "Dynamite"
+    description = "Passes around; may explode for 3 damage."

--- a/bang_py/cards/equipment.py
+++ b/bang_py/cards/equipment.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from .card import Card
+from ..player import Player
+
+
+class EquipmentCard(Card):
+    """Base class for equipment cards."""
+
+    card_name = "Equipment"
+    slot: str | None = None
+    # Range added to attacks made by the player
+    range_modifier: int = 0
+    # Distance penalty applied to opponents trying to target the player
+    distance_modifier: int = 0
+    # Optional description of the card's effect for UI purposes
+    description: str | None = None
+
+    def play(self, target: Player) -> None:
+        if not target:
+            return
+        target.equip(self)

--- a/bang_py/cards/jail.py
+++ b/bang_py/cards/jail.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from .equipment import EquipmentCard
+
+
+class JailCard(EquipmentCard):
+    card_name = "Jail"
+    description = "Skip your turn unless you draw a Heart."

--- a/bang_py/cards/mustang.py
+++ b/bang_py/cards/mustang.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from .equipment import EquipmentCard
+
+
+class MustangCard(EquipmentCard):
+    card_name = "Mustang"
+    distance_modifier = 1
+    description = "Opponents see you at 1 greater distance."

--- a/bang_py/cards/remington.py
+++ b/bang_py/cards/remington.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from .equipment import EquipmentCard
+
+
+class RemingtonCard(EquipmentCard):
+    card_name = "Remington"
+    slot = "Gun"
+    range = 3
+    description = "Gun with range 3."

--- a/bang_py/cards/schofield.py
+++ b/bang_py/cards/schofield.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from .equipment import EquipmentCard
+
+
+class SchofieldCard(EquipmentCard):
+    card_name = "Schofield"
+    slot = "Gun"
+    range = 2
+    description = "Gun with range 2."

--- a/bang_py/cards/scope.py
+++ b/bang_py/cards/scope.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from .equipment import EquipmentCard
+
+
+class ScopeCard(EquipmentCard):
+    card_name = "Scope"
+    range_modifier = 1
+    description = "Increases your attack range by 1."

--- a/bang_py/cards/volcanic.py
+++ b/bang_py/cards/volcanic.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from .equipment import EquipmentCard
+
+
+class VolcanicCard(EquipmentCard):
+    card_name = "Volcanic"
+    slot = "Gun"
+    range = 1
+    description = "Gun with range 1."

--- a/bang_py/cards/winchester.py
+++ b/bang_py/cards/winchester.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from .equipment import EquipmentCard
+
+
+class WinchesterCard(EquipmentCard):
+    card_name = "Winchester"
+    slot = "Gun"
+    range = 5
+    description = "Gun with range 5."

--- a/bang_py/player.py
+++ b/bang_py/player.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 from dataclasses import dataclass, field
 from enum import Enum, auto
+from typing import Dict, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from .cards.equipment import EquipmentCard
 
 
 class Role(Enum):
@@ -17,9 +21,51 @@ class Player:
     max_health: int = 4
     health: int = field(init=False)
     metadata: dict = field(default_factory=dict)
+    equipment: Dict[str, "EquipmentCard"] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         self.health = self.max_health
+
+    def equip(self, card: "EquipmentCard") -> None:
+        """Add equipment to the player, respecting slot rules."""
+        if getattr(card, "slot", None) == "Gun":
+            self.equipment.pop("Gun", None)
+            self.equipment["Gun"] = card
+        else:
+            # Replace any existing equipment with the same card name
+            self.equipment[card.card_name] = card
+
+    @property
+    def gun_range(self) -> int:
+        gun = self.equipment.get("Gun")
+        if gun and hasattr(gun, "range"):
+            return int(getattr(gun, "range"))
+        return 1
+
+    @property
+    def range_bonus(self) -> int:
+        """Bonus range from equipment such as Scope."""
+        bonus = 0
+        for eq in self.equipment.values():
+            bonus += getattr(eq, "range_modifier", 0)
+        return bonus
+
+    @property
+    def distance_bonus(self) -> int:
+        """Distance penalty applied to opponents due to equipment such as Mustang."""
+        bonus = 0
+        for eq in self.equipment.values():
+            bonus += getattr(eq, "distance_modifier", 0)
+        return bonus
+
+    @property
+    def attack_range(self) -> int:
+        """Maximum range this player can target based on gun and equipment."""
+        return self.gun_range + self.range_bonus
+
+    def distance_to(self, other: "Player") -> int:
+        """Calculate distance to another player considering equipment."""
+        return max(1, 1 + other.distance_bonus - self.range_bonus)
 
     def take_damage(self, amount: int) -> None:
         self.health = max(0, self.health - amount)

--- a/tests/test_cards.py
+++ b/tests/test_cards.py
@@ -1,6 +1,11 @@
 from bang_py.cards.bang import BangCard
 from bang_py.cards.beer import BeerCard
 from bang_py.cards.missed import MissedCard
+from bang_py.cards.barrel import BarrelCard
+from bang_py.cards.schofield import SchofieldCard
+from bang_py.cards.volcanic import VolcanicCard
+from bang_py.cards.scope import ScopeCard
+from bang_py.cards.mustang import MustangCard
 from bang_py.player import Player
 
 
@@ -23,3 +28,39 @@ def test_missed_card_sets_dodged_metadata():
     target = Player("Target")
     MissedCard().play(target)
     assert target.metadata.get("dodged") is True
+
+
+def test_equipment_replaces_same_name():
+    target = Player("Target")
+    BarrelCard().play(target)
+    assert "Barrel" in target.equipment
+    # Play another barrel, should replace existing (no duplicate entries)
+    BarrelCard().play(target)
+    assert list(target.equipment.keys()).count("Barrel") == 1
+
+
+def test_gun_slot_only_one_equipped():
+    target = Player("Target")
+    SchofieldCard().play(target)
+    assert target.equipment["Gun"].card_name == "Schofield"
+    VolcanicCard().play(target)
+    assert target.equipment["Gun"].card_name == "Volcanic"
+
+
+def test_scope_increases_attack_range():
+    player = Player("Shooter")
+    assert player.attack_range == 1
+    ScopeCard().play(player)
+    assert player.attack_range == 2
+    SchofieldCard().play(player)
+    assert player.attack_range == 3  # gun range 2 + scope 1
+
+
+def test_mustang_increases_distance():
+    p1 = Player("One")
+    p2 = Player("Two")
+    assert p1.distance_to(p2) == 1
+    MustangCard().play(p2)
+    assert p1.distance_to(p2) == 2
+    ScopeCard().play(p1)
+    assert p1.distance_to(p2) == 1


### PR DESCRIPTION
## Summary
- move range & distance modifiers onto equipment cards
- expose description attribute for card tooltip text
- compute bonuses from equipped cards

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686f472c80408323b560290249b0f1ba