### PR TITLE
Fix Stagecoach & Wells Fargo card handling

### DIFF
--- a/bang_py/game_manager.py
+++ b/bang_py/game_manager.py
@@ -367,9 +367,9 @@ class GameManager:
                     if extra.health > before_x:
                         self.on_player_healed(extra)
         elif isinstance(card, StagecoachCard):
-            self.draw_card(player, 2)
+            card.play(player, game=self)
         elif isinstance(card, WellsFargoCard):
-            self.draw_card(player, 3)
+            card.play(player, game=self)
         elif isinstance(card, CatBalouCard) and target:
             card.play(target, game=self)
         elif isinstance(card, PanicCard) and target:


### PR DESCRIPTION
## Summary
- ensure `GameManager.play_card` uses each card's own logic when playing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871f35d299883239788fdfc5353d058