### PR TITLE
Handle Janet Bang dodging

### DIFF
--- a/bang_py/game_manager.py
+++ b/bang_py/game_manager.py
@@ -393,6 +393,15 @@ class GameManager:
             if has_ability(target, MollyStark):
                 self.draw_card(target)
             return True
+        if has_ability(target, CalamityJanet):
+            bang = next((c for c in target.hand if isinstance(c, BangCard)), None)
+            if bang:
+                target.hand.remove(bang)
+                self.discard_pile.append(bang)
+                target.metadata["dodged"] = True
+                if has_ability(target, MollyStark):
+                    self.draw_card(target)
+                return True
         if has_ability(target, ElenaFuente) and target.hand:
             card = target.hand.pop()
             self.discard_pile.append(card)

--- a/tests/test_characters.py
+++ b/tests/test_characters.py
@@ -103,6 +103,21 @@ def test_calamity_janet_plays_missed_as_bang():
     assert target.health == target.max_health - 1
 
 
+def test_calamity_janet_dodges_with_bang():
+    gm = GameManager()
+    attacker = Player("Bandit")
+    janet = Player("Janet", character=CalamityJanet())
+    gm.add_player(attacker)
+    gm.add_player(janet)
+    janet.hand.append(BangCard())
+    attacker.hand.append(BangCard())
+    gm.play_card(attacker, attacker.hand[0], janet)
+    assert janet.health == janet.max_health
+    assert janet.metadata.get("dodged") is True
+    assert len(janet.hand) == 0
+    assert sum(isinstance(c, BangCard) for c in gm.discard_pile) == 2
+
+
 def test_el_gringo_steals_on_damage():
     gm = GameManager()
     gringo = Player("Gringo", character=ElGringo())


### PR DESCRIPTION
## Summary
- allow `GameManager._auto_miss` to discard a Bang card if the target is Calamity Janet
- keep Molly Stark's draw trigger for this scenario
- test Calamity Janet dodging with a Bang

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68708d7f1c84832387db66b6ecd084d7