### PR TITLE
Add draw phase choice support

### DIFF
--- a/bang_py/network/server.py
+++ b/bang_py/network/server.py
@@ -109,11 +109,13 @@ class BangServer:
                     ability = data.get("ability")
                     player = self.connections[websocket].player
                     if ability == "sid_ketchum":
-                        self.game.sid_ketchum_ability(player)
+                        idxs = data.get("indices") or []
+                        self.game.sid_ketchum_ability(player, idxs)
                     elif ability == "chuck_wengam":
                         self.game.chuck_wengam_ability(player)
                     elif ability == "doc_holyday":
-                        self.game.doc_holyday_ability(player)
+                        idxs = data.get("indices") or []
+                        self.game.doc_holyday_ability(player, idxs)
                     elif ability == "vera_custer":
                         idx = data.get("target")
                         target = None
@@ -121,6 +123,24 @@ class BangServer:
                             target = self.game._get_player_by_index(idx)
                         if target:
                             self.game.vera_custer_copy(player, target)
+                    elif ability == "jesse_jones":
+                        idx = data.get("target")
+                        target = self.game._get_player_by_index(idx) if idx is not None else None
+                        self.game.draw_phase(player, jesse_target=target)
+                    elif ability == "kit_carlson":
+                        discard = data.get("discard")
+                        self.game.draw_phase(player, kit_discard=discard)
+                    elif ability == "pedro_ramirez":
+                        use_discard = bool(data.get("use_discard", True))
+                        self.game.draw_phase(player, pedro_use_discard=use_discard)
+                    elif ability == "jose_delgado":
+                        eq_idx = data.get("equipment")
+                        self.game.draw_phase(player, jose_equipment=eq_idx)
+                    elif ability == "pat_brennan":
+                        idx = data.get("target")
+                        card = data.get("card")
+                        target = self.game._get_player_by_index(idx) if idx is not None else None
+                        self.game.draw_phase(player, pat_target=target, pat_card=card)
                     elif ability == "uncle_will":
                         cidx = data.get("card_index")
                         if cidx is not None and 0 <= cidx < len(player.hand):

--- a/bang_py/ui.py
+++ b/bang_py/ui.py
@@ -302,7 +302,16 @@ class BangUI:
         for i, card in enumerate(cards):
             btn = ttk.Button(self.hand_frame, text=card, command=lambda idx=i: self._play_card(idx))
             btn.grid(row=0, column=i, padx=2)
-        if self.current_character in {"Sid Ketchum", "Chuck Wengam", "Doc Holyday"}:
+        if self.current_character in {
+            "Sid Ketchum",
+            "Chuck Wengam",
+            "Doc Holyday",
+            "Jesse Jones",
+            "Kit Carlson",
+            "Pedro Ramirez",
+            "Jose Delgado",
+            "Pat Brennan",
+        }:
             ttk.Button(
                 self.hand_frame,
                 text="Use Ability",

--- a/tests/test_draw_discard_equipment.py
+++ b/tests/test_draw_discard_equipment.py
@@ -45,7 +45,7 @@ def test_sid_ketchum_discard_two_to_heal():
     gm.add_player(sid)
     sid.health = sid.max_health - 1
     sid.hand.extend([BangCard(), BangCard()])
-    gm.sid_ketchum_ability(sid)
+    gm.sid_ketchum_ability(sid, [0, 1])
     assert sid.health == sid.max_health
     assert len(sid.hand) == 0
 

--- a/tests/test_expansions.py
+++ b/tests/test_expansions.py
@@ -152,7 +152,7 @@ def test_doc_holyday_free_bang():
     gm.add_player(doc)
     gm.add_player(target)
     doc.hand.extend([PanicCard(), PanicCard()])
-    gm.doc_holyday_ability(doc)
+    gm.doc_holyday_ability(doc, [0, 1])
     bang = next(c for c in doc.hand if isinstance(c, BangCard))
     gm.play_card(doc, bang, target)
     assert doc.metadata.get("bangs_played", 0) == 0
@@ -190,8 +190,8 @@ def test_pat_brennan_draw_in_play():
     gm.add_player(pat)
     gm.add_player(other)
     BarrelCard().play(other)
-    gm.draw_phase(pat)
-    assert "Barrel" in pat.hand[0].card_name
+    gm.draw_phase(pat, pat_target=other, pat_card="Barrel")
+    assert any("Barrel" in c.card_name for c in pat.hand)
 
 
 def test_uncle_will_general_store():


### PR DESCRIPTION
## Summary
- support user selections in `GameManager.draw_phase`
- let Sid Ketchum and Doc Holyday discard chosen cards
- expose new ability commands through the websocket server
- show ability button for more characters in the Tk UI
- update tests for new workflows

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68716731d5508323afa7bd340daabbd9