### PR TITLE
Fix card selection logic for Cat Balou and Panic

### DIFF
--- a/bang_py/cards/cat_balou.py
+++ b/bang_py/cards/cat_balou.py
@@ -12,19 +12,32 @@ if TYPE_CHECKING:
 
 class CatBalouCard(Card):
     card_name = "Cat Balou"
-    description = "Force a player to discard a random card or equipment."
+    description = (
+        "Choose a card from the target's hand or in play and discard it."
+    )
 
-    def play(self, target: Player, game: GameManager | None = None) -> None:
+    def play(
+        self,
+        target: Player,
+        game: GameManager | None = None,
+        *,
+        hand_idx: int | None = None,
+        equip_name: str | None = None,
+    ) -> None:
+        """Discard a chosen card from the target's hand or equipment."""
         if not target:
             return
-        if target.hand:
-            card = random.choice(target.hand)
-            target.hand.remove(card)
+
+        if target.hand and (hand_idx is not None or not target.equipment):
+            idx = hand_idx if hand_idx is not None and 0 <= hand_idx < len(target.hand) else 0
+            card = target.hand.pop(idx)
             if game:
                 game.discard_pile.append(card)
                 handle_out_of_turn_discard(game, target, card)
-        elif target.equipment:
-            card = random.choice(list(target.equipment.values()))
-            target.unequip(card.card_name)
-            if game:
+            return
+
+        if target.equipment:
+            name = equip_name or next(iter(target.equipment))
+            card = target.unequip(name)
+            if card and game:
                 game.discard_pile.append(card)

--- a/bang_py/cards/duel.py
+++ b/bang_py/cards/duel.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 
 class DuelCard(Card):
     card_name = "Duel"
-    description = "Players alternate playing Bang!; loser takes 1 damage."
+    description = "Players alternate discarding Bang! cards; loser takes 1 damage."
 
     def play(
         self, target: Player, player: Player | None = None, game: GameManager | None = None

--- a/bang_py/cards/dynamite.py
+++ b/bang_py/cards/dynamite.py
@@ -12,7 +12,10 @@ if TYPE_CHECKING:  # pragma: no cover - for type hints only
 
 class DynamiteCard(EquipmentCard):
     card_name = "Dynamite"
-    description = "Passes around; may explode for 3 damage."
+    description = (
+        "Passes around; at the start of your turn draw a card, and if it is a "
+        "spade between 2 and 9, Dynamite explodes for 3 damage."
+    )
 
     def play(self, target: Player, deck: Deck | None = None) -> None:
         super().play(target)

--- a/bang_py/cards/panic.py
+++ b/bang_py/cards/panic.py
@@ -12,19 +12,32 @@ if TYPE_CHECKING:
 
 class PanicCard(Card):
     card_name = "Panic!"
-    description = "Steal a random card or equipment from another player."
+    description = (
+        "Range 1: choose a card from the target's hand or in play and take it."
+    )
 
     def play(
-        self, target: Player, player: Player | None = None, game: GameManager | None = None
+        self,
+        target: Player,
+        player: Player | None = None,
+        game: GameManager | None = None,
+        *,
+        hand_idx: int | None = None,
+        equip_name: str | None = None,
     ) -> None:
+        """Steal a chosen card from the target."""
         if not target or not player:
             return
-        if target.hand:
-            card = random.choice(target.hand)
-            target.hand.remove(card)
+
+        if target.hand and (hand_idx is not None or not target.equipment):
+            idx = hand_idx if hand_idx is not None and 0 <= hand_idx < len(target.hand) else 0
+            card = target.hand.pop(idx)
             handle_out_of_turn_discard(game, target, card)
             player.hand.append(card)
-        elif target.equipment:
-            card = random.choice(list(target.equipment.values()))
-            target.unequip(card.card_name)
-            player.hand.append(card)
+            return
+
+        if target.equipment:
+            name = equip_name or next(iter(target.equipment))
+            card = target.unequip(name)
+            if card:
+                player.hand.append(card)

--- a/tests/test_additional_cards.py
+++ b/tests/test_additional_cards.py
@@ -154,3 +154,57 @@ def test_gatling_hits_all_opponents():
     GatlingCard().play(p1, p1, game=gm)
     assert p2.health == p2.max_health - 1
     assert p3.health == p3.max_health - 1
+
+
+def test_cat_balou_allows_choice_from_hand():
+    gm = GameManager(deck=Deck([]))
+    attacker = Player("A")
+    target = Player("B")
+    gm.add_player(attacker)
+    gm.add_player(target)
+    c1, c2 = BangCard(), BeerCard()
+    target.hand.extend([c1, c2])
+    CatBalouCard().play(target, game=gm, hand_idx=1)
+    assert gm.discard_pile[-1] is c2
+    assert target.hand == [c1]
+
+
+def test_cat_balou_allows_choice_from_equipment():
+    from bang_py.cards.barrel import BarrelCard
+
+    gm = GameManager(deck=Deck([]))
+    attacker = Player("A")
+    target = Player("B")
+    gm.add_player(attacker)
+    gm.add_player(target)
+    BarrelCard().play(target)
+    CatBalouCard().play(target, game=gm, equip_name="Barrel")
+    assert "Barrel" not in target.equipment
+    assert isinstance(gm.discard_pile[-1], BarrelCard)
+
+
+def test_panic_allows_choice_from_hand():
+    gm = GameManager(deck=Deck([]))
+    attacker = Player("A")
+    target = Player("B")
+    gm.add_player(attacker)
+    gm.add_player(target)
+    c1, c2 = BangCard(), BeerCard()
+    target.hand.extend([c1, c2])
+    PanicCard().play(target, attacker, game=gm, hand_idx=0)
+    assert attacker.hand[-1] is c1
+    assert target.hand == [c2]
+
+
+def test_panic_allows_choice_from_equipment():
+    from bang_py.cards.scope import ScopeCard
+
+    gm = GameManager(deck=Deck([]))
+    attacker = Player("A")
+    target = Player("B")
+    gm.add_player(attacker)
+    gm.add_player(target)
+    ScopeCard().play(target)
+    PanicCard().play(target, attacker, game=gm, equip_name="Scope")
+    assert "Scope" not in target.equipment
+    assert any(isinstance(c, ScopeCard) for c in attacker.hand)


### PR DESCRIPTION
## Summary
- let Cat Balou and Panic specify which card to take
- add tests for choosing cards explicitly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68733d809ff88323bdd3ce88f7414dc2