### PR TITLE
Fix F401 warnings

### DIFF
--- a/bang_py/cards/bang.py
+++ b/bang_py/cards/bang.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from .card import Card
 from ..player import Player
 from typing import TYPE_CHECKING
-from ..helpers import is_heart, is_spade_between
+from ..helpers import is_heart
 from ..characters import Jourdonnais, LuckyDuke
 from .barrel import BarrelCard
 

--- a/bang_py/cards/duel.py
+++ b/bang_py/cards/duel.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from ..game_manager import GameManager
-    from .bang import BangCard
 
 
 class DuelCard(Card):

--- a/bang_py/cards/general_store.py
+++ b/bang_py/cards/general_store.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from .card import Card
 from ..player import Player
-import random
 from typing import TYPE_CHECKING, List
 
 if TYPE_CHECKING:

--- a/bang_py/cards/indians.py
+++ b/bang_py/cards/indians.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from ..game_manager import GameManager
-    from .bang import BangCard
 
 
 class IndiansCard(Card):

--- a/bang_py/game_manager.py
+++ b/bang_py/game_manager.py
@@ -10,11 +10,9 @@ from .cards.card import Card
 from .helpers import has_ability, handle_out_of_turn_discard
 from .characters import (
     BartCassidy,
-    BlackJack,
     CalamityJanet,
     ElGringo,
     JesseJones,
-    Jourdonnais,
     KitCarlson,
     LuckyDuke,
     PedroRamirez,
@@ -23,23 +21,19 @@ from .characters import (
     SuzyLafayette,
     VultureSam,
     WillyTheKid,
-    PixiePete,
     JoseDelgado,
     SeanMallory,
     VeraCuster,
     ApacheKid,
     GregDigger,
     BelleStar,
-    BillNoface,
     ChuckWengam,
     DocHolyday,
     ElenaFuente,
     HerbHunter,
     PatBrennan,
     UncleWill,
-    MollyStark,
     JohnnyKisch,
-    ClausTheSaint,
 )
 from .cards.bang import BangCard
 from .cards.missed import MissedCard

--- a/tests/test_cards.py
+++ b/tests/test_cards.py
@@ -8,7 +8,6 @@ from bang_py.cards.scope import ScopeCard
 from bang_py.cards.mustang import MustangCard
 from bang_py.cards.jail import JailCard
 from bang_py.cards.dynamite import DynamiteCard
-from bang_py.deck import Deck
 from bang_py.deck_factory import create_standard_deck
 from bang_py.player import Player
 

--- a/tests/test_characters.py
+++ b/tests/test_characters.py
@@ -20,7 +20,6 @@ from bang_py.characters import (
     WillyTheKid,
 )
 from bang_py.game_manager import GameManager
-from bang_py.deck import Deck
 from bang_py.deck_factory import create_standard_deck
 from bang_py.cards.bang import BangCard
 from bang_py.cards.beer import BeerCard

--- a/tests/test_expansions.py
+++ b/tests/test_expansions.py
@@ -19,8 +19,6 @@ from bang_py.cards import (
     CatBalouCard,
     PanicCard,
     IndiansCard,
-    StagecoachCard,
-    MissedCard,
 )
 from bang_py.characters import (
     PixiePete,

--- a/tests/test_new_features.py
+++ b/tests/test_new_features.py
@@ -1,5 +1,4 @@
 from bang_py.game_manager import GameManager
-from bang_py.deck import Deck
 from bang_py.deck_factory import create_standard_deck
 from bang_py.player import Player
 from bang_py.cards.bang import BangCard


### PR DESCRIPTION
## Summary
- remove unused imports flagged by flake8
- clean up test imports

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687228a5f5d48323837965424d79fcf2