### PR TITLE
Add deterministic testing guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@ when making changes.
 - Use Python 3.10+.
 - After modifying code, run `pytest` from the repository root to ensure tests
   pass.
+- Keep tests deterministic. If randomness is needed, seed the RNG inside the tests or offer hooks to bypass shuffling.
 
 ## Style
 - Follow standard PEP8 conventions and keep lines under 100 characters.

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,0 +1,2 @@
+# Test Guidelines
+- Set the event deck explicitly or call `random.seed()` in tests to avoid flaky behavior.


### PR DESCRIPTION
## Summary
- add a note in `AGENTS.md` on making tests deterministic
- add `tests/AGENTS.md` with specific instructions for test authors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871edfdcef083238d03aa987c8a32cc