### PR TITLE
Improve error visibility and refactor draw logic

### DIFF
--- a/bang_py/game_manager.py
+++ b/bang_py/game_manager.py
@@ -267,17 +267,20 @@ class GameManager:
         self.current_turn = (self.current_turn + 1) % len(self.turn_order)
         self._begin_turn()
 
+    def _draw_from_deck(self) -> Card | None:
+        """Draw a card reshuffling the discard pile if the deck is empty."""
+        card = self.deck.draw()
+        if card is None and self.discard_pile:
+            self.deck.cards.extend(self.discard_pile)
+            self.discard_pile.clear()
+            random.shuffle(self.deck.cards)
+            card = self.deck.draw()
+        return card
+
     def draw_card(self, player: Player, num: int = 1) -> None:
         bonus = int(self.event_flags.get("peyote_bonus", 0))
         for _ in range(num + bonus):
-            card = self.deck.draw()
-            if card is None:
-                if self.discard_pile:
-                    # reshuffle discard into deck
-                    self.deck.cards.extend(self.discard_pile)
-                    self.discard_pile.clear()
-                    random.shuffle(self.deck.cards)
-                    card = self.deck.draw()
+            card = self._draw_from_deck()
             if card:
                 player.hand.append(card)
 
@@ -634,13 +637,7 @@ class GameManager:
         alive = [p for p in self.players if p.is_alive()]
         cards: List[Card] = []
         for _ in range(len(alive)):
-            card = self.deck.draw()
-            if card is None:
-                if self.discard_pile:
-                    self.deck.cards.extend(self.discard_pile)
-                    self.discard_pile.clear()
-                    random.shuffle(self.deck.cards)
-                    card = self.deck.draw()
+            card = self._draw_from_deck()
             if card:
                 cards.append(card)
         self.general_store_cards = cards

--- a/bang_py/network/server.py
+++ b/bang_py/network/server.py
@@ -246,6 +246,10 @@ class BangServer:
             except Exception:
                 # Remove the player from the game if their websocket is no
                 # longer reachable before dropping the connection entirely.
+                try:
+                    await conn.websocket.close()
+                except Exception:
+                    pass
                 self.game.remove_player(conn.player)
                 self.connections.pop(websocket, None)
 

--- a/bang_py/ui.py
+++ b/bang_py/ui.py
@@ -6,6 +6,7 @@ import queue
 import tkinter as tk
 from tkinter import ttk, messagebox
 from typing import Callable
+import logging
 import websockets
 
 from .network.server import BangServer
@@ -44,7 +45,7 @@ class ServerThread(threading.Thread):
         try:
             self.loop.run_until_complete(self.server_task)
         except asyncio.CancelledError:
-            pass
+            logging.info("Server thread cancelled")
         finally:
             self.loop.run_until_complete(self.loop.shutdown_asyncgens())
             self.loop.close()
@@ -80,7 +81,7 @@ class ClientThread(threading.Thread):
             try:
                 fut.result(timeout=1)
             except Exception:
-                pass
+                logging.exception("Failed to close websocket")
         if self.loop.is_running():
             self.loop.call_soon_threadsafe(self.loop.stop)
 

--- a/tests/test_event_deck_effects.py
+++ b/tests/test_event_deck_effects.py
@@ -38,13 +38,17 @@ def test_fistful_event_damage_by_hand():
     assert p.health == p.max_health - 2
 
 
+def _enable_no_bang(game: GameManager) -> None:
+    game.event_flags.update(no_bang=True)
+
+
 def test_sermon_event_blocks_bang():
     gm = GameManager()
     sheriff = Player("Sheriff", role=Role.SHERIFF)
     outlaw = Player("Outlaw")
     gm.add_player(sheriff)
     gm.add_player(outlaw)
-    gm.event_deck = [EventCard("The Sermon", lambda g: g.event_flags.update(no_bang=True), "")]
+    gm.event_deck = [EventCard("The Sermon", _enable_no_bang, "")]
     gm.draw_event_card()
     sheriff.hand.append(BangCard())
     gm.play_card(sheriff, sheriff.hand[0], outlaw)
@@ -52,11 +56,15 @@ def test_sermon_event_blocks_bang():
     assert outlaw.health == outlaw.max_health
 
 
+def _enable_no_beer(game: GameManager) -> None:
+    game.event_flags.update(no_beer=True)
+
+
 def test_hangover_event_disables_beer():
     gm = GameManager()
     sheriff = Player("Sheriff", role=Role.SHERIFF)
     gm.add_player(sheriff)
-    gm.event_deck = [EventCard("Hangover", lambda g: g.event_flags.update(no_beer=True), "")]
+    gm.event_deck = [EventCard("Hangover", _enable_no_beer, "")]
     gm.draw_event_card()
     sheriff.health -= 1
     sheriff.hand.append(BeerCard())

--- a/tests/test_full_game_simulation.py
+++ b/tests/test_full_game_simulation.py
@@ -165,7 +165,11 @@ def simulate_game(num_players: int) -> str:
         player = Player(f"P{i}", role=roles[i], character=chars[i]())
         gm.add_player(player)
     result: List[str] = []
-    gm.game_over_listeners.append(lambda res: result.append(res))
+
+    def _record_result(res: str) -> None:
+        result.append(res)
+
+    gm.game_over_listeners.append(_record_result)
     gm.start_game()
     steps = 0
     while not result and steps < 2000:

--- a/tests/test_gamemanager.py
+++ b/tests/test_gamemanager.py
@@ -9,7 +9,11 @@ def test_start_game_initializes_turn_order_and_calls_listener():
     gm.add_player(p1)
     gm.add_player(p2)
     started_players = []
-    gm.turn_started_listeners.append(lambda player: started_players.append(player))
+
+    def _record_start(player: Player) -> None:
+        started_players.append(player)
+
+    gm.turn_started_listeners.append(_record_start)
 
     gm.start_game()
 

--- a/tests/test_turn_rules.py
+++ b/tests/test_turn_rules.py
@@ -52,7 +52,11 @@ def test_outlaws_win_when_sheriff_dies():
     gm.add_player(sheriff)
     gm.add_player(outlaw)
     results: list[str] = []
-    gm.game_over_listeners.append(lambda r: results.append(r))
+
+    def _record_result(r: str) -> None:
+        results.append(r)
+
+    gm.game_over_listeners.append(_record_result)
     sheriff.health = 1
     outlaw.hand.append(BangCard())
     gm.play_card(outlaw, outlaw.hand[0], sheriff)


### PR DESCRIPTION
## Summary
- log when UI threads are cancelled or fail to close sockets
- close broken websockets when broadcasting state
- add `_draw_from_deck` helper to shuffle the discard pile when needed
- replace test lambdas with named helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873205e325c8323a917b3c2b7aee0a7