### PR TITLE
Add dynamic UI and state updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,18 @@ Run the interface with:
 bang-ui
 ```
 
-Enter your name and choose **Host Game** or **Join Game**. Hosting launches a local server and shows a room code to share with friends. Joining requires the host address, port, and the room code.
+Enter your name and choose **Host Game** or **Join Game**. Hosting launches a local
+server and shows a room code to share with friends. Joining requires the host
+address, port, and the room code.
+
+Once connected you will see:
+
+1. A list of players with their current health and any equipped items.
+2. A log area for game messages.
+3. Buttons representing the cards in your hand that can be clicked to play them.
+
+Use the **End Turn** button when you are finished. Win or elimination messages are
+shown both in the log and as a popup dialog.
 
 ## Characters
 

--- a/tests/test_network_serialization.py
+++ b/tests/test_network_serialization.py
@@ -11,8 +11,18 @@ def test_serialize_players_json_roundtrip():
     json_str = json.dumps(serialized)
     loaded = json.loads(json_str)
     assert loaded == [
-        {"name": "Alice", "health": players[0].health, "role": "OUTLAW"},
-        {"name": "Bob", "health": players[1].health, "role": "SHERIFF"},
+        {
+            "name": "Alice",
+            "health": players[0].health,
+            "role": "OUTLAW",
+            "equipment": [],
+        },
+        {
+            "name": "Bob",
+            "health": players[1].health,
+            "role": "SHERIFF",
+            "equipment": [],
+        },
     ]
 
 
@@ -20,5 +30,12 @@ def test_serialize_players_with_health_changes():
     sheriff = Player("Bill", role=Role.SHERIFF)
     sheriff.health = 3
     data = _serialize_players([sheriff])
-    assert data == [{"name": "Bill", "health": 3, "role": "SHERIFF"}]
+    assert data == [
+        {
+            "name": "Bill",
+            "health": 3,
+            "role": "SHERIFF",
+            "equipment": [],
+        }
+    ]
 


### PR DESCRIPTION
## Summary
- serialize equipment with player info
- send each player's hand with state updates
- display current players, health, and equipment in Tk UI
- allow selecting any card from hand to play
- notify on wins and eliminations
- document GUI usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f73010ca88323aedd75ba49dd1ad1