### PR TITLE
Handle more event effects

### DIFF
--- a/bang_py/cards/beer.py
+++ b/bang_py/cards/beer.py
@@ -15,10 +15,14 @@ class BeerCard(Card):
         if not target:
             return
         game: Optional["GameManager"] = target.metadata.get("game")
+        heal_amt = 1
         if game:
+            if game.event_flags.get("no_beer"):
+                return
+            heal_amt = int(game.event_flags.get("beer_heal", 1))
             alive = [p for p in game.players if p.is_alive()]
             if len(alive) <= 2:
                 return
         if target.health < target.max_health:
-            target.heal(1)
+            target.heal(heal_amt)
 

--- a/bang_py/network/server.py
+++ b/bang_py/network/server.py
@@ -193,7 +193,8 @@ class BangServer:
             payload = {
                 "players": _serialize_players(self.game.players),
                 "hand": [c.card_name for c in conn.player.hand],
-                "character": getattr(conn.player.character, "name", "")
+                "character": getattr(conn.player.character, "name", ""),
+                "event": getattr(self.game.current_event, "name", "")
             }
             if message:
                 payload["message"] = message

--- a/bang_py/player.py
+++ b/bang_py/player.py
@@ -104,6 +104,9 @@ class Player:
     @property
     def attack_range(self) -> int:
         """Maximum range this player can target based on gun and equipment."""
+        game = self.metadata.get("game")
+        if getattr(game, "event_flags", {}).get("range_unlimited"):
+            return 99
         return self.gun_range + self.range_bonus
 
     def distance_to(self, other: "Player") -> int:

--- a/bang_py/ui.py
+++ b/bang_py/ui.py
@@ -243,14 +243,18 @@ class BangUI:
         self.players_text = tk.Text(self.root, height=5, width=40, state="disabled")
         self.players_text.grid(row=0, column=0, columnspan=2)
 
+        self.event_var = tk.StringVar(value="")
+        self.event_label = ttk.Label(self.root, textvariable=self.event_var)
+        self.event_label.grid(row=1, column=0, columnspan=2)
+
         self.text = tk.Text(self.root, height=10, width=40, state="disabled")
-        self.text.grid(row=1, column=0, columnspan=2)
+        self.text.grid(row=2, column=0, columnspan=2)
 
         self.hand_frame = ttk.Frame(self.root)
-        self.hand_frame.grid(row=2, column=0, columnspan=2, pady=5)
+        self.hand_frame.grid(row=3, column=0, columnspan=2, pady=5)
 
         end_btn = ttk.Button(self.root, text="End Turn", command=self._end_turn)
-        end_btn.grid(row=3, column=0, columnspan=2, pady=5)
+        end_btn.grid(row=4, column=0, columnspan=2, pady=5)
 
     def _process_queue(self) -> None:
         while not self.msg_queue.empty():
@@ -265,6 +269,7 @@ class BangUI:
                 self._update_players(data["players"])
                 self.current_character = data.get("character", self.current_character)
                 self._update_hand(data.get("hand", []))
+                self.event_var.set(data.get("event", ""))
                 if "message" in data:
                     self._append_message(data["message"])
                     if any(k in data["message"].lower() for k in ["win", "eliminated"]):

--- a/tests/test_event_deck_effects.py
+++ b/tests/test_event_deck_effects.py
@@ -2,7 +2,7 @@ import random
 from bang_py.event_decks import EventCard, _thirst, _fistful
 from bang_py.game_manager import GameManager
 from bang_py.player import Player, Role
-from bang_py.cards import BangCard
+from bang_py.cards import BangCard, BeerCard
 
 
 def test_thirst_event_draw_one():
@@ -25,3 +25,29 @@ def test_fistful_event_damage_by_hand():
     gm.current_turn = 0
     gm._begin_turn()
     assert p.health == p.max_health - 2
+
+
+def test_sermon_event_blocks_bang():
+    gm = GameManager()
+    sheriff = Player("Sheriff", role=Role.SHERIFF)
+    outlaw = Player("Outlaw")
+    gm.add_player(sheriff)
+    gm.add_player(outlaw)
+    gm.event_deck = [EventCard("The Sermon", lambda g: g.event_flags.update(no_bang=True), "")]
+    gm.draw_event_card()
+    sheriff.hand.append(BangCard())
+    gm.play_card(sheriff, sheriff.hand[0], outlaw)
+    assert len(sheriff.hand) == 1
+    assert outlaw.health == outlaw.max_health
+
+
+def test_hangover_event_disables_beer():
+    gm = GameManager()
+    sheriff = Player("Sheriff", role=Role.SHERIFF)
+    gm.add_player(sheriff)
+    gm.event_deck = [EventCard("Hangover", lambda g: g.event_flags.update(no_beer=True), "")]
+    gm.draw_event_card()
+    sheriff.health -= 1
+    sheriff.hand.append(BeerCard())
+    gm.play_card(sheriff, sheriff.hand[0])
+    assert sheriff.health == sheriff.max_health - 1


### PR DESCRIPTION
## Summary
- support more High Noon/Fistful of Cards events during play
- show active event in server state and UI
- expand event effect tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871702efdec8323a15fa6e49139f1b9