### PR TITLE
Add Pepperbox and Howitzer cards

### DIFF
--- a/bang_py/cards/__init__.py
+++ b/bang_py/cards/__init__.py
@@ -25,6 +25,8 @@ from .punch import PunchCard
 from .hideout import HideoutCard
 from .binoculars import BinocularsCard
 from .buffalo_rifle import BuffaloRifleCard
+from .pepperbox import PepperboxCard
+from .howitzer import HowitzerCard
 from .whisky import WhiskyCard
 from .high_noon_card import HighNoonCard
 from .sombrero import SombreroCard
@@ -61,6 +63,8 @@ __all__ = [
     "HideoutCard",
     "BinocularsCard",
     "BuffaloRifleCard",
+    "PepperboxCard",
+    "HowitzerCard",
     "WhiskyCard",
     "HighNoonCard",
     "SombreroCard",

--- a/bang_py/cards/howitzer.py
+++ b/bang_py/cards/howitzer.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from .card import Card
+from ..player import Player
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from ..game_manager import GameManager
+    from ..deck import Deck
+
+from .bang import BangCard
+
+
+class HowitzerCard(Card):
+    """Attack all opponents regardless of distance."""
+
+    card_name = "Howitzer"
+
+    def play(
+        self, target: Player, player: Player | None = None, game: GameManager | None = None,
+        deck: Deck | None = None
+    ) -> None:
+        if not game or not player:
+            return
+        for p in game.players:
+            if p is player:
+                continue
+            before = p.health
+            BangCard().play(p, deck or game.deck)
+            if p.health < before:
+                game.on_player_damaged(p, player)

--- a/bang_py/cards/pepperbox.py
+++ b/bang_py/cards/pepperbox.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from .equipment import EquipmentCard
+
+
+class PepperboxCard(EquipmentCard):
+    """Gun from the Dodge City expansion with range 3."""
+
+    card_name = "Pepperbox"
+    slot = "Gun"
+    range = 3
+    description = "Gun with range 3."

--- a/bang_py/deck_factory.py
+++ b/bang_py/deck_factory.py
@@ -38,6 +38,8 @@ from .cards import (
     TequilaCard,
     PonyExpressCard,
     DerringerCard,
+    PepperboxCard,
+    HowitzerCard,
 )
 from .cards.card import Card
 
@@ -73,6 +75,8 @@ DODGE_CITY_COUNTS: List[Tuple[Type[Card], int]] = [
     (HideoutCard, 2),
     (BinocularsCard, 2),
     (BuffaloRifleCard, 1),
+    (PepperboxCard, 1),
+    (HowitzerCard, 1),
     (SombreroCard, 1),
     (IronPlateCard, 1),
     (DerringerCard, 2),

--- a/bang_py/game_manager.py
+++ b/bang_py/game_manager.py
@@ -57,6 +57,7 @@ from .cards.duel import DuelCard
 from .cards.general_store import GeneralStoreCard
 from .cards.saloon import SaloonCard
 from .cards.gatling import GatlingCard
+from .cards.howitzer import HowitzerCard
 from .cards.punch import PunchCard
 from .cards.whisky import WhiskyCard
 from .cards.beer import BeerCard
@@ -423,6 +424,8 @@ class GameManager:
         elif isinstance(card, SaloonCard):
             card.play(player, player, game=self)
         elif isinstance(card, GatlingCard):
+            card.play(player, player, game=self)
+        elif isinstance(card, HowitzerCard):
             card.play(player, player, game=self)
         elif isinstance(card, WhiskyCard):
             card.play(target or player, player, game=self)

--- a/tests/test_expansions.py
+++ b/tests/test_expansions.py
@@ -7,6 +7,8 @@ from bang_py.cards import (
     HideoutCard,
     BinocularsCard,
     BuffaloRifleCard,
+    PepperboxCard,
+    HowitzerCard,
     WhiskyCard,
     HighNoonCard,
     PonyExpressCard,
@@ -43,7 +45,14 @@ from bang_py.characters import (
 def test_dodge_city_cards_added():
     deck = create_standard_deck(["dodge_city"])
     types = {type(c) for c in deck.cards}
-    assert {PunchCard, HideoutCard, BinocularsCard, BuffaloRifleCard} <= types
+    assert {
+        PunchCard,
+        HideoutCard,
+        BinocularsCard,
+        BuffaloRifleCard,
+        PepperboxCard,
+        HowitzerCard,
+    } <= types
 
 
 def test_whisky_heals_two():
@@ -340,3 +349,24 @@ def test_high_noon_event_deck_draw():
     gm.add_player(outlaw)
     gm.start_game()
     assert gm.current_event is not None
+
+
+def test_pepperbox_sets_range_three():
+    player = Player("Shooter")
+    PepperboxCard().play(player)
+    assert player.attack_range == 3
+
+
+def test_howitzer_hits_all_opponents():
+    gm = GameManager(deck=Deck([]))
+    p1 = Player("A")
+    p2 = Player("B")
+    p3 = Player("C")
+    gm.add_player(p1)
+    gm.add_player(p2)
+    gm.add_player(p3)
+    card = HowitzerCard()
+    p1.hand.append(card)
+    gm.play_card(p1, card)
+    assert p2.health == p2.max_health - 1
+    assert p3.health == p3.max_health - 1


### PR DESCRIPTION
## Summary
- implement Pepperbox gun and Howitzer attack
- register new cards with deck factory
- handle Howitzer in GameManager
- export cards through cards package
- extend expansion tests for new cards and behaviors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871972b0c308323ada39f49d2bea80c