### PR TITLE
Interactive general store selection

### DIFF
--- a/bang_py/cards/general_store.py
+++ b/bang_py/cards/general_store.py
@@ -13,31 +13,21 @@ class GeneralStoreCard(Card):
     card_name = "General Store"
 
     def play(
-        self, target: Player, player: Player | None = None, game: GameManager | None = None
+        self,
+        target: Player,
+        player: Player | None = None,
+        game: GameManager | None = None,
+        choices: List[int] | None = None,
     ) -> None:
-        """Draw ``len(players)`` cards and allow each player to select one."""
+        """Reveal cards equal to players and let each choose in order."""
         if not game or not player:
             return
 
-        alive = [p for p in game.players if p.is_alive()]
-        cards: List[Card] = []
-        for _ in range(len(alive)):
-            card = game.deck.draw()
-            if card is None:
-                if game.discard_pile:
-                    game.deck.cards.extend(game.discard_pile)
-                    game.discard_pile.clear()
-                    random.shuffle(game.deck.cards)
-                    card = game.deck.draw()
-            if card:
-                cards.append(card)
-
-        start_idx = game.players.index(player)
-        for i in range(len(alive)):
-            p = game.players[(start_idx + i) % len(game.players)]
-            if p.is_alive() and cards:
-                chosen = cards.pop(0)
-                p.hand.append(chosen)
-
-        for leftover in cards:
-            game.discard_pile.append(leftover)
+        game.start_general_store(player)
+        order = game.general_store_order or []
+        selections = choices or []
+        for i, p in enumerate(order):
+            if game.general_store_cards is None:
+                break
+            idx = selections[i] if i < len(selections) else 0
+            game.general_store_pick(p, idx)

--- a/bang_py/ui.py
+++ b/bang_py/ui.py
@@ -271,6 +271,8 @@ class BangUI:
                         messagebox.showinfo("Game Update", data["message"])
             elif isinstance(data, dict) and data.get("prompt") == "vera":
                 self._prompt_vera(data.get("options", []))
+            elif isinstance(data, dict) and data.get("prompt") == "general_store":
+                self._prompt_general_store(data.get("cards", []))
             else:
                 self._append_message(msg)
         if self.client and self.client.is_alive():
@@ -361,6 +363,29 @@ class BangUI:
                 ),
             )
             btn.pack(fill="x")
+
+    def _prompt_general_store(self, cards: list[str]) -> None:
+        win = tk.Toplevel(self.root)
+        win.title("General Store")
+        ttk.Label(win, text="Choose a card:").pack()
+
+        for i, card in enumerate(cards):
+            btn = ttk.Button(
+                win,
+                text=card,
+                command=lambda idx=i: (
+                    self._pick_general_store(idx),
+                    win.destroy(),
+                ),
+            )
+            btn.pack(fill="x")
+
+    def _pick_general_store(self, index: int) -> None:
+        if self.client and self.client.websocket:
+            payload = json.dumps({"action": "general_store_pick", "index": index})
+            asyncio.run_coroutine_threadsafe(
+                self.client.websocket.send(payload), self.client.loop
+            )
 
     def _bind_keys(self) -> None:
         if self._bound_key:

--- a/tests/test_additional_cards.py
+++ b/tests/test_additional_cards.py
@@ -113,6 +113,23 @@ def test_general_store_selection_order():
     assert p3.hand == [c1]
 
 
+def test_general_store_allows_player_choice():
+    deck = Deck([])
+    c1, c2, c3 = BangCard(), BeerCard(), GatlingCard()
+    deck.cards = [c1, c2, c3]
+    gm = GameManager(deck=deck)
+    p1 = Player("A")
+    p2 = Player("B")
+    p3 = Player("C")
+    gm.add_player(p1)
+    gm.add_player(p2)
+    gm.add_player(p3)
+    GeneralStoreCard().play(p1, p1, game=gm, choices=[1, 0, 0])
+    assert p1.hand == [c2]
+    assert p2.hand == [c3]
+    assert p3.hand == [c1]
+
+
 def test_saloon_heals_everyone():
     gm = GameManager(deck=Deck([]))
     p1 = Player("A")


### PR DESCRIPTION
## Summary
- allow specifying choices when playing General Store
- track General Store selection state in `GameManager`
- prompt players for card choice over the websocket server
- add selection dialog in the Tkinter UI
- test explicit player choice during General Store

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68716bdb3b588323a69a8f11a1440526