### PR TITLE
Add missing Bullet expansion cards

### DIFF
--- a/bang_py/cards/__init__.py
+++ b/bang_py/cards/__init__.py
@@ -38,6 +38,11 @@ from .tequila import TequilaCard
 from .pony_express import PonyExpressCard
 from .derringer import DerringerCard
 from .rag_time import RagTimeCard
+from .bible import BibleCard
+from .canteen import CanteenCard
+from .conestoga import ConestogaCard
+from .can_can import CanCanCard
+from .ten_gallon_hat import TenGallonHatCard
 
 __all__ = [
     "BangCard",
@@ -80,4 +85,9 @@ __all__ = [
     "PonyExpressCard",
     "DerringerCard",
     "RagTimeCard",
+    "BibleCard",
+    "CanteenCard",
+    "ConestogaCard",
+    "CanCanCard",
+    "TenGallonHatCard",
 ]

--- a/bang_py/cards/bible.py
+++ b/bang_py/cards/bible.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from .card import Card
+from ..player import Player
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..game_manager import GameManager
+
+
+class BibleCard(Card):
+    """Missed! effect that also lets the player draw a card."""
+
+    card_name = "Bible"
+    description = "Play as Missed! and then draw one card."
+    green_border = True
+
+    def play(
+        self,
+        target: Player,
+        player: Player | None = None,
+        game: GameManager | None = None,
+    ) -> None:
+        if not target:
+            return
+        target.metadata.dodged = True
+        if game:
+            game.draw_card(player or target)

--- a/bang_py/cards/can_can.py
+++ b/bang_py/cards/can_can.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from .card import Card
+from ..player import Player
+from typing import TYPE_CHECKING
+from ..helpers import handle_out_of_turn_discard
+
+if TYPE_CHECKING:
+    from ..game_manager import GameManager
+
+
+class CanCanCard(Card):
+    """Discard a chosen card from the target."""
+
+    card_name = "Can Can"
+    description = "Choose a card to discard from any one player."
+    green_border = True
+
+    def play(
+        self,
+        target: Player,
+        player: Player | None = None,
+        game: GameManager | None = None,
+        *,
+        hand_idx: int | None = None,
+        equip_name: str | None = None,
+    ) -> None:
+        if not target or not game:
+            return
+        if target.hand and (hand_idx is not None or not target.equipment):
+            idx = hand_idx if hand_idx is not None and 0 <= hand_idx < len(target.hand) else 0
+            card = target.hand.pop(idx)
+            game.discard_pile.append(card)
+            handle_out_of_turn_discard(game, target, card)
+        elif target.equipment:
+            name = equip_name or next(iter(target.equipment))
+            card = target.unequip(name)
+            if card:
+                game.discard_pile.append(card)

--- a/bang_py/cards/canteen.py
+++ b/bang_py/cards/canteen.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from .card import Card
+from ..player import Player
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..game_manager import GameManager
+
+
+class CanteenCard(Card):
+    """Refreshment to heal one health."""
+
+    card_name = "Canteen"
+    description = "Heal 1 health."
+    green_border = True
+
+    def play(
+        self,
+        target: Player,
+        player: Player | None = None,
+        game: GameManager | None = None,
+    ) -> None:
+        if not target:
+            return
+        before = target.health
+        target.heal(1)
+        if game and target.health > before:
+            game.on_player_healed(target)

--- a/bang_py/cards/conestoga.py
+++ b/bang_py/cards/conestoga.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from .card import Card
+from ..player import Player
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..game_manager import GameManager
+
+
+class ConestogaCard(Card):
+    """Steal a card from any one player."""
+
+    card_name = "Conestoga"
+    description = "Steal a card from any player."
+    green_border = True
+
+    def play(
+        self,
+        target: Player,
+        player: Player | None = None,
+        game: GameManager | None = None,
+        *,
+        hand_idx: int | None = None,
+        equip_name: str | None = None,
+    ) -> None:
+        if not target or not player:
+            return
+        if target.hand and (hand_idx is not None or not target.equipment):
+            idx = hand_idx if hand_idx is not None and 0 <= hand_idx < len(target.hand) else 0
+            card = target.hand.pop(idx)
+            player.hand.append(card)
+        elif target.equipment:
+            name = equip_name or next(iter(target.equipment))
+            card = target.unequip(name)
+            if card:
+                player.hand.append(card)

--- a/bang_py/cards/ten_gallon_hat.py
+++ b/bang_py/cards/ten_gallon_hat.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from .missed import MissedCard
+from ..player import Player
+
+
+class TenGallonHatCard(MissedCard):
+    """Simple green-bordered Missed!"""
+
+    card_name = "Ten Gallon Hat"
+    description = "Counts as a Missed!"
+    green_border = True
+
+    def play(self, target: Player) -> None:  # type: ignore[override]
+        super().play(target)

--- a/bang_py/deck_factory.py
+++ b/bang_py/deck_factory.py
@@ -44,6 +44,11 @@ from .cards import (
     RagTimeCard,
     PepperboxCard,
     HowitzerCard,
+    BibleCard,
+    CanteenCard,
+    ConestogaCard,
+    CanCanCard,
+    TenGallonHatCard,
 )
 from .cards.card import Card
 
@@ -87,6 +92,11 @@ DODGE_CITY_COUNTS: List[Tuple[Type[Card], int]] = [
     (SombreroCard, 1),
     (IronPlateCard, 1),
     (DerringerCard, 2),
+    (BibleCard, 1),
+    (CanteenCard, 1),
+    (ConestogaCard, 1),
+    (CanCanCard, 1),
+    (TenGallonHatCard, 1),
 ]
 
 FISTFUL_COUNTS: List[Tuple[Type[Card], int]] = [

--- a/bang_py/game_manager.py
+++ b/bang_py/game_manager.py
@@ -58,6 +58,11 @@ from .cards.high_noon_card import HighNoonCard
 from .cards.pony_express import PonyExpressCard
 from .cards.tequila import TequilaCard
 from .cards.rag_time import RagTimeCard
+from .cards.bible import BibleCard
+from .cards.canteen import CanteenCard
+from .cards.conestoga import ConestogaCard
+from .cards.can_can import CanCanCard
+from .cards.ten_gallon_hat import TenGallonHatCard
 
 from .player import Player, Role
 from .event_decks import (
@@ -489,6 +494,10 @@ class GameManager:
             BrawlCard: self._handler_self_player_game,
             SpringfieldCard: self._handler_target_player_game,
             RagTimeCard: self._handler_target_player_game,
+            BibleCard: self._handler_target_or_self_player_game,
+            CanteenCard: self._handler_target_or_self_player_game,
+            ConestogaCard: self._handler_target_player_game,
+            CanCanCard: self._handler_target_game,
         }
 
     def play_card(self, player: Player, card: Card, target: Optional[Player] = None) -> None:

--- a/tests/test_expansions.py
+++ b/tests/test_expansions.py
@@ -18,6 +18,11 @@ from bang_py.cards import (
     PonyExpressCard,
     TequilaCard,
     RagTimeCard,
+    BibleCard,
+    CanteenCard,
+    ConestogaCard,
+    CanCanCard,
+    TenGallonHatCard,
     BeerCard,
     BarrelCard,
     BangCard,
@@ -453,4 +458,60 @@ def test_green_bordered_cards():
         if getattr(obj, "green_border", False)
     }
     assert green <= allowed
+
+
+def test_bible_card_dodges_and_draws():
+    gm = GameManager()
+    p = Player("P")
+    gm.add_player(p)
+    card = BibleCard()
+    p.hand.append(card)
+    gm.play_card(p, card, p)
+    assert p.metadata.dodged is True
+    assert len(p.hand) == 1
+
+
+def test_canteen_card_heals():
+    gm = GameManager()
+    p = Player("P")
+    gm.add_player(p)
+    p.health -= 1
+    card = CanteenCard()
+    p.hand.append(card)
+    gm.play_card(p, card, p)
+    assert p.health == p.max_health
+
+
+def test_conestoga_steals_card():
+    gm = GameManager()
+    p1 = Player("A")
+    p2 = Player("B")
+    gm.add_player(p1)
+    gm.add_player(p2)
+    stolen = BangCard()
+    p2.hand.append(stolen)
+    card = ConestogaCard()
+    p1.hand.append(card)
+    gm.play_card(p1, card, p2)
+    assert stolen in p1.hand
+    assert not p2.hand
+
+
+def test_can_can_discards_card():
+    gm = GameManager()
+    attacker = Player("A")
+    target = Player("B")
+    gm.add_player(attacker)
+    gm.add_player(target)
+    target.hand.append(BangCard())
+    card = CanCanCard()
+    attacker.hand.append(card)
+    gm.play_card(attacker, card, target)
+    assert not target.hand
+
+
+def test_ten_gallon_hat_is_missed():
+    target = Player("T")
+    TenGallonHatCard().play(target)
+    assert target.metadata.dodged is True
 


### PR DESCRIPTION
## Summary
- implement Bible as green Missed! that draws a card
- implement Can Can discard mechanic
- implement Conestoga as card stealing effect
- simplify Ten Gallon Hat to a green Missed!
- update tests for new Bullet card behaviours

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687361e1a7b883239542e95e4a8f80b2