### PR TITLE
Add missing cards and functionality

### DIFF
--- a/bang_py/cards/__init__.py
+++ b/bang_py/cards/__init__.py
@@ -12,20 +12,38 @@ from .scope import ScopeCard
 from .mustang import MustangCard
 from .jail import JailCard
 from .dynamite import DynamiteCard
+from .stagecoach import StagecoachCard
+from .wells_fargo import WellsFargoCard
+from .cat_balou import CatBalouCard
+from .panic import PanicCard
+from .indians import IndiansCard
+from .duel import DuelCard
+from .general_store import GeneralStoreCard
+from .saloon import SaloonCard
+from .gatling import GatlingCard
 
 __all__ = [
-    'BangCard',
-    'BeerCard',
-    'MissedCard',
-    'EquipmentCard',
-    'VolcanicCard',
-    'SchofieldCard',
-    'RemingtonCard',
-    'CarbineCard',
-    'WinchesterCard',
-    'BarrelCard',
-    'ScopeCard',
-    'MustangCard',
-    'JailCard',
-    'DynamiteCard',
+    "BangCard",
+    "BeerCard",
+    "MissedCard",
+    "EquipmentCard",
+    "VolcanicCard",
+    "SchofieldCard",
+    "RemingtonCard",
+    "CarbineCard",
+    "WinchesterCard",
+    "BarrelCard",
+    "ScopeCard",
+    "MustangCard",
+    "JailCard",
+    "DynamiteCard",
+    "StagecoachCard",
+    "WellsFargoCard",
+    "CatBalouCard",
+    "PanicCard",
+    "IndiansCard",
+    "DuelCard",
+    "GeneralStoreCard",
+    "SaloonCard",
+    "GatlingCard",
 ]

--- a/bang_py/cards/cat_balou.py
+++ b/bang_py/cards/cat_balou.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import random
+from .card import Card
+from ..player import Player
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..game_manager import GameManager
+
+
+class CatBalouCard(Card):
+    card_name = "Cat Balou"
+
+    def play(
+        self, target: Player, game: GameManager | None = None
+    ) -> None:
+        if not target:
+            return
+        if target.hand:
+            card = random.choice(target.hand)
+            target.hand.remove(card)
+            if game:
+                game.discard_pile.append(card)
+        elif target.equipment:
+            card = random.choice(list(target.equipment.values()))
+            target.equipment.pop(card.card_name, None)
+            if game:
+                game.discard_pile.append(card)

--- a/bang_py/cards/duel.py
+++ b/bang_py/cards/duel.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from .card import Card
+from ..player import Player
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..game_manager import GameManager
+    from .bang import BangCard
+
+
+class DuelCard(Card):
+    card_name = "Duel"
+
+    def play(
+        self, target: Player, player: Player | None = None, game: GameManager | None = None
+    ) -> None:
+        if not target or not player or not game:
+            return
+        from .bang import BangCard
+
+        attacker = target
+        defender = player
+        while True:
+            bang = next((c for c in attacker.hand if isinstance(c, BangCard)), None)
+            if bang:
+                attacker.hand.remove(bang)
+                game.discard_pile.append(bang)
+                attacker, defender = defender, attacker
+            else:
+                before = attacker.health
+                attacker.take_damage(1)
+                if attacker.health < before:
+                    game.on_player_damaged(attacker, defender)
+                break

--- a/bang_py/cards/gatling.py
+++ b/bang_py/cards/gatling.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from .card import Card
+from ..player import Player
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..game_manager import GameManager
+    from ..deck import Deck
+
+
+class GatlingCard(Card):
+    card_name = "Gatling"
+
+    def play(
+        self, target: Player, player: Player | None = None, game: GameManager | None = None,
+        deck: Deck | None = None
+    ) -> None:
+        if not game or not player:
+            return
+        for p in game.players:
+            if p is player:
+                continue
+            before = p.health
+            from .bang import BangCard
+
+            BangCard().play(p, deck or game.deck)
+            if p.health < before:
+                game.on_player_damaged(p, player)

--- a/bang_py/cards/general_store.py
+++ b/bang_py/cards/general_store.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from .card import Card
+from ..player import Player
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..game_manager import GameManager
+
+
+class GeneralStoreCard(Card):
+    card_name = "General Store"
+
+    def play(
+        self, target: Player, player: Player | None = None, game: GameManager | None = None
+    ) -> None:
+        if not game:
+            return
+        for p in game.players:
+            game.draw_card(p)

--- a/bang_py/cards/indians.py
+++ b/bang_py/cards/indians.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from .card import Card
+from ..player import Player
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..game_manager import GameManager
+    from .bang import BangCard
+
+
+class IndiansCard(Card):
+    card_name = "Indians!"
+
+    def play(
+        self, target: Player, player: Player | None = None, game: GameManager | None = None
+    ) -> None:
+        if not game or not player:
+            return
+        from .bang import BangCard
+
+        for p in game.players:
+            if p is player:
+                continue
+            bang = next((c for c in p.hand if isinstance(c, BangCard)), None)
+            if bang:
+                p.hand.remove(bang)
+                game.discard_pile.append(bang)
+            else:
+                before = p.health
+                p.take_damage(1)
+                if p.health < before:
+                    game.on_player_damaged(p, player)

