### PR TITLE
Implement remaining Bang rules

### DIFF
--- a/bang_py/cards/beer.py
+++ b/bang_py/cards/beer.py
@@ -2,6 +2,10 @@ from __future__ import annotations
 
 from .card import Card
 from ..player import Player
+from typing import Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from ..game_manager import GameManager
 
 
 class BeerCard(Card):
@@ -10,5 +14,11 @@ class BeerCard(Card):
     def play(self, target: Player) -> None:
         if not target:
             return
-        target.heal(1)
+        game: Optional["GameManager"] = target.metadata.get("game")
+        if game:
+            alive = [p for p in game.players if p.is_alive()]
+            if len(alive) <= 2:
+                return
+        if target.health < target.max_health:
+            target.heal(1)
 

--- a/bang_py/game_manager.py
+++ b/bang_py/game_manager.py
@@ -29,6 +29,7 @@ from .cards.stagecoach import StagecoachCard
 from .cards.wells_fargo import WellsFargoCard
 from .cards.cat_balou import CatBalouCard
 from .cards.panic import PanicCard
+from .cards.jail import JailCard
 from .cards.indians import IndiansCard
 from .cards.duel import DuelCard
 from .cards.general_store import GeneralStoreCard
@@ -163,6 +164,14 @@ class GameManager:
 
     def play_card(self, player: Player, card: Card, target: Optional[Player] = None) -> None:
         if card not in player.hand:
+            return
+        if isinstance(card, BangCard) and target:
+            if player.distance_to(target) > player.attack_range:
+                return
+        if isinstance(card, PanicCard) and target:
+            if player.distance_to(target) > 1:
+                return
+        if isinstance(card, JailCard) and target and target.role == Role.SHERIFF:
             return
         # Determine if this card counts as a Bang!
         is_bang = isinstance(card, BangCard) or (

--- a/tests/test_missing_rules.py
+++ b/tests/test_missing_rules.py
@@ -1,0 +1,67 @@
+from bang_py.game_manager import GameManager
+from bang_py.player import Player, Role
+from bang_py.cards.bang import BangCard
+from bang_py.cards.beer import BeerCard
+from bang_py.cards.panic import PanicCard
+from bang_py.cards.jail import JailCard
+
+
+def test_bang_requires_range():
+    gm = GameManager()
+    attacker = Player("A")
+    target = Player("B")
+    gm.add_player(attacker)
+    gm.add_player(target)
+    attacker.hand.append(BangCard())
+    # default distance is 1 so attack succeeds
+    gm.play_card(attacker, attacker.hand[0], target)
+    assert target.health == target.max_health - 1
+    target.health = target.max_health
+    # give target Mustang to increase distance to 2
+    from bang_py.cards.mustang import MustangCard
+    MustangCard().play(target)
+    attacker.hand.append(BangCard())
+    gm.play_card(attacker, attacker.hand[-1], target)
+    # out of range, no damage and card still in hand
+    assert target.health == target.max_health
+    assert len(attacker.hand) == 1
+
+
+def test_panic_requires_range_one():
+    gm = GameManager()
+    p1 = Player("One")
+    p2 = Player("Two")
+    gm.add_player(p1)
+    gm.add_player(p2)
+    p2.hand.append(BangCard())
+    p1.hand.append(PanicCard())
+    # Increase distance to 2
+    from bang_py.cards.mustang import MustangCard
+    MustangCard().play(p2)
+    gm.play_card(p1, p1.hand[0], p2)
+    assert len(p2.hand) == 1
+    assert len(p1.hand) == 1
+
+
+def test_beer_no_effect_with_two_players():
+    gm = GameManager()
+    p1 = Player("A")
+    p2 = Player("B")
+    gm.add_player(p1)
+    gm.add_player(p2)
+    p1.health -= 1
+    BeerCard().play(p1)
+    assert p1.health == p1.max_health - 1
+
+
+def test_jail_cannot_target_sheriff():
+    gm = GameManager()
+    sheriff = Player("Sheriff", role=Role.SHERIFF)
+    outlaw = Player("Outlaw")
+    gm.add_player(sheriff)
+    gm.add_player(outlaw)
+    jail = JailCard()
+    outlaw.hand.append(jail)
+    gm.play_card(outlaw, jail, sheriff)
+    assert "Jail" not in sheriff.equipment
+    assert len(outlaw.hand) == 1


### PR DESCRIPTION
## Summary
- enforce range for Bang and Panic
- prevent Jail from targeting the Sheriff
- disable Beer when only two players remain
- add tests for these rules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68701f0e8ad88323a55a38341ca9d341