### PR TITLE
Support role-based health

### DIFF
--- a/bang_py/characters/__init__.py
+++ b/bang_py/characters/__init__.py
@@ -5,6 +5,7 @@ class Character:
     description: str = ""
     range_modifier: int = 0
     distance_modifier: int = 0
+    max_health_modifier: int = 0
 
 
 class BartCassidy(Character):

--- a/bang_py/player.py
+++ b/bang_py/player.py
@@ -28,6 +28,12 @@ class Player:
     hand: List["Card"] = field(default_factory=list)
 
     def __post_init__(self) -> None:
+        """Initialize max health from role and character modifiers."""
+        base = 5 if self.role == Role.SHERIFF else 4
+        self.max_health = base
+        if self.character is not None:
+            bonus = getattr(self.character, "max_health_modifier", 0)
+            self.max_health += int(bonus)
         self.health = self.max_health
 
     def equip(self, card: "EquipmentCard") -> None:

--- a/tests/test_network_serialization.py
+++ b/tests/test_network_serialization.py
@@ -5,6 +5,8 @@ from bang_py.network.server import _serialize_players
 
 def test_serialize_players_json_roundtrip():
     players = [Player("Alice"), Player("Bob", role=Role.SHERIFF)]
+    assert players[0].max_health == 4
+    assert players[1].max_health == 5
     serialized = _serialize_players(players)
     json_str = json.dumps(serialized)
     loaded = json.loads(json_str)

--- a/tests/test_player_health.py
+++ b/tests/test_player_health.py
@@ -1,0 +1,15 @@
+from bang_py.player import Player, Role
+from bang_py.characters import Character
+
+class BonusLife(Character):
+    max_health_modifier = 1
+
+
+def test_bonus_life_character_increases_max_health():
+    p = Player("Hero", role=Role.OUTLAW, character=BonusLife())
+    assert p.max_health == 5
+    assert p.health == 5
+    sheriff = Player("Sheriff", role=Role.SHERIFF, character=BonusLife())
+    assert sheriff.max_health == 6
+    assert sheriff.health == 6
+


### PR DESCRIPTION
## Summary
- set player health based on role at initialization
- allow characters to modify player max health
- test health initialization and network serialization
- add tests covering custom health bonuses

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f6b598cb08323a4fbe249f9439c03