### PR TITLE
Fix long description lines

### DIFF
--- a/bang_py/characters/__init__.py
+++ b/bang_py/characters/__init__.py
@@ -18,7 +18,8 @@ class BartCassidy(Character):
 class BlackJack(Character):
     name = "Black Jack"
     description = (
-        "During your draw phase, reveal the second card. If it's Heart or Diamond, draw one additional card."
+        "During your draw phase, reveal the second card. "
+        "If it's Heart or Diamond, draw one additional card."
     )
 
 
@@ -37,7 +38,8 @@ class ElGringo(Character):
 class JesseJones(Character):
     name = "Jesse Jones"
     description = (
-        "At the start of your draw phase, you may draw the first card from another player's hand instead of the deck."
+        "At the start of your draw phase, you may draw the first card from another "
+        "player's hand instead of the deck."
     )
 
 
@@ -69,7 +71,8 @@ class PaulRegret(Character):
 class PedroRamirez(Character):
     name = "Pedro Ramirez"
     description = (
-        "At the start of your draw phase, you may take the top card from the discard pile instead of drawing."
+        "At the start of your draw phase, you may take the top card from the discard "
+        "pile instead of drawing."
     )
 
 


### PR DESCRIPTION
## Summary
- split long description strings in character definitions so lines stay under 100 chars

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f764a6ef08323bd1319910a2c5321