### PR TITLE
Add Bullet event deck entries

### DIFF
--- a/bang_py/cards/__init__.py
+++ b/bang_py/cards/__init__.py
@@ -43,6 +43,7 @@ from .canteen import CanteenCard
 from .conestoga import ConestogaCard
 from .can_can import CanCanCard
 from .ten_gallon_hat import TenGallonHatCard
+from .rev_carabine import RevCarabineCard
 
 __all__ = [
     "BangCard",
@@ -90,4 +91,5 @@ __all__ = [
     "ConestogaCard",
     "CanCanCard",
     "TenGallonHatCard",
+    "RevCarabineCard",
 ]

--- a/bang_py/cards/rev_carabine.py
+++ b/bang_py/cards/rev_carabine.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from .equipment import EquipmentCard
+
+
+class RevCarabineCard(EquipmentCard):
+    """Classic gun with range 4."""
+
+    card_name = "Rev. Carabine"
+    slot = "Gun"
+    range = 4
+    description = "Gun with range 4."

--- a/bang_py/deck_factory.py
+++ b/bang_py/deck_factory.py
@@ -49,6 +49,7 @@ from .cards import (
     ConestogaCard,
     CanCanCard,
     TenGallonHatCard,
+    RevCarabineCard,
 )
 from .cards.card import Card
 
@@ -97,6 +98,7 @@ DODGE_CITY_COUNTS: List[Tuple[Type[Card], int]] = [
     (ConestogaCard, 1),
     (CanCanCard, 1),
     (TenGallonHatCard, 1),
+    (RevCarabineCard, 1),
 ]
 
 FISTFUL_COUNTS: List[Tuple[Type[Card], int]] = [

--- a/bang_py/event_decks.py
+++ b/bang_py/event_decks.py
@@ -139,6 +139,83 @@ def _prison_break(game: GameManager) -> None:
     game.event_flags["no_jail"] = True
 
 
+def _curse_event(game: GameManager) -> None:
+    """Players reveal their hands."""
+    game.event_flags["revealed_hands"] = True
+
+
+def _daltons_event(game: GameManager) -> None:
+    """Each player draws a card."""
+    for player in game.players:
+        game.draw_card(player)
+
+
+def _doctor_event(game: GameManager) -> None:
+    """Players heal instead of drawing."""
+    game.event_flags["doctor"] = True
+
+
+def _reverend_event(game: GameManager) -> None:
+    """Limit each player to two cards per turn."""
+    game.event_flags["reverend_limit"] = 2
+
+
+def _train_arrival_event(game: GameManager) -> None:
+    """All players draw one card."""
+    for player in game.players:
+        game.draw_card(player)
+
+
+def _handcuffs_event(game: GameManager) -> None:
+    """Skip the next player's turn."""
+    game.event_flags["skip_turn"] = True
+
+
+def _new_identity_event(game: GameManager) -> None:
+    """All players discard their hand and draw the same number of cards."""
+    for player in game.players:
+        num = len(player.hand)
+        while player.hand:
+            game.discard_pile.append(player.hand.pop())
+        if num:
+            game.draw_card(player, num)
+
+
+def _lasso_event(game: GameManager) -> None:
+    """Each player takes the first card from the next player's hand if possible."""
+    players = game.players
+    taken: list = []
+    for i, player in enumerate(players):
+        target = players[(i + 1) % len(players)]
+        card = target.hand.pop(0) if target.hand else None
+        taken.append(card)
+    for card, player in zip(taken, players):
+        if card:
+            player.hand.append(card)
+
+
+def _sniper_event(game: GameManager) -> None:
+    """All players have unlimited range."""
+    game.event_flags["range_unlimited"] = True
+
+
+def _russian_roulette_event(game: GameManager) -> None:
+    """All players take 1 damage."""
+    for player in list(game.players):
+        player.take_damage(1)
+        game.on_player_damaged(player)
+
+
+def _blood_brothers_event(game: GameManager) -> None:
+    """Players share damage."""
+    game.event_flags["blood_brothers"] = True
+
+
+def _dead_man_event(game: GameManager) -> None:
+    """Players skip their draw phase."""
+    game.event_flags["no_draw"] = True
+
+
 def _high_stakes(game: GameManager) -> None:
     """Players may play any number of Bang! cards."""
     game.event_flags["bang_limit"] = 99
@@ -160,19 +237,21 @@ class EventCard:
 def create_high_noon_deck() -> List[EventCard]:
     """Return a simple High Noon event deck."""
     return [
-        EventCard("Thirst", _thirst, "Players draw only one card"),
-        EventCard("Shootout", _shootout, "Unlimited Bang!s per turn"),
         EventCard("Blessing", _blessing, "All players heal"),
-        EventCard("Gold Rush", _gold_rush, "Draw three cards"),
-        EventCard("The Judge", _judge, "Beer cards cannot be played"),
+        EventCard("Curse", _curse_event, "Hands are visible"),
         EventCard("Ghost Town", _ghost_town, "Eliminated players return"),
-        EventCard("Law of the West", _law_of_the_west, "Unlimited range"),
-        EventCard("Siesta", _siesta, "Draw three cards"),
-        EventCard("Cattle Drive", _cattle_drive, "Discard a card"),
-        EventCard("The Sermon", _sermon, "Bang! cannot be played"),
-        EventCard("Peyote", _peyote, "Lucky draws"),
+        EventCard("Gold Rush", _gold_rush, "Draw three cards"),
         EventCard("Hangover", _hangover, "Beer gives no health"),
         EventCard("High Noon", _high_noon, "Lose 1 life at start of turn"),
+        EventCard("Shootout", _shootout, "Unlimited Bang!s per turn"),
+        EventCard("The Daltons", _daltons_event, "Everyone draws"),
+        EventCard("The Doctor", _doctor_event, "Draw to heal"),
+        EventCard("The Reverend", _reverend_event, "Limit to two cards"),
+        EventCard("The Sermon", _sermon, "Bang! cannot be played"),
+        EventCard("Thirst", _thirst, "Players draw only one card"),
+        EventCard("Train Arrival", _train_arrival_event, "Everyone draws"),
+        EventCard("Handcuffs", _handcuffs_event, "Skip the sheriff's turn"),
+        EventCard("New Identity", _new_identity_event, "Players redraw hands"),
     ]
 
 
@@ -181,15 +260,17 @@ def create_fistful_deck() -> List[EventCard]:
     return [
         EventCard("Abandoned Mine", _abandoned_mine, "Everyone draws"),
         EventCard("Ambush", _ambush_event, "Missed! has no effect"),
-        EventCard("Ricochet", _ricochet, "Bang! hits an extra player"),
-        EventCard("Ranch", _ranch, "All heal"),
-        EventCard("Gold Rush", _gold_rush, "Draw extra"),
+        EventCard("Blood Brothers", _blood_brothers_event, "Shared damage"),
+        EventCard("Dead Man", _dead_man_event, "Skip draw phase"),
         EventCard("Hard Liquor", _hard_liquor, "Beer heals 2"),
-        EventCard("The River", _river, "Discards pass left"),
-        EventCard("Bounty", _bounty, "Rewards for eliminations"),
+        EventCard("Lasso", _lasso_event, "Steal from next player"),
+        EventCard("Law of the West", _law_of_the_west, "Unlimited range"),
+        EventCard("Peyote", _peyote, "Lucky draws"),
+        EventCard("Ranch", _ranch, "All heal"),
+        EventCard("Ricochet", _ricochet, "Bang! hits an extra player"),
+        EventCard("Russian Roulette", _russian_roulette_event, "All take damage"),
+        EventCard("Sniper", _sniper_event, "Unlimited range"),
+        EventCard("The Judge", _judge, "Beer cards cannot be played"),
         EventCard("Vendetta", _vendetta, "Outlaws have +1 range"),
-        EventCard("Prison Break", _prison_break, "Jail discarded"),
-        EventCard("High Stakes", _high_stakes, "Unlimited Bang!s"),
-        EventCard("Ghost Town", _fistful_ghost_town, "Eliminated return"),
         EventCard("A Fistful of Cards", _fistful, "Damage equal to cards in hand"),
     ]

--- a/bang_py/game_manager.py
+++ b/bang_py/game_manager.py
@@ -63,6 +63,7 @@ from .cards.canteen import CanteenCard
 from .cards.conestoga import ConestogaCard
 from .cards.can_can import CanCanCard
 from .cards.ten_gallon_hat import TenGallonHatCard
+from .cards.rev_carabine import RevCarabineCard
 
 from .player import Player, Role
 from .event_decks import (
@@ -213,6 +214,11 @@ class GameManager:
                     self.current_turn = self.turn_order.index(self.players.index(player))
                     idx = self.turn_order[self.current_turn]
                     player = self.players[idx]
+        if self.event_flags.get("skip_turn"):
+            self.event_flags.pop("skip_turn")
+            self.current_turn = (self.current_turn + 1) % len(self.turn_order)
+            self._begin_turn()
+            return
         dmg = self.event_flags.get("start_damage", 0)
         if dmg:
             player.take_damage(dmg)
@@ -252,6 +258,7 @@ class GameManager:
                     self.current_turn = (self.current_turn + 1) % len(self.turn_order)
                     self._begin_turn()
                     return
+
 
         ability_chars = (
             JesseJones,

--- a/tests/test_bullet_event_cards.py
+++ b/tests/test_bullet_event_cards.py
@@ -1,0 +1,125 @@
+from bang_py.game_manager import GameManager
+from bang_py.player import Player, Role
+from bang_py.event_decks import (
+    EventCard,
+    create_high_noon_deck,
+    create_fistful_deck,
+    _handcuffs_event,
+    _new_identity_event,
+    _lasso_event,
+    _sniper_event,
+    _russian_roulette_event,
+)
+from bang_py.cards import BangCard
+from bang_py.deck import Deck
+
+
+def test_handcuffs_event_skips_turn():
+    gm = GameManager()
+    sheriff = Player("S", role=Role.SHERIFF)
+    outlaw = Player("O")
+    gm.add_player(sheriff)
+    gm.add_player(outlaw)
+    gm.event_deck = [EventCard("Handcuffs", _handcuffs_event, "")]
+    gm.turn_order = [0, 1]
+    gm.current_turn = 0
+    gm.draw_event_card()
+    gm._begin_turn()
+    assert gm.players[gm.turn_order[gm.current_turn]] is outlaw
+
+
+def test_new_identity_event_redraw():
+    deck = Deck([BangCard(), BangCard(), BangCard(), BangCard(), BangCard()])
+    gm = GameManager(deck=deck)
+    p = Player("P", role=Role.SHERIFF)
+    gm.add_player(p)
+    p.hand = [BangCard(), BangCard()]
+    gm.event_deck = [EventCard("New Identity", _new_identity_event, "")]
+    gm.draw_event_card()
+    assert len(p.hand) == 2
+
+
+def test_lasso_event_transfers_card():
+    gm = GameManager()
+    a = Player("A")
+    b = Player("B")
+    gm.add_player(a)
+    gm.add_player(b)
+    b.hand.append(BangCard())
+    gm.event_deck = [EventCard("Lasso", _lasso_event, "")]
+    gm.draw_event_card()
+    assert isinstance(a.hand[0], BangCard)
+    assert not b.hand
+
+
+def test_sniper_event_unlimited_range():
+    gm = GameManager()
+    p = Player("P", role=Role.SHERIFF)
+    gm.add_player(p)
+    gm.event_deck = [EventCard("Sniper", _sniper_event, "")]
+    gm.draw_event_card()
+    assert p.attack_range == 99
+
+
+def test_russian_roulette_event_damage():
+    gm = GameManager()
+    p1 = Player("A")
+    p2 = Player("B")
+    gm.add_player(p1)
+    gm.add_player(p2)
+    gm.event_deck = [EventCard("Russian Roulette", _russian_roulette_event, "")]
+    gm.draw_event_card()
+    assert p1.health == p1.max_health - 1
+    assert p2.health == p2.max_health - 1
+
+
+def test_rev_carabine_range():
+    from bang_py.cards import RevCarabineCard
+    p = Player("P")
+    RevCarabineCard().play(p)
+    assert p.attack_range == 4
+
+
+def test_high_noon_deck_contents():
+    names = {card.name for card in create_high_noon_deck()}
+    assert len(names) == 15
+    assert names == {
+        "Blessing",
+        "Curse",
+        "Ghost Town",
+        "Gold Rush",
+        "Hangover",
+        "High Noon",
+        "Shootout",
+        "The Daltons",
+        "The Doctor",
+        "The Reverend",
+        "The Sermon",
+        "Thirst",
+        "Train Arrival",
+        "Handcuffs",
+        "New Identity",
+    }
+
+
+def test_fistful_deck_contents():
+    names = {card.name for card in create_fistful_deck()}
+    assert len(names) == 15
+    assert names == {
+        "A Fistful of Cards",
+        "Abandoned Mine",
+        "Ambush",
+        "Blood Brothers",
+        "Dead Man",
+        "Hard Liquor",
+        "Lasso",
+        "Law of the West",
+        "Peyote",
+        "Ranch",
+        "Ricochet",
+        "Russian Roulette",
+        "Sniper",
+        "The Judge",
+        "Vendetta",
+    }
+


### PR DESCRIPTION
## Summary
- implement placeholder effects for missing High Noon and Fistful event cards
- rebuild High Noon and Fistful decks to contain the official 15 cards
- extend bullet event tests to verify deck contents

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687467f808c88323a91ffe58f0304bb4