### PR TITLE
Remove unused assignment in damage handler

### DIFF
--- a/bang_py/game_manager.py
+++ b/bang_py/game_manager.py
@@ -697,7 +697,7 @@ class GameManager:
                 if p is not player and has_ability(p, VultureSam):
                     p.hand.extend(player.hand)
                     player.hand.clear()
-            result = self._check_win_conditions()
+            self._check_win_conditions()
 
     def on_player_healed(self, player: Player) -> None:
         for cb in self.player_healed_listeners:


### PR DESCRIPTION
## Summary
- remove unused assignment when checking win conditions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872342b3a9c8323a1fc33df593700a2