### PR TITLE
Implement character abilities and unit tests

### DIFF
--- a/bang_py/cards/bang.py
+++ b/bang_py/cards/bang.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 from .card import Card
 from ..player import Player
 from typing import TYPE_CHECKING
+from ..helpers import is_heart, is_spade_between
+from ..characters import Jourdonnais, LuckyDuke
+from .barrel import BarrelCard
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from ..deck import Deck
@@ -17,7 +20,17 @@ class BangCard(Card):
         if deck:
             barrel = target.equipment.get("Barrel")
             if barrel and getattr(barrel, "draw_check", None):
-                if barrel.draw_check(deck):
+                if barrel.draw_check(deck, target):
+                    target.metadata["dodged"] = True
+                    return
+            if isinstance(target.character, Jourdonnais):
+                if BarrelCard().draw_check(deck, target):
+                    target.metadata["dodged"] = True
+                    return
+            if isinstance(target.character, LuckyDuke):
+                card1 = deck.draw()
+                card2 = deck.draw()
+                if is_heart(card1) or is_heart(card2):
                     target.metadata["dodged"] = True
                     return
         target.take_damage(1)

--- a/bang_py/cards/barrel.py
+++ b/bang_py/cards/barrel.py
@@ -7,6 +7,7 @@ from ..player import Player
 from typing import TYPE_CHECKING
 
 from ..helpers import is_heart
+from ..characters import LuckyDuke
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from ..deck import Deck
@@ -19,7 +20,11 @@ class BarrelCard(EquipmentCard):
     def play(self, target: Player, deck: Deck | None = None) -> None:
         super().play(target)
 
-    def draw_check(self, deck: Deck) -> bool:
+    def draw_check(self, deck: Deck, player: Player | None = None) -> bool:
         """Perform the Barrel draw! check, returning True if Bang! is dodged."""
+        if player and isinstance(player.character, LuckyDuke):
+            card1 = deck.draw()
+            card2 = deck.draw()
+            return is_heart(card1) or is_heart(card2)
         card = deck.draw()
         return is_heart(card)

--- a/bang_py/cards/dynamite.py
+++ b/bang_py/cards/dynamite.py
@@ -4,6 +4,7 @@ from .equipment import EquipmentCard
 from ..player import Player
 from typing import TYPE_CHECKING
 from ..helpers import is_spade_between
+from ..characters import LuckyDuke
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from ..deck import Deck
@@ -23,7 +24,12 @@ class DynamiteCard(EquipmentCard):
 
         Returns True if it exploded on the current player.
         """
-        card = deck.draw()
+        if isinstance(current.character, LuckyDuke):
+            c1 = deck.draw()
+            c2 = deck.draw()
+            card = c1 if not is_spade_between(c1, 2, 9) else c2
+        else:
+            card = deck.draw()
         current.equipment.pop(self.card_name, None)
         if is_spade_between(card, 2, 9):
             current.take_damage(3)

--- a/bang_py/cards/jail.py
+++ b/bang_py/cards/jail.py
@@ -4,6 +4,7 @@ from .equipment import EquipmentCard
 from ..player import Player
 from typing import TYPE_CHECKING
 from ..helpers import is_heart
+from ..characters import LuckyDuke
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from ..deck import Deck
@@ -21,6 +22,12 @@ class JailCard(EquipmentCard):
 
         Returns True if the player's turn is skipped.
         """
-        card = deck.draw()
+        if isinstance(player.character, LuckyDuke):
+            card1 = deck.draw()
+            card2 = deck.draw()
+            result = is_heart(card1) or is_heart(card2)
+        else:
+            card1 = deck.draw()
+            result = is_heart(card1)
         player.equipment.pop(self.card_name, None)
-        return not is_heart(card)
+        return not result

--- a/bang_py/example.py
+++ b/bang_py/example.py
@@ -34,7 +34,7 @@ def main() -> None:
 
     target = gm.players[1]
     bang.play(target)
-    gm.on_player_damaged(target)
+    gm.on_player_damaged(target, gm.players[0])
 
     beer.play(target)
     gm.on_player_healed(target)

--- a/tests/test_characters.py
+++ b/tests/test_characters.py
@@ -18,6 +18,12 @@ from bang_py.characters import (
     VultureSam,
     WillyTheKid,
 )
+from bang_py.game_manager import GameManager
+from bang_py.deck import Deck
+from bang_py.cards.bang import BangCard
+from bang_py.cards.beer import BeerCard
+from bang_py.cards.missed import MissedCard
+from bang_py.cards.jail import JailCard
 
 
 def test_rose_doolan_range_bonus():
@@ -56,3 +62,149 @@ def test_all_character_classes_instantiable():
     ]
     instances = [cls() for cls in chars]
     assert len(instances) == 16
