### PR TITLE
Expand event deck tests

### DIFF
--- a/tests/test_event_deck_effects.py
+++ b/tests/test_event_deck_effects.py
@@ -14,10 +14,21 @@ from bang_py.event_decks import (
     _law_of_the_west,
     _cattle_drive,
     _shootout,
+    _blessing,
+    _gold_rush,
+    _siesta,
+    _sermon,
+    _hangover,
+    _ambush_event,
+    _ranch,
+    _prison_break,
+    _high_noon,
+    _high_stakes,
 )
 from bang_py.game_manager import GameManager
 from bang_py.player import Player, Role
-from bang_py.cards import BangCard, BeerCard
+from bang_py.cards import BangCard, BeerCard, MissedCard
+from bang_py.cards.jail import JailCard
 from bang_py.deck import Deck
 
 
@@ -137,6 +148,40 @@ def test_bounty_rewards_elimination():
     assert len(sheriff.hand) == 2
 
 
+def test_blessing_heals_everyone():
+    gm = GameManager()
+    p1 = Player("A")
+    p2 = Player("B")
+    gm.add_player(p1)
+    gm.add_player(p2)
+    p1.health -= 1
+    p2.health -= 1
+    gm.event_deck = [EventCard("Blessing", _blessing, "")]
+    gm.draw_event_card()
+    assert p1.health == p1.max_health
+    assert p2.health == p2.max_health
+
+
+def test_gold_rush_draws_three():
+    gm = GameManager()
+    p = Player("Sheriff", role=Role.SHERIFF)
+    gm.add_player(p)
+    gm.event_deck = [EventCard("Gold Rush", _gold_rush, "")]
+    gm.draw_event_card()
+    gm.draw_phase(p)
+    assert len(p.hand) == 3
+
+
+def test_siesta_draws_three():
+    gm = GameManager()
+    p = Player("Sheriff", role=Role.SHERIFF)
+    gm.add_player(p)
+    gm.event_deck = [EventCard("Siesta", _siesta, "")]
+    gm.draw_event_card()
+    gm.draw_phase(p)
+    assert len(p.hand) == 3
+
+
 def test_vendetta_outlaw_range_bonus():
     gm = GameManager()
     outlaw = Player("Out", role=Role.OUTLAW)
@@ -146,6 +191,32 @@ def test_vendetta_outlaw_range_bonus():
     gm.event_deck = [EventCard("Vendetta", _vendetta, "")]
     gm.draw_event_card()
     assert outlaw.attack_range == 2
+
+
+def test_sermon_blocks_bang_real():
+    gm = GameManager()
+    sheriff = Player("Sheriff", role=Role.SHERIFF)
+    outlaw = Player("Outlaw")
+    gm.add_player(sheriff)
+    gm.add_player(outlaw)
+    gm.event_deck = [EventCard("The Sermon", _sermon, "")]
+    gm.draw_event_card()
+    sheriff.hand.append(BangCard())
+    gm.play_card(sheriff, sheriff.hand[0], outlaw)
+    assert len(sheriff.hand) == 1
+    assert outlaw.health == outlaw.max_health
+
+
+def test_hangover_no_beer_real():
+    gm = GameManager()
+    p = Player("Sheriff", role=Role.SHERIFF)
+    gm.add_player(p)
+    gm.event_deck = [EventCard("Hangover", _hangover, "")]
+    gm.draw_event_card()
+    p.health -= 1
+    p.hand.append(BeerCard())
+    gm.play_card(p, p.hand[0])
+    assert p.health == p.max_health - 1
 
 
 def test_ricochet_hits_next_player():
@@ -162,6 +233,87 @@ def test_ricochet_hits_next_player():
     gm.play_card(p1, p1.hand[0], p2)
     assert p2.health == p2.max_health - 1
     assert p3.health == p3.max_health - 1
+
+
+def test_ambush_disables_auto_miss():
+    gm = GameManager()
+    p1 = Player("A")
+    p2 = Player("B")
+    gm.add_player(p1)
+    gm.add_player(p2)
+    gm.event_deck = [EventCard("Ambush", _ambush_event, "")]
+    gm.draw_event_card()
+    p1.hand.append(BangCard())
+    p2.hand.append(MissedCard())
+    gm.play_card(p1, p1.hand[0], p2)
+    assert p2.health == p2.max_health - 1
+    assert isinstance(p2.hand[0], MissedCard)
+
+
+def test_ranch_heals_everyone():
+    gm = GameManager()
+    p1 = Player("A")
+    p2 = Player("B")
+    gm.add_player(p1)
+    gm.add_player(p2)
+    p1.health -= 1
+    p2.health -= 1
+    gm.event_deck = [EventCard("Ranch", _ranch, "")]
+    gm.draw_event_card()
+    assert p1.health == p1.max_health
+    assert p2.health == p2.max_health
+
+
+def test_prison_break_discards_jail():
+    gm = GameManager()
+    p = Player("Sheriff", role=Role.SHERIFF)
+    gm.add_player(p)
+    jail = JailCard()
+    p.equipment["Jail"] = jail
+    gm.event_deck = [EventCard("Prison Break", _prison_break, "")]
+    gm.turn_order = [0]
+    gm.current_turn = 0
+    gm.draw_event_card()
+    gm._begin_turn()
+    assert "Jail" not in p.equipment
+    assert jail in gm.discard_pile
+
+
+def test_high_noon_start_damage():
+    gm = GameManager()
+    p = Player("Sheriff", role=Role.SHERIFF)
+    gm.add_player(p)
+    gm.event_deck = [EventCard("High Noon", _high_noon, "")]
+    gm.turn_order = [0]
+    gm.current_turn = 0
+    gm.draw_event_card()
+    gm._begin_turn()
+    assert p.health == p.max_health - 1
+
+
+def test_high_stakes_allows_multiple_bangs():
+    gm = GameManager()
+    p1 = Player("Sheriff", role=Role.SHERIFF)
+    p2 = Player("Outlaw")
+    gm.add_player(p1)
+    gm.add_player(p2)
+    gm.event_deck = [EventCard("High Stakes", _high_stakes, "")]
+    gm.draw_event_card()
+    p1.hand.extend([BangCard(), BangCard()])
+    gm.play_card(p1, p1.hand[0], p2)
+    gm.play_card(p1, p1.hand[0], p2)
+    assert p2.health == p2.max_health - 2
+
+
+def test_event_deck_order_fistful():
+    gm = GameManager(expansions=["fistful_of_cards"])
+    sheriff = Player("Sheriff", role=Role.SHERIFF)
+    outlaw = Player("Outlaw")
+    gm.add_player(sheriff)
+    gm.add_player(outlaw)
+    gm.start_game()
+    assert gm.current_event is not None
+    assert gm.event_deck[-1].name == "A Fistful of Cards"
 
 
 def test_river_passes_discard_left():


### PR DESCRIPTION
## Summary
- increase coverage for high noon and fistful events
- verify both event deck orders remain correct

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68736b3aaea08323af07b5ca91e83e26