### PR TITLE
Add mechanics for Ricochet and River events

### DIFF
--- a/bang_py/event_decks.py
+++ b/bang_py/event_decks.py
@@ -11,6 +11,26 @@ def _noop(game: "GameManager") -> None:
     return
 
 
+def _peyote(game: "GameManager") -> None:
+    """Each draw gives one extra card."""
+    game.event_flags["peyote_bonus"] = 1
+
+
+def _ricochet(game: "GameManager") -> None:
+    """Bang! cards also hit the next player."""
+    game.event_flags["ricochet"] = True
+
+
+def _river(game: "GameManager") -> None:
+    """Discarded cards pass to the left player."""
+    game.event_flags["river"] = True
+
+
+def _fistful_ghost_town(game: "GameManager") -> None:
+    """Alias of Ghost Town for the Fistful deck."""
+    _ghost_town(game)
+
+
 def _judge(game: "GameManager") -> None:
     """Beer cards cannot be played."""
     game.event_flags["no_beer_play"] = True
@@ -81,7 +101,7 @@ def create_high_noon_deck() -> List[EventCard]:
         EventCard("Siesta", lambda g: g.event_flags.update(draw_count=3), "Draw three cards"),
         EventCard("Cattle Drive", lambda g: [p.hand.pop() for p in g.players if p.hand], "Discard a card"),
         EventCard("The Sermon", lambda g: g.event_flags.update(no_bang=True), "Bang! cannot be played"),
-        EventCard("Peyote", _noop, "Lucky draws"),
+        EventCard("Peyote", _peyote, "Lucky draws"),
         EventCard("Hangover", lambda g: g.event_flags.update(no_beer=True), "Beer gives no health"),
         EventCard("High Noon", _high_noon, "Lose 1 life at start of turn"),
     ]
@@ -92,16 +112,16 @@ def create_fistful_deck() -> List[EventCard]:
     return [
         EventCard("Abandoned Mine", lambda g: [g.draw_card(p) for p in g.players], "Everyone draws"),
         EventCard("Ambush", lambda g: g.event_flags.update(no_missed=True), "Missed! has no effect"),
-        EventCard("Ricochet", _noop, "Bang! hits an extra player"),
+        EventCard("Ricochet", _ricochet, "Bang! hits an extra player"),
         EventCard("Ranch", lambda g: [p.heal(1) for p in g.players], "All heal"),
         EventCard("Gold Rush", lambda g: g.event_flags.update(draw_count=3), "Draw extra"),
         EventCard("Hard Liquor", lambda g: g.event_flags.update(beer_heal=2), "Beer heals 2"),
-        EventCard("The River", _noop, "Discards pass left"),
+        EventCard("The River", _river, "Discards pass left"),
         EventCard("Bounty", _bounty, "Rewards for eliminations"),
         EventCard("Vendetta", _vendetta, "Outlaws have +1 range"),
         EventCard("Prison Break", lambda g: g.event_flags.update(no_jail=True), "Jail discarded"),
         EventCard("High Stakes", lambda g: g.event_flags.update(bang_limit=2), "Two Bang!s"),
-        EventCard("Ghost Town", _noop, "Eliminated return"),
+        EventCard("Ghost Town", _fistful_ghost_town, "Eliminated return"),
         EventCard("A Fistful of Cards", _fistful, "Damage equal to cards in hand"),
     ]
 

--- a/tests/test_event_deck_effects.py
+++ b/tests/test_event_deck_effects.py
@@ -4,6 +4,9 @@ from bang_py.event_decks import (
     _fistful,
     _judge,
     _ghost_town,
+    _peyote,
+    _ricochet,
+    _river,
     _bounty,
     _vendetta,
 )
@@ -110,3 +113,46 @@ def test_vendetta_outlaw_range_bonus():
     gm.event_deck = [EventCard("Vendetta", _vendetta, "")]
     gm.draw_event_card()
     assert outlaw.attack_range == 2
+
+
+def test_ricochet_hits_next_player():
+    gm = GameManager()
+    p1 = Player("P1")
+    p2 = Player("P2")
+    p3 = Player("P3")
+    gm.add_player(p1)
+    gm.add_player(p2)
+    gm.add_player(p3)
+    gm.event_deck = [EventCard("Ricochet", _ricochet, "")]
+    gm.draw_event_card()
+    p1.hand.append(BangCard())
+    gm.play_card(p1, p1.hand[0], p2)
+    assert p2.health == p2.max_health - 1
+    assert p3.health == p3.max_health - 1
+
+
+def test_river_passes_discard_left():
+    gm = GameManager()
+    p1 = Player("A")
+    p2 = Player("B")
+    p3 = Player("C")
+    gm.add_player(p1)
+    gm.add_player(p2)
+    gm.add_player(p3)
+    gm.event_deck = [EventCard("The River", _river, "")]
+    gm.draw_event_card()
+    card = BangCard()
+    p1.hand.append(card)
+    gm.discard_card(p1, card)
+    assert card in p2.hand
+    assert card not in gm.discard_pile
+
+
+def test_peyote_extra_draw():
+    gm = GameManager()
+    p = Player("Sheriff", role=Role.SHERIFF)
+    gm.add_player(p)
+    gm.event_deck = [EventCard("Peyote", _peyote, "")]
+    gm.draw_event_card()
+    gm.draw_card(p)
+    assert len(p.hand) == 2


### PR DESCRIPTION
## Summary
- implement real effects for event cards previously no-ops
- handle Ricochet, The River and Peyote events with new event flags
- add helper methods in `GameManager` for passing cards left and extra Bang! hits
- update tests to cover new event behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871c71cb030832385e7288b5dc00e05