### PR TITLE
Handle Ghost Town revival expiry

### DIFF
--- a/bang_py/event_decks.py
+++ b/bang_py/event_decks.py
@@ -37,13 +37,14 @@ def _judge(game: "GameManager") -> None:
 
 
 def _ghost_town(game: "GameManager") -> None:
-    """Revive eliminated players with 1 health."""
+    """Revive eliminated players with 1 health until the next event card."""
     game.event_flags["ghost_town"] = True
     revived = []
-    for i, p in enumerate(game.players):
+    for p in game.players:
         if not p.is_alive():
             p.health = 1
-            revived.append(i)
+            p.metadata["ghost_revived"] = True
+            revived.append(p)
     if revived:
         game.turn_order = [
             i for i, pl in enumerate(game.players) if pl.is_alive()

--- a/bang_py/game_manager.py
+++ b/bang_py/game_manager.py
@@ -142,8 +142,22 @@ class GameManager:
                 if modifier:
                     player._apply_health_modifier(modifier)
         self.reset_turn_flags(player)
+        pre_ghost = self.event_flags.get("ghost_town")
         if self.event_deck and player.role == Role.SHERIFF:
             self.draw_event_card()
+            if pre_ghost:
+                removed = False
+                for pl in self.players:
+                    if pl.metadata.pop("ghost_revived", False) and pl.is_alive():
+                        pl.health = 0
+                        removed = True
+                if removed:
+                    self.turn_order = [
+                        i for i, pl in enumerate(self.players) if pl.is_alive()
+                    ]
+                    self.current_turn = self.turn_order.index(self.players.index(player))
+                    idx = self.turn_order[self.current_turn]
+                    player = self.players[idx]
         dmg = self.event_flags.get("start_damage", 0)
         if dmg:
             player.take_damage(dmg)

--- a/tests/test_event_deck_effects.py
+++ b/tests/test_event_deck_effects.py
@@ -89,6 +89,26 @@ def test_ghost_town_revives_players():
     assert outlaw.health == 1
 
 
+def test_ghost_town_players_disappear_next_event():
+    gm = GameManager()
+    sheriff = Player("Sheriff", role=Role.SHERIFF)
+    outlaw = Player("Outlaw")
+    gm.add_player(sheriff)
+    gm.add_player(outlaw)
+    outlaw.take_damage(outlaw.health)
+    gm.event_deck = [
+        EventCard("Ghost Town", _ghost_town, ""),
+        EventCard("Thirst", _thirst, ""),
+    ]
+    gm.draw_event_card()
+    assert outlaw.is_alive()
+    gm.turn_order = [0, 1]
+    gm.current_turn = 0
+    gm._begin_turn()
+    assert not outlaw.is_alive()
+    assert len(gm.turn_order) == 1
+
+
 def test_bounty_rewards_elimination():
     deck = Deck([BangCard(), BangCard(), BangCard()])
     gm = GameManager(deck=deck)


### PR DESCRIPTION
## Summary
- mark Ghost Town revived players
- clear revived players once a new event is drawn
- test that revived players disappear when the next event starts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871d4b80100832388acfebb5bd995af