### PR TITLE
Enforce green equipment activation after turn

### DIFF
--- a/bang_py/cards/binoculars.py
+++ b/bang_py/cards/binoculars.py
@@ -9,3 +9,4 @@ class BinocularsCard(EquipmentCard):
     card_name = "Binoculars"
     range_modifier = 1
     description = "Increases attack range by 1."
+    green_border = True

--- a/bang_py/cards/buffalo_rifle.py
+++ b/bang_py/cards/buffalo_rifle.py
@@ -10,3 +10,4 @@ class BuffaloRifleCard(EquipmentCard):
     slot = "Gun"
     range = 5
     description = "Gun with range 5."
+    green_border = True

--- a/bang_py/cards/derringer.py
+++ b/bang_py/cards/derringer.py
@@ -10,3 +10,4 @@ class DerringerCard(EquipmentCard):
     slot = "Gun"
     range = 1
     description = "Gun with range 1."
+    green_border = True

--- a/bang_py/cards/equipment.py
+++ b/bang_py/cards/equipment.py
@@ -15,8 +15,16 @@ class EquipmentCard(Card):
     distance_modifier: int = 0
     # Optional description of the card's effect for UI purposes
     description: str | None = None
+    # Green bordered cards activate on the owner's next turn
+    green_border: bool = False
+
+    def __init__(self, suit: str | None = None, rank: int | None = None) -> None:
+        super().__init__(suit, rank)
+        self.active = True
 
     def play(self, target: Player) -> None:
         if not target:
             return
-        target.equip(self)
+        if self.green_border:
+            self.active = False
+        target.equip(self, active=self.active)

--- a/bang_py/cards/hideout.py
+++ b/bang_py/cards/hideout.py
@@ -9,3 +9,4 @@ class HideoutCard(EquipmentCard):
     card_name = "Hideout"
     distance_modifier = 1
     description = "Opponents see you at +1 distance."
+    green_border = True

--- a/bang_py/cards/iron_plate.py
+++ b/bang_py/cards/iron_plate.py
@@ -8,3 +8,4 @@ class IronPlateCard(EquipmentCard):
 
     card_name = "Iron Plate"
     max_health_modifier = 1
+    green_border = True

--- a/bang_py/cards/pepperbox.py
+++ b/bang_py/cards/pepperbox.py
@@ -10,3 +10,4 @@ class PepperboxCard(EquipmentCard):
     slot = "Gun"
     range = 3
     description = "Gun with range 3."
+    green_border = True

--- a/bang_py/cards/sombrero.py
+++ b/bang_py/cards/sombrero.py
@@ -7,3 +7,4 @@ class SombreroCard(BarrelCard):
     """Protection equipment functioning like a Barrel from Dodge City."""
 
     card_name = "Sombrero"
+    green_border = True

--- a/bang_py/game_manager.py
+++ b/bang_py/game_manager.py
@@ -135,6 +135,12 @@ class GameManager:
         self.current_turn %= len(self.turn_order)
         idx = self.turn_order[self.current_turn]
         player = self.players[idx]
+        for eq in list(player.equipment.values()):
+            if getattr(eq, "green_border", False) and not getattr(eq, "active", True):
+                eq.active = True
+                modifier = int(getattr(eq, "max_health_modifier", 0))
+                if modifier:
+                    player._apply_health_modifier(modifier)
         self.reset_turn_flags(player)
         if self.event_deck and player.role == Role.SHERIFF:
             self.draw_event_card()
@@ -202,7 +208,14 @@ class GameManager:
         if not self.turn_order:
             return
         idx = self.turn_order[self.current_turn]
-        self.discard_phase(self.players[idx])
+        player = self.players[idx]
+        self.discard_phase(player)
+        for eq in list(player.equipment.values()):
+            if getattr(eq, "green_border", False) and not getattr(eq, "active", True):
+                eq.active = True
+                modifier = int(getattr(eq, "max_health_modifier", 0))
+                if modifier:
+                    player._apply_health_modifier(modifier)
         self.current_turn = (self.current_turn + 1) % len(self.turn_order)
         self._begin_turn()
 

--- a/tests/test_draw_discard_equipment.py
+++ b/tests/test_draw_discard_equipment.py
@@ -50,19 +50,36 @@ def test_sid_ketchum_discard_two_to_heal():
     assert len(sid.hand) == 0
 
 
-def test_iron_plate_increases_max_health():
-    player = Player("Platey")
-    IronPlateCard().play(player)
-    assert player.max_health == 5
-    assert player.health == 5
+def test_iron_plate_activates_after_turn():
+    gm = GameManager(deck=Deck([]))
+    p1 = Player("Platey")
+    p2 = Player("Other")
+    gm.add_player(p1)
+    gm.add_player(p2)
+    gm.start_game()
+    card = IronPlateCard()
+    p1.hand.append(card)
+    gm.play_card(p1, card, p1)
+    assert p1.max_health == 4
+    gm.end_turn()
+    assert p1.max_health == 5
+    assert p1.health == 5
 
 
 def test_iron_plate_removed_restores_max_health():
     gm = GameManager(deck=Deck([]))
-    player = Player("Platey")
-    gm.add_player(player)
-    IronPlateCard().play(player)
-    assert player.max_health == 5
-    CatBalouCard().play(player, game=gm)
-    assert player.max_health == 4
-    assert player.health == 4
+    p1 = Player("Platey")
+    p2 = Player("Other")
+    gm.add_player(p1)
+    gm.add_player(p2)
+    gm.start_game()
+    card = IronPlateCard()
+    p1.hand.append(card)
+    gm.play_card(p1, card, p1)
+    gm.end_turn()
+    assert p1.max_health == 5
+    cat = CatBalouCard()
+    p2.hand.append(cat)
+    gm.play_card(p2, cat, p1)
+    assert p1.max_health == 4
+    assert p1.health == 4

--- a/tests/test_expansions.py
+++ b/tests/test_expansions.py
@@ -313,10 +313,38 @@ def test_high_noon_event_deck_draw():
     assert gm.current_event is not None
 
 
-def test_pepperbox_sets_range_three():
-    player = Player("Shooter")
-    PepperboxCard().play(player)
-    assert player.attack_range == 3
+def test_pepperbox_activates_after_turn():
+    gm = GameManager()
+    p1 = Player("Shooter")
+    p2 = Player("Other")
+    gm.add_player(p1)
+    gm.add_player(p2)
+    gm.start_game()
+    card = PepperboxCard()
+    p1.hand.append(card)
+    gm.play_card(p1, card, p1)
+    assert p1.attack_range == 1
+    gm.end_turn()
+    assert p1.attack_range == 3
+
+
+def test_binoculars_and_hideout_activate_after_turn():
+    gm = GameManager()
+    p1 = Player("A")
+    p2 = Player("B")
+    gm.add_player(p1)
+    gm.add_player(p2)
+    gm.start_game()
+    b = BinocularsCard()
+    h = HideoutCard()
+    p1.hand.extend([b, h])
+    gm.play_card(p1, b, p1)
+    gm.play_card(p1, h, p1)
+    assert p1.attack_range == 1
+    assert p2.distance_to(p1) == 1
+    gm.end_turn()
+    assert p1.attack_range == 2
+    assert p2.distance_to(p1) == 2
 
 
 def test_howitzer_hits_all_opponents():


### PR DESCRIPTION
## Summary
- activate green equipment at the end of the owner's turn
- simplify green activation tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6871b4b1acfc8323af4ebb65c3117f68