### PR TITLE
Introduce PlayerMetadata dataclass

### DIFF
--- a/bang_py/__init__.py
+++ b/bang_py/__init__.py
@@ -2,7 +2,7 @@
 
 from .game_manager import GameManager
 from .deck_factory import create_standard_deck
-from .player import Player, Role
+from .player import Player, Role, PlayerMetadata
 from .characters import (
     Character,
     BartCassidy,
@@ -27,6 +27,7 @@ __all__ = [
     "GameManager",
     "Player",
     "Role",
+    "PlayerMetadata",
     "Character",
     "BartCassidy",
     "BlackJack",

--- a/bang_py/cards/bang.py
+++ b/bang_py/cards/bang.py
@@ -22,17 +22,17 @@ class BangCard(Card):
             barrel = target.equipment.get("Barrel")
             if barrel and getattr(barrel, "draw_check", None):
                 if barrel.draw_check(deck, target):
-                    target.metadata["dodged"] = True
+                    target.metadata.dodged = True
                     return
             if isinstance(target.character, Jourdonnais):
                 if BarrelCard().draw_check(deck, target):
-                    target.metadata["dodged"] = True
+                    target.metadata.dodged = True
                     return
             if isinstance(target.character, LuckyDuke):
                 card1 = deck.draw()
                 card2 = deck.draw()
                 if is_heart(card1) or is_heart(card2):
-                    target.metadata["dodged"] = True
+                    target.metadata.dodged = True
                     return
         target.take_damage(1)
 

--- a/bang_py/cards/beer.py
+++ b/bang_py/cards/beer.py
@@ -25,8 +25,8 @@ class BeerCard(Card):
         if not target:
             return
 
-        game = game or (player.metadata.get("game") if player else None)
-        game = game or target.metadata.get("game")
+        game = game or (player.metadata.game if player else None)
+        game = game or target.metadata.game
 
         if game:
             if game.event_flags.get("no_beer_play"):

--- a/bang_py/cards/missed.py
+++ b/bang_py/cards/missed.py
@@ -11,5 +11,5 @@ class MissedCard(Card):
     def play(self, target: Player) -> None:
         if not target:
             return
-        target.metadata["dodged"] = True
+        target.metadata.dodged = True
 

--- a/bang_py/cards/punch.py
+++ b/bang_py/cards/punch.py
@@ -18,5 +18,5 @@ class PunchCard(Card):
             return
         before = target.health
         target.take_damage(1)
-        if target.health < before and target.metadata.get("game"):
-            target.metadata["game"].on_player_damaged(target, player)
+        if target.health < before and target.metadata.game:
+            target.metadata.game.on_player_damaged(target, player)

--- a/bang_py/event_decks.py
+++ b/bang_py/event_decks.py
@@ -38,7 +38,7 @@ def _ghost_town(game: "GameManager") -> None:
     for p in game.players:
         if not p.is_alive():
             p.health = 1
-            p.metadata["ghost_revived"] = True
+            p.metadata.ghost_revived = True
             revived.append(p)
     if revived:
         game.turn_order = [i for i, pl in enumerate(game.players) if pl.is_alive()]

--- a/bang_py/helpers.py
+++ b/bang_py/helpers.py
@@ -27,7 +27,7 @@ def has_ability(player: Player, char_cls: Type[Character]) -> bool:
     if isinstance(player.character, char_cls):
         return True
     if isinstance(player.character, VeraCuster):
-        copied = player.metadata.get("vera_copy")
+        copied = player.metadata.vera_copy
         return bool(copied and issubclass(copied, char_cls))
     return False
 

--- a/bang_py/player.py
+++ b/bang_py/player.py
@@ -9,6 +9,28 @@ if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from .cards.equipment import EquipmentCard
     from .characters import Character
     from .cards.card import Card
+    from .game_manager import GameManager
+
+
+@dataclass
+class PlayerMetadata:
+    """State information associated with a player."""
+
+    game: "GameManager | None" = None
+    auto_miss: bool = True
+    awaiting_draw: bool = False
+    bangs_played: int = 0
+    doc_free_bang: int = 0
+    doc_used: bool = False
+    dodged: bool = False
+    ghost_revived: bool = False
+    kit_cards: list["Card"] | None = None
+    lucky_cards: list["Card"] | None = None
+    last_card_played: type["Card"] | None = None
+    last_card_target: "Player | None" = None
+    uncle_used: bool = False
+    vera_copy: type["Character"] | None = None
+    lvk_used: bool = False
 
 
 class Role(Enum):
@@ -25,7 +47,7 @@ class Player:
     character: "Character | None" = None
     max_health: int = 4
     health: int = field(init=False)
-    metadata: dict = field(default_factory=dict)
+    metadata: PlayerMetadata = field(default_factory=PlayerMetadata)
     equipment: Dict[str, "EquipmentCard"] = field(default_factory=dict)
     hand: List["Card"] = field(default_factory=list)
 
@@ -109,7 +131,7 @@ class Player:
     @property
     def attack_range(self) -> int:
         """Maximum range this player can target based on gun and equipment."""
-        game = self.metadata.get("game")
+        game = self.metadata.game
         if getattr(game, "event_flags", {}).get("range_unlimited"):
             return 99
         rng = self.gun_range + self.range_bonus
@@ -122,7 +144,7 @@ class Player:
 
     def distance_to(self, other: "Player") -> int:
         """Return distance to another player considering equipment and abilities."""
-        game = self.metadata.get("game")
+        game = self.metadata.game
         players = getattr(game, "players", None)
 
         base = 1

--- a/tests/test_cards.py
+++ b/tests/test_cards.py
@@ -31,7 +31,7 @@ def test_beer_card_heals_target():
 def test_missed_card_sets_dodged_metadata():
     target = Player("Target")
     MissedCard().play(target)
-    assert target.metadata.get("dodged") is True
+    assert target.metadata.dodged is True
 
 
 def test_equipment_replaces_same_name():
@@ -77,7 +77,7 @@ def test_barrel_dodges_bang_on_heart():
     deck.cards.append(BeerCard(suit="Hearts"))
     BangCard().play(target, deck)
     assert target.health == target.max_health
-    assert target.metadata.get("dodged") is True
+    assert target.metadata.dodged is True
 
 
 def test_barrel_fails_on_non_heart():

--- a/tests/test_characters.py
+++ b/tests/test_characters.py
@@ -114,7 +114,7 @@ def test_calamity_janet_dodges_with_bang():
     attacker.hand.append(BangCard())
     gm.play_card(attacker, attacker.hand[0], janet)
     assert janet.health == janet.max_health
-    assert janet.metadata.get("dodged") is True
+    assert janet.metadata.dodged is True
     assert len(janet.hand) == 0
     assert sum(isinstance(c, BangCard) for c in gm.discard_pile) == 2
 
@@ -150,7 +150,7 @@ def test_jourdonnais_has_virtual_barrel():
     deck.cards.append(BeerCard(suit="Hearts"))
     target = Player("Jour", character=Jourdonnais())
     BangCard().play(target, deck)
-    assert target.metadata.get("dodged") is True
+    assert target.metadata.dodged is True
 
 
 def test_kit_carlson_draw_three_keep_two():

--- a/tests/test_expansions.py
+++ b/tests/test_expansions.py
@@ -168,7 +168,7 @@ def test_doc_holyday_free_bang():
     gm.doc_holyday_ability(doc, [0, 1])
     bang = next(c for c in doc.hand if isinstance(c, BangCard))
     gm.play_card(doc, bang, target)
-    assert doc.metadata.get("bangs_played", 0) == 0
+    assert doc.metadata.bangs_played == 0
 
 
 def test_elena_fuente_any_card_as_missed():

--- a/tests/test_full_game_simulation.py
+++ b/tests/test_full_game_simulation.py
@@ -140,7 +140,7 @@ def auto_turn(gm: GameManager) -> None:
                     played = True
                     break
             if isinstance(card, BangCard):
-                bangs = int(player.metadata.get("bangs_played", 0))
+                bangs = player.metadata.bangs_played
                 unlimited = isinstance(player.character, WillyTheKid)
                 if bangs >= 1 and not unlimited:
                     continue


### PR DESCRIPTION
## Summary
- add `PlayerMetadata` dataclass to store player state
- update game logic and server to use typed metadata
- adjust tests for new metadata interface

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6872085f3c10832399c90366a388e5da