### PR TITLE
Fix flake8 warnings in card modules

### DIFF
--- a/bang_py/cards/__init__.py
+++ b/bang_py/cards/__init__.py
@@ -73,4 +73,3 @@ __all__ = [
     "PonyExpressCard",
     "DerringerCard",
 ]
-

--- a/bang_py/cards/bang.py
+++ b/bang_py/cards/bang.py
@@ -15,7 +15,13 @@ class BangCard(Card):
     card_name = "Bang!"
     description = "Basic attack that deals 1 damage unless dodged."
 
-    def play(self, target: Player, deck: Deck | None = None, *, ignore_equipment: bool = False) -> None:
+    def play(
+        self,
+        target: Player,
+        deck: Deck | None = None,
+        *,
+        ignore_equipment: bool = False,
+    ) -> None:
         if not target:
             return
         if deck and not ignore_equipment:
@@ -35,4 +41,3 @@ class BangCard(Card):
                     target.metadata.dodged = True
                     return
         target.take_damage(1)
-

--- a/bang_py/cards/beer.py
+++ b/bang_py/cards/beer.py
@@ -48,4 +48,3 @@ class BeerCard(Card):
             target.heal(heal_amt)
             if game and target.health > before:
                 game.on_player_healed(target)
-

--- a/bang_py/cards/high_noon_card.py
+++ b/bang_py/cards/high_noon_card.py
@@ -10,12 +10,15 @@ if TYPE_CHECKING:
 
 class HighNoonCard(Card):
     """All players draw a card."""
-    
+
     card_name = "High Noon"
     description = "Event: everyone draws one card."
 
     def play(
-        self, target: Player | None = None, player: Player | None = None, game: GameManager | None = None
+        self,
+        target: Player | None = None,
+        player: Player | None = None,
+        game: GameManager | None = None,
     ) -> None:
         if not game:
             return

--- a/bang_py/cards/missed.py
+++ b/bang_py/cards/missed.py
@@ -12,4 +12,3 @@ class MissedCard(Card):
         if not target:
             return
         target.metadata.dodged = True
-

--- a/bang_py/cards/pony_express.py
+++ b/bang_py/cards/pony_express.py
@@ -16,7 +16,10 @@ class PonyExpressCard(Card):
     green_border = True
 
     def play(
-        self, target: Player | None = None, player: Player | None = None, game: GameManager | None = None
+        self,
+        target: Player | None = None,
+        player: Player | None = None,
+        game: GameManager | None = None,
     ) -> None:
         if player and game:
             game.draw_card(player, 3)


### PR DESCRIPTION
## Summary
- remove trailing blank lines in card modules
- split overly long method signatures to respect 100 char limit

## Testing
- `flake8 bang_py/cards --max-line-length=100`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68722ef0fe5483238aa37550ce42cdb9