### PR TITLE
Fix unequipped health reduction bug

### DIFF
--- a/bang_py/player.py
+++ b/bang_py/player.py
@@ -58,9 +58,9 @@ class Player:
             self.equipment[card.card_name] = card
 
         if existing:
-            self._apply_health_modifier(
-                -int(getattr(existing, "max_health_modifier", 0))
-            )
+            modifier = int(getattr(existing, "max_health_modifier", 0))
+            if modifier and getattr(existing, "active", True):
+                self._apply_health_modifier(-modifier)
 
         card.active = active
         if active:

--- a/tests/test_draw_discard_equipment.py
+++ b/tests/test_draw_discard_equipment.py
@@ -83,3 +83,25 @@ def test_iron_plate_removed_restores_max_health():
     gm.play_card(p2, cat, p1)
     assert p1.max_health == 4
     assert p1.health == 4
+
+
+def test_iron_plate_replaced_before_activation_no_max_health_change():
+    gm = GameManager(deck=Deck([]))
+    p1 = Player("Platey")
+    p2 = Player("Other")
+    gm.add_player(p1)
+    gm.add_player(p2)
+    gm.start_game()
+
+    first = IronPlateCard()
+    second = IronPlateCard()
+    p1.hand.extend([first, second])
+    gm.play_card(p1, first, p1)
+    gm.play_card(p1, second, p1)
+
+    assert p1.max_health == 4
+
+    gm.end_turn()
+
+    assert p1.max_health == 5
+    assert p1.health == 5


### PR DESCRIPTION
## Summary
- fix Player.equip to only subtract modifiers for active equipment
- add regression test for replacing an inactive Iron Plate

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871ca678f7c8323a0b70eac744f16af