### PR TITLE
Simplify seat-based distance

### DIFF
--- a/bang_py/game_manager.py
+++ b/bang_py/game_manager.py
@@ -55,6 +55,8 @@ class GameManager:
     game_over_listeners: List[Callable[[str], None]] = field(default_factory=list)
 
     def add_player(self, player: Player) -> None:
+        """Add a player to the game and record the game reference."""
+        player.metadata["game"] = self
         self.players.append(player)
 
     def start_game(self) -> None:

--- a/tests/test_gamemanager.py
+++ b/tests/test_gamemanager.py
@@ -1,5 +1,3 @@
-import pytest
-
 from bang_py.game_manager import GameManager
 from bang_py.player import Player
 
@@ -18,3 +16,40 @@ def test_start_game_initializes_turn_order_and_calls_listener():
     assert gm.turn_order == [0, 1]
     assert gm.current_turn == 0
     assert started_players == [p1]
+
+
+def test_distance_accounts_for_seating_and_deaths():
+    gm = GameManager()
+    p1 = Player("A")
+    p2 = Player("B")
+    p3 = Player("C")
+    p4 = Player("D")
+    gm.add_player(p1)
+    gm.add_player(p2)
+    gm.add_player(p3)
+    gm.add_player(p4)
+
+    assert p1.distance_to(p3) == 2
+
+    p2.health = 0
+
+    assert p1.distance_to(p3) == 1
+
+
+def test_distance_with_three_players_is_one():
+    gm = GameManager()
+    players = [Player(str(i)) for i in range(3)]
+    for p in players:
+        gm.add_player(p)
+
+    assert all(players[0].distance_to(players[i]) == 1 for i in [1, 2])
+
+
+def test_max_distance_with_seven_players():
+    gm = GameManager()
+    players = [Player(str(i)) for i in range(7)]
+    for p in players:
+        gm.add_player(p)
+
+    assert players[0].distance_to(players[3]) == 3
+    assert players[0].distance_to(players[4]) == 3


### PR DESCRIPTION
## Summary
- attach GameManager reference to players when added
- compute distance based on seating and living players
- test seat-aware distance calculation
- clarify maximum distance with 3 and 7 player setups

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687011f37cc88323b6d58a23ad80f45f