### PR TITLE
Fix long line in GameManager

### DIFF
--- a/bang_py/game_manager.py
+++ b/bang_py/game_manager.py
@@ -139,7 +139,10 @@ class GameManager:
         if is_bang:
             count = int(player.metadata.get("bangs_played", 0))
             gun = player.equipment.get("Gun")
-            unlimited = isinstance(player.character, WillyTheKid) or getattr(gun, "unlimited_bang", False)
+            unlimited = (
+                isinstance(player.character, WillyTheKid)
+                or getattr(gun, "unlimited_bang", False)
+            )
             if count >= 1 and not unlimited:
                 # Cannot play more Bang! cards this turn
                 return


### PR DESCRIPTION
## Summary
- wrap long line in `GameManager.play_card` so it is under 100 chars

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f7a367ab4832394182928e7f0ba28