--- a/bang_py/cards/panic.py
+++ b/bang_py/cards/panic.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import random
+from .card import Card
+from ..player import Player
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..game_manager import GameManager
+
+
+class PanicCard(Card):
+    card_name = "Panic!"
+
+    def play(
+        self, target: Player, player: Player | None = None, game: GameManager | None = None
+    ) -> None:
+        if not target or not player:
+            return
+        if target.hand:
+            card = random.choice(target.hand)
+            target.hand.remove(card)
+            player.hand.append(card)
+        elif target.equipment:
+            card = random.choice(list(target.equipment.values()))
+            target.equipment.pop(card.card_name, None)
+            player.hand.append(card)
+        if game:
+            # No discard since card is stolen
+            pass

--- a/bang_py/cards/saloon.py
+++ b/bang_py/cards/saloon.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from .card import Card
+from ..player import Player
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..game_manager import GameManager
+
+
+class SaloonCard(Card):
+    card_name = "Saloon"
+
+    def play(
+        self, target: Player, player: Player | None = None, game: GameManager | None = None
+    ) -> None:
+        if not game:
+            return
+        for p in game.players:
+            before = p.health
+            p.heal(1)
+            if p.health > before:
+                game.on_player_healed(p)

--- a/bang_py/cards/stagecoach.py
+++ b/bang_py/cards/stagecoach.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from .card import Card
+from ..player import Player
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..deck import Deck
+    from ..game_manager import GameManager
+
+
+class StagecoachCard(Card):
+    card_name = "Stagecoach"
+
+    def play(
+        self, target: Player, game: GameManager | None = None, deck: Deck | None = None
+    ) -> None:
+        if game:
+            game.draw_card(target, 2)
+        elif deck:
+            for _ in range(2):
+                card = deck.draw()
+                if card:
+                    target.hand.append(card)

--- a/bang_py/cards/wells_fargo.py
+++ b/bang_py/cards/wells_fargo.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from .card import Card
+from ..player import Player
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..deck import Deck
+    from ..game_manager import GameManager
+
+
+class WellsFargoCard(Card):
+    card_name = "Wells Fargo"
+
+    def play(
+        self, target: Player, game: GameManager | None = None, deck: Deck | None = None
+    ) -> None:
+        if game:
+            game.draw_card(target, 3)
+        elif deck:
+            for _ in range(3):
+                card = deck.draw()
+                if card:
+                    target.hand.append(card)

--- a/bang_py/deck_factory.py
+++ b/bang_py/deck_factory.py
@@ -18,6 +18,15 @@ from .cards import (
     MustangCard,
     JailCard,
     DynamiteCard,
+    StagecoachCard,
+    WellsFargoCard,
+    CatBalouCard,
+    PanicCard,
+    IndiansCard,
+    DuelCard,
+    GeneralStoreCard,
+    SaloonCard,
+    GatlingCard,
 )
 from .cards.card import Card
 
@@ -36,6 +45,15 @@ CARD_COUNTS: List[Tuple[Type[Card], int]] = [
     (MustangCard, 2),
     (JailCard, 3),
     (DynamiteCard, 1),
+    (StagecoachCard, 2),
+    (WellsFargoCard, 1),
+    (CatBalouCard, 4),
+    (PanicCard, 4),
+    (IndiansCard, 2),
+    (DuelCard, 3),
+    (GeneralStoreCard, 2),
+    (SaloonCard, 1),
+    (GatlingCard, 1),
 ]
 
 

--- a/bang_py/game_manager.py
+++ b/bang_py/game_manager.py
@@ -24,6 +24,15 @@ from .characters import (
 )
 from .cards.bang import BangCard
 from .cards.missed import MissedCard
+from .cards.stagecoach import StagecoachCard
+from .cards.wells_fargo import WellsFargoCard
+from .cards.cat_balou import CatBalouCard
+from .cards.panic import PanicCard
+from .cards.indians import IndiansCard
+from .cards.duel import DuelCard
+from .cards.general_store import GeneralStoreCard
+from .cards.saloon import SaloonCard
+from .cards.gatling import GatlingCard
 
 from .player import Player, Role
 
@@ -150,11 +159,28 @@ class GameManager:
         before = target.health if target else None
         if isinstance(player.character, CalamityJanet) and isinstance(card, MissedCard) and target:
             BangCard().play(target, self.deck)
+        elif isinstance(card, BangCard):
+            card.play(target, self.deck)
+        elif isinstance(card, StagecoachCard):
+            self.draw_card(player, 2)
+        elif isinstance(card, WellsFargoCard):
+            self.draw_card(player, 3)
+        elif isinstance(card, CatBalouCard) and target:
+            card.play(target, game=self)
+        elif isinstance(card, PanicCard) and target:
+            card.play(target, player, game=self)
+        elif isinstance(card, IndiansCard):
+            card.play(player, player, game=self)
+        elif isinstance(card, DuelCard) and target:
+            card.play(target, player, game=self)
+        elif isinstance(card, GeneralStoreCard):
+            card.play(player, player, game=self)
+        elif isinstance(card, SaloonCard):
+            card.play(player, player, game=self)
+        elif isinstance(card, GatlingCard):
+            card.play(player, player, game=self)
         else:
