### PR TITLE
Add ability prompts in UI and server

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,3 +97,18 @@ from bang_py.characters import RoseDoolan
 player = Player("Rose", character=RoseDoolan())
 ```
 
+## Using Character Abilities
+
+When the server requires input for a character ability the GUI will show a
+popup prompt. The following abilities currently trigger prompts:
+
+- Jesse Jones – choose another player's hand to draw from or skip.
+- Kit Carlson – pick one of three drawn cards to discard.
+- Pedro Ramirez – decide whether to take the top discard instead of drawing.
+- Jose Delgado – optionally discard an equipment card for two cards.
+- Pat Brennan – select an equipment card in play to draw.
+- Lucky Duke – pick one of two cards when his ability activates.
+
+Simply click the desired option in the popup window. If no choice is made the
+default behaviour is used.
+

--- a/bang_py/game_manager.py
+++ b/bang_py/game_manager.py
@@ -175,6 +175,22 @@ class GameManager:
                     self.current_turn = (self.current_turn + 1) % len(self.turn_order)
                     self._begin_turn()
                     return
+
+        ability_chars = (
+            JesseJones,
+            KitCarlson,
+            PedroRamirez,
+            JoseDelgado,
+            PatBrennan,
+            LuckyDuke,
+        )
+
+        if isinstance(player.character, ability_chars):
+            player.metadata["awaiting_draw"] = True
+            for cb in self.turn_started_listeners:
+                cb(player)
+            return
+
         self.draw_phase(player)
         player.metadata["bangs_played"] = 0
         for cb in self.turn_started_listeners:


### PR DESCRIPTION
## Summary
- pause draw phase for characters with optional draw abilities
- prompt for Jesse Jones, Kit Carlson, Pedro Ramirez, Jose Delgado, Pat Brennan and Lucky Duke
- add client handlers for new prompts
- document using ability prompts in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687176ed787c8323b95cd55fa9ed209e