### PR TITLE
Add balanced deck creation

### DIFF
--- a/bang_py/__init__.py
+++ b/bang_py/__init__.py
@@ -1,6 +1,7 @@
 """Bang card game modules"""
 
 from .game_manager import GameManager
+from .deck_factory import create_standard_deck
 from .player import Player, Role
 from .characters import (
     Character,
@@ -43,6 +44,7 @@ __all__ = [
     "SuzyLafayette",
     "VultureSam",
     "WillyTheKid",
+    "create_standard_deck",
 ]
 try:
     from .network.server import BangServer

--- a/bang_py/deck_factory.py
+++ b/bang_py/deck_factory.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import random
+from typing import List, Tuple, Type
+
+from .deck import Deck
+from .cards import (
+    BangCard,
+    BeerCard,
+    MissedCard,
+    VolcanicCard,
+    SchofieldCard,
+    RemingtonCard,
+    CarbineCard,
+    WinchesterCard,
+    BarrelCard,
+    ScopeCard,
+    MustangCard,
+    JailCard,
+    DynamiteCard,
+)
+from .cards.card import Card
+
+
+CARD_COUNTS: List[Tuple[Type[Card], int]] = [
+    (BangCard, 25),
+    (MissedCard, 12),
+    (BeerCard, 6),
+    (VolcanicCard, 1),
+    (SchofieldCard, 3),
+    (RemingtonCard, 1),
+    (CarbineCard, 1),
+    (WinchesterCard, 1),
+    (BarrelCard, 2),
+    (ScopeCard, 1),
+    (MustangCard, 2),
+    (JailCard, 3),
+    (DynamiteCard, 1),
+]
+
+
+def _generate_suits(count: int) -> List[str]:
+    """Return a shuffled list of suits with nearly even distribution."""
+    base = count // 4
+    extra = count % 4
+    suits_pool: List[str] = []
+    for i, suit in enumerate(["Hearts", "Diamonds", "Clubs", "Spades"]):
+        suits_pool.extend([suit] * (base + (1 if i < extra else 0)))
+    random.shuffle(suits_pool)
+    return suits_pool
+
+
+def create_standard_deck() -> Deck:
+    """Return a Deck built with cards using a balanced suit distribution."""
+    total = sum(c for _, c in CARD_COUNTS)
+    suits = _generate_suits(total)
+    ranks = list(range(1, 14)) * (total // 13 + 1)
+    random.shuffle(ranks)
+
+    cards: List[Card] = []
+    idx = 0
+    for card_cls, count in CARD_COUNTS:
+        for _ in range(count):
+            suit = suits[idx % len(suits)]
+            rank = ranks[idx % len(ranks)]
+            cards.append(card_cls(suit=suit, rank=rank))
+            idx += 1
+
+    return Deck(cards)

--- a/bang_py/game_manager.py
+++ b/bang_py/game_manager.py
@@ -5,6 +5,7 @@ from typing import Callable, List, Optional
 import random
 
 from .deck import Deck
+from .deck_factory import create_standard_deck
 from .cards.card import Card
 from .characters import (
     BartCassidy,
@@ -29,7 +30,7 @@ from .player import Player, Role
 @dataclass
 class GameManager:
     players: List[Player] = field(default_factory=list)
-    deck: Deck = field(default_factory=Deck)
+    deck: Deck = field(default_factory=create_standard_deck)
     discard_pile: List[Card] = field(default_factory=list)
     current_turn: int = 0
     turn_order: List[int] = field(default_factory=list)

--- a/tests/test_cards.py
+++ b/tests/test_cards.py
@@ -9,6 +9,7 @@ from bang_py.cards.mustang import MustangCard
 from bang_py.cards.jail import JailCard
 from bang_py.cards.dynamite import DynamiteCard
 from bang_py.deck import Deck
+from bang_py.deck_factory import create_standard_deck
 from bang_py.player import Player
 
 
@@ -72,7 +73,8 @@ def test_mustang_increases_distance():
 def test_barrel_dodges_bang_on_heart():
     target = Player("Target")
     BarrelCard().play(target)
-    deck = Deck([BeerCard(suit="Hearts")])
+    deck = create_standard_deck()
+    deck.cards.append(BeerCard(suit="Hearts"))
     BangCard().play(target, deck)
     assert target.health == target.max_health
     assert target.metadata.get("dodged") is True
@@ -81,7 +83,8 @@ def test_barrel_dodges_bang_on_heart():
 def test_barrel_fails_on_non_heart():
     target = Player("Target")
     BarrelCard().play(target)
-    deck = Deck([BeerCard(suit="Clubs")])
+    deck = create_standard_deck()
+    deck.cards.append(BeerCard(suit="Clubs"))
     BangCard().play(target, deck)
     assert target.health == target.max_health - 1
 
@@ -90,7 +93,8 @@ def test_jail_skip_turn():
     player = Player("Prisoner")
     jail = JailCard()
     jail.play(player)
-    deck = Deck([BangCard(suit="Clubs")])
+    deck = create_standard_deck()
+    deck.cards.append(BangCard(suit="Clubs"))
     skipped = jail.check_turn(player, deck)
     assert skipped is True
     assert "Jail" not in player.equipment
@@ -100,7 +104,8 @@ def test_jail_freed_on_heart():
     player = Player("Prisoner")
     jail = JailCard()
     jail.play(player)
-    deck = Deck([BangCard(suit="Hearts")])
+    deck = create_standard_deck()
+    deck.cards.append(BangCard(suit="Hearts"))
     skipped = jail.check_turn(player, deck)
     assert skipped is False
     assert "Jail" not in player.equipment
@@ -111,7 +116,8 @@ def test_dynamite_explodes():
     p2 = Player("Two")
     dyn = DynamiteCard()
     dyn.play(p1)
-    deck = Deck([BangCard(suit="Spades", rank=5)])
+    deck = create_standard_deck()
+    deck.cards.append(BangCard(suit="Spades", rank=5))
     exploded = dyn.check_dynamite(p1, p2, deck)
     assert exploded is True
     assert p1.health == p1.max_health - 3
@@ -123,7 +129,8 @@ def test_dynamite_passes():
     p2 = Player("Two")
     dyn = DynamiteCard()
     dyn.play(p1)
-    deck = Deck([BangCard(suit="Hearts", rank=1)])
+    deck = create_standard_deck()
+    deck.cards.append(BangCard(suit="Hearts", rank=1))
     exploded = dyn.check_dynamite(p1, p2, deck)
     assert exploded is False
     assert "Dynamite" not in p1.equipment

--- a/tests/test_characters.py
+++ b/tests/test_characters.py
@@ -20,6 +20,7 @@ from bang_py.characters import (
 )
 from bang_py.game_manager import GameManager
 from bang_py.deck import Deck
+from bang_py.deck_factory import create_standard_deck
 from bang_py.cards.bang import BangCard
 from bang_py.cards.beer import BeerCard
 from bang_py.cards.missed import MissedCard
@@ -65,7 +66,9 @@ def test_all_character_classes_instantiable():
 
 
 def test_bart_cassidy_draw_on_damage():
-    gm = GameManager(deck=Deck([BangCard()]))
+    deck = create_standard_deck()
+    deck.cards.append(BangCard())
+    gm = GameManager(deck=deck)
     p1 = Player("Bart", character=BartCassidy())
     p2 = Player("Shooter")
     gm.add_player(p1)
@@ -76,8 +79,12 @@ def test_bart_cassidy_draw_on_damage():
 
 
 def test_black_jack_extra_draw():
-    deck = Deck([])
-    deck.cards = [BeerCard(suit="Clubs"), BeerCard(suit="Diamonds"), BeerCard(suit="Spades")]
+    deck = create_standard_deck()
+    deck.cards.extend([
+        BeerCard(suit="Clubs"),
+        BeerCard(suit="Diamonds"),
+        BeerCard(suit="Spades"),
+    ])
     gm = GameManager(deck=deck)
     p = Player("BJ", character=BlackJack())
     gm.add_player(p)
@@ -109,7 +116,8 @@ def test_el_gringo_steals_on_damage():
 
 
 def test_jesse_jones_draws_from_opponent():
-    deck = Deck([BangCard()])
+    deck = create_standard_deck()
+    deck.cards.append(BangCard())
     gm = GameManager(deck=deck)
     jj = Player("JJ", character=JesseJones())
     other = Player("Other")
@@ -122,16 +130,16 @@ def test_jesse_jones_draws_from_opponent():
 
 
 def test_jourdonnais_has_virtual_barrel():
-    deck = Deck([])
-    deck.cards = [BeerCard(suit="Hearts")]
+    deck = create_standard_deck()
+    deck.cards.append(BeerCard(suit="Hearts"))
     target = Player("Jour", character=Jourdonnais())
     BangCard().play(target, deck)
     assert target.metadata.get("dodged") is True
 
 
 def test_kit_carlson_draw_three_keep_two():
-    deck = Deck([])
-    deck.cards = [BangCard(), BeerCard(), MissedCard()]
+    deck = create_standard_deck()
+    deck.cards.extend([BangCard(), BeerCard(), MissedCard()])
     gm = GameManager(deck=deck)
     kit = Player("Kit", character=KitCarlson())
     gm.add_player(kit)
@@ -141,8 +149,8 @@ def test_kit_carlson_draw_three_keep_two():
 
 
 def test_lucky_duke_draw_two_on_jail():
-    deck = Deck([])
-    deck.cards = [BangCard(suit="Clubs"), BangCard(suit="Hearts")]
+    deck = create_standard_deck()
+    deck.cards.extend([BangCard(suit="Clubs"), BangCard(suit="Hearts")])
     player = Player("Lucky", character=LuckyDuke())
     jail = JailCard()
     jail.play(player)
@@ -151,7 +159,8 @@ def test_lucky_duke_draw_two_on_jail():
 
 
 def test_pedro_ramirez_takes_from_discard():
-    deck = Deck([BangCard()])
+    deck = create_standard_deck()
+    deck.cards.append(BangCard())
     gm = GameManager(deck=deck)
     gm.discard_pile.append(MissedCard())
     pedro = Player("Pedro", character=PedroRamirez())
@@ -172,7 +181,9 @@ def test_sid_ketchum_discard_two_to_heal():
 
 
 def test_suzy_lafayette_draws_when_empty():
-    gm = GameManager(deck=Deck([BangCard()]))
+    deck = create_standard_deck()
+    deck.cards.append(BangCard())
+    gm = GameManager(deck=deck)
     suzy = Player("Suzy", character=SuzyLafayette())
     target = Player("Target")
     gm.add_player(suzy)

--- a/tests/test_new_features.py
+++ b/tests/test_new_features.py
@@ -1,12 +1,15 @@
 from bang_py.game_manager import GameManager
 from bang_py.deck import Deck
+from bang_py.deck_factory import create_standard_deck
 from bang_py.player import Player
 from bang_py.cards.bang import BangCard
 from bang_py.characters import BartCassidy
 
 
 def test_drawing_and_playing():
-    gm = GameManager(deck=Deck([BangCard(), BangCard()]))
+    deck = create_standard_deck()
+    deck.cards.extend([BangCard(), BangCard()])
+    gm = GameManager(deck=deck)
     p1 = Player("A")
     p2 = Player("B")
     gm.add_player(p1)
@@ -19,7 +22,9 @@ def test_drawing_and_playing():
 
 
 def test_bart_cassidy_draw_on_damage():
-    gm = GameManager(deck=Deck([BangCard()]))
+    deck = create_standard_deck()
+    deck.cards.append(BangCard())
+    gm = GameManager(deck=deck)
     p1 = Player("Bart", character=BartCassidy())
     p2 = Player("B")
     gm.add_player(p1)


### PR DESCRIPTION
## Summary
- refine `deck_factory.create_standard_deck` to use a nearly even suit distribution
- keep card counts in a constant table and randomize suits and ranks
- minor imports cleanup

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686f5a122c6c832395c683699faaf2ef