### PR TITLE
Add basic deck and card play system

### DIFF
--- a/bang_py/deck.py
+++ b/bang_py/deck.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from random import shuffle
+from typing import List
+
+from .cards.card import Card
+
+
+class Deck:
+    """Simple deck of cards supporting drawing."""
+
+    def __init__(self, cards: List[Card] | None = None) -> None:
+        self.cards: List[Card] = cards[:] if cards else []
+        shuffle(self.cards)
+
+    def draw(self) -> Card | None:
+        """Draw a card from the deck if available."""
+        if self.cards:
+            return self.cards.pop()
+        return None
+
+    def add(self, card: Card) -> None:
+        self.cards.insert(0, card)
+
+    def __len__(self) -> int:
+        return len(self.cards)

--- a/bang_py/network/client.py
+++ b/bang_py/network/client.py
@@ -17,6 +17,13 @@ async def main(uri: str = "ws://localhost:8765", room_code: str = "", name: str 
         await websocket.send(name)
         join_msg = await websocket.recv()
         print(join_msg)
+
+        async def send_play(idx: int, target: int | None = None) -> None:
+            payload = {"action": "play_card", "card_index": idx}
+            if target is not None:
+                payload["target"] = target
+            await websocket.send(json.dumps(payload))
+
         async for message in websocket:
             try:
                 data = json.loads(message)

--- a/bang_py/player.py
+++ b/bang_py/player.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 from dataclasses import dataclass, field
 from enum import Enum, auto
-from typing import Dict, TYPE_CHECKING
+from typing import Dict, List, TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from .cards.equipment import EquipmentCard
     from .characters import Character
+    from .cards.card import Card
 
 
 class Role(Enum):
@@ -24,6 +25,7 @@ class Player:
     health: int = field(init=False)
     metadata: dict = field(default_factory=dict)
     equipment: Dict[str, "EquipmentCard"] = field(default_factory=dict)
+    hand: List["Card"] = field(default_factory=list)
 
     def __post_init__(self) -> None:
         self.health = self.max_health

--- a/bang_py/ui.py
+++ b/bang_py/ui.py
@@ -165,8 +165,10 @@ class BangUI:
 
         self.text = tk.Text(self.root, height=15, width=40, state="disabled")
         self.text.grid(row=0, column=0, columnspan=2)
+        play_btn = ttk.Button(self.root, text="Play Card 0", command=self._play_first)
+        play_btn.grid(row=1, column=0, pady=5)
         end_btn = ttk.Button(self.root, text="End Turn", command=self._end_turn)
-        end_btn.grid(row=1, column=0, columnspan=2, pady=5)
+        end_btn.grid(row=1, column=1, pady=5)
 
     def _process_queue(self) -> None:
         while not self.msg_queue.empty():
@@ -180,6 +182,11 @@ class BangUI:
     def _end_turn(self) -> None:
         if self.client:
             self.client.send_end_turn()
+
+    def _play_first(self) -> None:
+        if self.client and self.client.websocket:
+            payload = json.dumps({"action": "play_card", "card_index": 0})
+            asyncio.run_coroutine_threadsafe(self.client.websocket.send(payload), self.client.loop)
 
     def run(self) -> None:
         self.root.mainloop()

--- a/tests/test_new_features.py
+++ b/tests/test_new_features.py
@@ -1,0 +1,29 @@
+from bang_py.game_manager import GameManager
+from bang_py.deck import Deck
+from bang_py.player import Player
+from bang_py.cards.bang import BangCard
+from bang_py.characters import BartCassidy
+
+
+def test_drawing_and_playing():
+    gm = GameManager(deck=Deck([BangCard(), BangCard()]))
+    p1 = Player("A")
+    p2 = Player("B")
+    gm.add_player(p1)
+    gm.add_player(p2)
+    gm.draw_card(p1)
+    assert len(p1.hand) == 1
+    gm.play_card(p1, p1.hand[0], p2)
+    assert len(gm.discard_pile) == 1
+    assert p2.health == p2.max_health - 1
+
+
+def test_bart_cassidy_draw_on_damage():
+    gm = GameManager(deck=Deck([BangCard()]))
+    p1 = Player("Bart", character=BartCassidy())
+    p2 = Player("B")
+    gm.add_player(p1)
+    gm.add_player(p2)
+    p2.hand.append(BangCard())
+    gm.play_card(p2, p2.hand[0], p1)
+    assert len(p1.hand) == 1


### PR DESCRIPTION
## Summary
- implement `Deck` for drawing cards
- store hands in `Player`
- extend `GameManager` with deck support, drawing and card play
- update server to accept card play actions
- simple UI button to play a card
- add new tests for drawing and Bart Cassidy ability

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f51da164c83238d00d7266fa5bfab