### PR TITLE
Remove unused noop function

### DIFF
--- a/bang_py/event_decks.py
+++ b/bang_py/event_decks.py
@@ -6,11 +6,6 @@ from dataclasses import dataclass
 from typing import Callable, List
 
 
-def _noop(game: "GameManager") -> None:
-    """Default no-op event effect."""
-    return
-
-
 def _peyote(game: "GameManager") -> None:
     """Each draw gives one extra card."""
     game.event_flags["peyote_bonus"] = 1


### PR DESCRIPTION
## Summary
- delete `_noop` from the event deck module since it's not referenced

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872061724b883239cf6448fb554e90f