### PR TITLE
Add turn mechanics and victory callbacks

### DIFF
--- a/bang_py/cards/volcanic.py
+++ b/bang_py/cards/volcanic.py
@@ -7,4 +7,6 @@ class VolcanicCard(EquipmentCard):
     card_name = "Volcanic"
     slot = "Gun"
     range = 1
-    description = "Gun with range 1."
+    # Allows the player to fire unlimited Bang! cards during their turn
+    unlimited_bang = True
+    description = "Gun with range 1. Allows unlimited Bang! cards per turn."

--- a/tests/test_turn_rules.py
+++ b/tests/test_turn_rules.py
@@ -1,0 +1,60 @@
+from bang_py.game_manager import GameManager
+from bang_py.deck import Deck
+from bang_py.player import Player, Role
+from bang_py.cards.bang import BangCard
+from bang_py.characters import WillyTheKid
+
+
+def test_bang_limit_default():
+    gm = GameManager()
+    p1 = Player("A")
+    p2 = Player("B")
+    gm.add_player(p1)
+    gm.add_player(p2)
+    p1.hand.extend([BangCard(), BangCard()])
+    gm.play_card(p1, p1.hand[0], p2)
+    gm.play_card(p1, p1.hand[0], p2)
+    assert p2.health == p2.max_health - 1
+    assert len(p1.hand) == 1
+
+
+def test_willy_the_kid_unlimited_bang():
+    gm = GameManager()
+    p1 = Player("Willy", character=WillyTheKid())
+    p2 = Player("B")
+    gm.add_player(p1)
+    gm.add_player(p2)
+    p1.hand.extend([BangCard(), BangCard()])
+    gm.play_card(p1, p1.hand[0], p2)
+    gm.play_card(p1, p1.hand[0], p2)
+    assert p2.health == p2.max_health - 2
+    assert len(p1.hand) == 0
+
+
+def test_discard_phase():
+    gm = GameManager(deck=Deck([]))
+    p1 = Player("A")
+    p2 = Player("B")
+    gm.add_player(p1)
+    gm.add_player(p2)
+    gm.turn_order = [0, 1]
+    gm.current_turn = 0
+    p1.hand.extend([BangCard() for _ in range(5)])
+    p1.health = 3
+    gm.end_turn()
+    assert len(p1.hand) == 3
+
+
+def test_outlaws_win_when_sheriff_dies():
+    gm = GameManager()
+    sheriff = Player("S", role=Role.SHERIFF)
+    outlaw = Player("O", role=Role.OUTLAW)
+    gm.add_player(sheriff)
+    gm.add_player(outlaw)
+    results: list[str] = []
+    gm.game_over_listeners.append(lambda r: results.append(r))
+    sheriff.health = 1
+    outlaw.hand.append(BangCard())
+    gm.play_card(outlaw, outlaw.hand[0], sheriff)
+    assert results == ["Outlaws win!"]
+


### PR DESCRIPTION
## Summary
- enforce Bang! card play limits and support unlimited-Bang equipment/ability
- add discard phase with hand size enforcement
- emit game over events instead of printing to console
- support Volcanic unlimited Bang gun
- test new turn rules and victory conditions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f6c73f0d08323afc373919b793344