### PR TITLE
Fix websocket disconnect cleanup

### DIFF
--- a/bang_py/network/server.py
+++ b/bang_py/network/server.py
@@ -236,6 +236,9 @@ class BangServer:
             try:
                 await conn.websocket.send(json.dumps(payload))
             except Exception:
+                # Remove the player from the game if their websocket is no
+                # longer reachable before dropping the connection entirely.
+                self.game.remove_player(conn.player)
                 self.connections.pop(websocket, None)
 
     def _find_connection(self, player: Player) -> Connection | None:


### PR DESCRIPTION
## Summary
- call `GameManager.remove_player` when websocket send fails in `broadcast_state`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687300521924832398e6390996359fa0