-            if isinstance(card, BangCard):
-                card.play(target, self.deck)
-            else:
-                card.play(target)
+            card.play(target)
         if target and before is not None and target.health < before:
             self.on_player_damaged(target, player)
         if target and before is not None and target.health > before:

--- a/tests/test_additional_cards.py
+++ b/tests/test_additional_cards.py
@@ -1,0 +1,122 @@
+from bang_py.game_manager import GameManager
+from bang_py.deck import Deck
+from bang_py.player import Player
+from bang_py.cards import (
+    StagecoachCard,
+    WellsFargoCard,
+    CatBalouCard,
+    PanicCard,
+    IndiansCard,
+    DuelCard,
+    GeneralStoreCard,
+    SaloonCard,
+    GatlingCard,
+    BangCard,
+)
+
+
+def test_stagecoach_draws_two_cards():
+    deck = Deck([BangCard(), BangCard(), BangCard()])
+    gm = GameManager(deck=deck)
+    p = Player("A")
+    gm.add_player(p)
+    StagecoachCard().play(p, game=gm)
+    assert len(p.hand) == 2
+
+
+def test_wells_fargo_draws_three_cards():
+    deck = Deck([BangCard(), BangCard(), BangCard(), BangCard()])
+    gm = GameManager(deck=deck)
+    p = Player("A")
+    gm.add_player(p)
+    WellsFargoCard().play(p, game=gm)
+    assert len(p.hand) == 3
+
+
+def test_panic_steals_card():
+    gm = GameManager(deck=Deck([]))
+    p1 = Player("A")
+    p2 = Player("B")
+    gm.add_player(p1)
+    gm.add_player(p2)
+    p2.hand.append(BangCard())
+    PanicCard().play(p2, p1, game=gm)
+    assert len(p1.hand) == 1
+    assert len(p2.hand) == 0
+
+
+def test_cat_balou_discards_card():
+    gm = GameManager(deck=Deck([]))
+    p1 = Player("A")
+    p2 = Player("B")
+    gm.add_player(p1)
+    gm.add_player(p2)
+    p2.hand.append(BangCard())
+    CatBalouCard().play(p2, game=gm)
+    assert len(p2.hand) == 0
+    assert len(gm.discard_pile) == 1
+
+
+def test_indians_forces_bang_or_damage():
+    gm = GameManager(deck=Deck([]))
+    p1 = Player("A")
+    p2 = Player("B")
+    p3 = Player("C")
+    gm.add_player(p1)
+    gm.add_player(p2)
+    gm.add_player(p3)
+    p2.hand.append(BangCard())
+    IndiansCard().play(p1, p1, game=gm)
+    assert len(p2.hand) == 0
+    assert p3.health == p3.max_health - 1
+
+
+def test_duel_discards_bang_until_damage():
+    gm = GameManager(deck=Deck([]))
+    p1 = Player("A")
+    p2 = Player("B")
+    gm.add_player(p1)
+    gm.add_player(p2)
+    p2.hand.append(BangCard())
+    DuelCard().play(p2, p1, game=gm)
+    assert p1.health == p1.max_health - 1
+    assert len(p2.hand) == 0
+
+
+def test_general_store_gives_each_player_card():
+    deck = Deck([BangCard(), BangCard()])
+    gm = GameManager(deck=deck)
+    p1 = Player("A")
+    p2 = Player("B")
+    gm.add_player(p1)
+    gm.add_player(p2)
+    GeneralStoreCard().play(p1, p1, game=gm)
+    assert len(p1.hand) == 1
+    assert len(p2.hand) == 1
+
+
+def test_saloon_heals_everyone():
+    gm = GameManager(deck=Deck([]))
+    p1 = Player("A")
+    p2 = Player("B")
+    gm.add_player(p1)
+    gm.add_player(p2)
+    p1.health -= 1
+    p2.health -= 1
+    SaloonCard().play(p1, p1, game=gm)
+    assert p1.health == p1.max_health
+    assert p2.health == p2.max_health
+
+
+def test_gatling_hits_all_opponents():
+    gm = GameManager(deck=Deck([]))
+    p1 = Player("A")
+    p2 = Player("B")
+    p3 = Player("C")
+    gm.add_player(p1)
+    gm.add_player(p2)
+    gm.add_player(p3)
+    GatlingCard().play(p1, p1, game=gm)
+    assert p2.health == p2.max_health - 1
+    assert p3.health == p3.max_health - 1
+


### PR DESCRIPTION
## Summary
- implement remaining Bang! cards and update exports
- expand deck factory with counts for all cards
- handle new cards in GameManager
- add tests for new card behaviors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f98bc502c8323a387480a80aa5d26