### PR TITLE
Update event decks and tests

### DIFF
--- a/bang_py/event_decks.py
+++ b/bang_py/event_decks.py
@@ -62,7 +62,8 @@ def _thirst(game: GameManager) -> None:
 
 
 def _shootout(game: GameManager) -> None:
-    game.event_flags["bang_limit"] = 2
+    """Allow unlimited Bang! cards this turn."""
+    game.event_flags["bang_limit"] = 99
 
 
 def _high_noon(game: GameManager) -> None:
@@ -139,8 +140,8 @@ def _prison_break(game: GameManager) -> None:
 
 
 def _high_stakes(game: GameManager) -> None:
-    """Players may play two Bang! cards."""
-    game.event_flags["bang_limit"] = 2
+    """Players may play any number of Bang! cards."""
+    game.event_flags["bang_limit"] = 99
 
 
 @dataclass
@@ -160,7 +161,7 @@ def create_high_noon_deck() -> List[EventCard]:
     """Return a simple High Noon event deck."""
     return [
         EventCard("Thirst", _thirst, "Players draw only one card"),
-        EventCard("Shootout", _shootout, "Play two Bang!s per turn"),
+        EventCard("Shootout", _shootout, "Unlimited Bang!s per turn"),
         EventCard("Blessing", _blessing, "All players heal"),
         EventCard("Gold Rush", _gold_rush, "Draw three cards"),
         EventCard("The Judge", _judge, "Beer cards cannot be played"),
@@ -188,7 +189,7 @@ def create_fistful_deck() -> List[EventCard]:
         EventCard("Bounty", _bounty, "Rewards for eliminations"),
         EventCard("Vendetta", _vendetta, "Outlaws have +1 range"),
         EventCard("Prison Break", _prison_break, "Jail discarded"),
-        EventCard("High Stakes", _high_stakes, "Two Bang!s"),
+        EventCard("High Stakes", _high_stakes, "Unlimited Bang!s"),
         EventCard("Ghost Town", _fistful_ghost_town, "Eliminated return"),
         EventCard("A Fistful of Cards", _fistful, "Damage equal to cards in hand"),
     ]

--- a/bang_py/game_manager.py
+++ b/bang_py/game_manager.py
@@ -109,9 +109,21 @@ class GameManager:
         self.event_flags = {}
         if "high_noon" in self.expansions:
             self.event_deck = create_high_noon_deck()
+            if self.event_deck:
+                final = next((c for c in self.event_deck if c.name == "High Noon"), None)
+                if final:
+                    self.event_deck.remove(final)
+                    random.shuffle(self.event_deck)
+                    self.event_deck.append(final)
         elif "fistful_of_cards" in self.expansions:
             self.event_deck = create_fistful_deck()
-        if self.event_deck:
+            if self.event_deck:
+                final = next((c for c in self.event_deck if c.name == "A Fistful of Cards"), None)
+                if final:
+                    self.event_deck.remove(final)
+                    random.shuffle(self.event_deck)
+                    self.event_deck.append(final)
+        elif self.event_deck:
             random.shuffle(self.event_deck)
         self._register_card_handlers()
 


### PR DESCRIPTION
## Summary
- fix `Shootout` and `High Stakes` to allow unlimited Bang! cards
- keep High Noon and Fistful decks ordered with their final cards on the bottom
- test additional event effects and deck sequencing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68734c0a6da08323af764bebb86d7bba