+
+
+def test_bart_cassidy_draw_on_damage():
+    gm = GameManager(deck=Deck([BangCard()]))
+    p1 = Player("Bart", character=BartCassidy())
+    p2 = Player("Shooter")
+    gm.add_player(p1)
+    gm.add_player(p2)
+    p2.hand.append(BangCard())
+    gm.play_card(p2, p2.hand[0], p1)
+    assert len(p1.hand) == 1
+
+
+def test_black_jack_extra_draw():
+    deck = Deck([])
+    deck.cards = [BeerCard(suit="Clubs"), BeerCard(suit="Diamonds"), BeerCard(suit="Spades")]
+    gm = GameManager(deck=deck)
+    p = Player("BJ", character=BlackJack())
+    gm.add_player(p)
+    gm.draw_phase(p)
+    assert len(p.hand) == 3
+
+
+def test_calamity_janet_plays_missed_as_bang():
+    gm = GameManager()
+    attacker = Player("Janet", character=CalamityJanet())
+    target = Player("Bob")
+    gm.add_player(attacker)
+    gm.add_player(target)
+    attacker.hand.append(MissedCard())
+    gm.play_card(attacker, attacker.hand[0], target)
+    assert target.health == target.max_health - 1
+
+
+def test_el_gringo_steals_on_damage():
+    gm = GameManager()
+    gringo = Player("Gringo", character=ElGringo())
+    attacker = Player("Bandit")
+    gm.add_player(gringo)
+    gm.add_player(attacker)
+    attacker.hand.extend([BangCard(), BangCard()])
+    gm.play_card(attacker, attacker.hand[0], gringo)
+    assert len(gringo.hand) == 1
+    assert len(attacker.hand) == 0
+
+
+def test_jesse_jones_draws_from_opponent():
+    deck = Deck([BangCard()])
+    gm = GameManager(deck=deck)
+    jj = Player("JJ", character=JesseJones())
+    other = Player("Other")
+    other.hand.append(BangCard())
+    gm.add_player(jj)
+    gm.add_player(other)
+    gm.draw_phase(jj)
+    assert len(jj.hand) == 2
+    assert len(other.hand) == 0
+
+
+def test_jourdonnais_has_virtual_barrel():
+    deck = Deck([])
+    deck.cards = [BeerCard(suit="Hearts")]
+    target = Player("Jour", character=Jourdonnais())
+    BangCard().play(target, deck)
+    assert target.metadata.get("dodged") is True
+
+
+def test_kit_carlson_draw_three_keep_two():
+    deck = Deck([])
+    deck.cards = [BangCard(), BeerCard(), MissedCard()]
+    gm = GameManager(deck=deck)
+    kit = Player("Kit", character=KitCarlson())
+    gm.add_player(kit)
+    gm.draw_phase(kit)
+    assert len(kit.hand) == 2
+    assert len(gm.discard_pile) == 1
+
+
+def test_lucky_duke_draw_two_on_jail():
+    deck = Deck([])
+    deck.cards = [BangCard(suit="Clubs"), BangCard(suit="Hearts")]
+    player = Player("Lucky", character=LuckyDuke())
+    jail = JailCard()
+    jail.play(player)
+    skipped = jail.check_turn(player, deck)
+    assert skipped is False
+
+
+def test_pedro_ramirez_takes_from_discard():
+    deck = Deck([BangCard()])
+    gm = GameManager(deck=deck)
+    gm.discard_pile.append(MissedCard())
+    pedro = Player("Pedro", character=PedroRamirez())
+    gm.add_player(pedro)
+    gm.draw_phase(pedro)
+    assert len(pedro.hand) == 2
+
+
+def test_sid_ketchum_discard_two_to_heal():
+    gm = GameManager()
+    sid = Player("Sid", character=SidKetchum())
+    gm.add_player(sid)
+    sid.hand.extend([BangCard(), BeerCard()])
+    sid.health -= 1
+    gm.sid_ketchum_ability(sid)
+    assert sid.health == sid.max_health
+    assert len(sid.hand) == 0
+
+
+def test_suzy_lafayette_draws_when_empty():
+    gm = GameManager(deck=Deck([BangCard()]))
+    suzy = Player("Suzy", character=SuzyLafayette())
+    target = Player("Target")
+    gm.add_player(suzy)
+    gm.add_player(target)
+    suzy.hand.append(BangCard())
+    gm.play_card(suzy, suzy.hand[0], target)
+    assert len(suzy.hand) == 1
+
+
+def test_vulture_sam_loots_on_death():
+    gm = GameManager()
+    sam = Player("Sam", character=VultureSam())
+    victim = Player("Vic")
+    attacker = Player("Att")
+    gm.add_player(sam)
+    gm.add_player(victim)
+    gm.add_player(attacker)
+    victim.hand.append(BangCard())
+    victim.health = 1
+    attacker.hand.append(BangCard())
+    gm.play_card(attacker, attacker.hand[0], victim)
+    assert not victim.is_alive()
+    assert len(sam.hand) == 1
+
+
+def test_willy_the_kid_can_play_multiple_bangs():
+    gm = GameManager()
+    willy = Player("Willy", character=WillyTheKid())
+    target = Player("Target")
+    gm.add_player(willy)
+    gm.add_player(target)
+    willy.hand.extend([BangCard(), BangCard()])
+    gm.play_card(willy, willy.hand[0], target)
+    gm.play_card(willy, willy.hand[0], target)
+    assert len(willy.hand) == 0


### PR DESCRIPTION
## Summary
- implement support for many character abilities in `GameManager`
- hook Bang card logic for Jourdonnais and Lucky Duke
- extend equipment checks for Lucky Duke
- add Sid Ketchum ability helper
- update example usage
- create comprehensive character tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f57db525c8323891e70360b0ad44e