### PR TITLE
Enable Dodge City by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ server and shows a room code to share with friends. The host screen now lets you
 set the maximum number of players and which expansions to enable. Joining requires
 the host address, port, and the room code.
 
+Available expansions are `dodge_city`, `high_noon`, and `fistful_of_cards`.
+`dodge_city` adds extra playing cards and is enabled automatically when no
+expansions are specified. The other two names activate their respective event
+decks.
+
 Once connected you will see:
 
 1. A list of players with their current health and any equipped items.

--- a/bang_py/game_manager.py
+++ b/bang_py/game_manager.py
@@ -108,6 +108,8 @@ class GameManager:
 
     def __post_init__(self) -> None:
         if self.deck is None:
+            if not self.expansions:
+                self.expansions.append("dodge_city")
             self.deck = create_standard_deck(self.expansions)
         self.event_flags = {}
         if "high_noon" in self.expansions:


### PR DESCRIPTION
## Summary
- include Dodge City when no expansions are specified
- document `dodge_city`, `high_noon`, and `fistful_of_cards` expansions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871e30bf8b083238e570da35545698a