### PR TITLE
Register abilities via metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ included:
 Create a player with a character using:
 
 ```python
-from bang_py.characters import RoseDoolan
+from bang_py.characters.rose_doolan import RoseDoolan
 player = Player("Rose", character=RoseDoolan())
 ```
 
@@ -126,23 +126,24 @@ powers trigger automatically with a message in the log.
 - **Doc Holyday** – button: discard two cards for a Bang! that does not count
   toward your limit.
 - **Elena Fuente** – automatic: any card may be played as a Missed!.
-- **El Gringo** – automatic: steal a random card from whoever damages him.
+ - **El Gringo** – automatic: choose a card blindly from whoever damages him.
 - **Greg Digger** – automatic: regain two life points whenever someone is
   eliminated.
 - **Herb Hunter** – automatic: draw two cards whenever another player is
   eliminated. The GUI adds these cards to your hand automatically.
-- **Jesse Jones** – popup: may take the first card from another player instead of
-  drawing. Use **Use Ability** if you closed the prompt.
+ - **Jesse Jones** – popup: may choose an opponent and take a card from their hand
+   instead of drawing. Use **Use Ability** if you closed the prompt.
 - **Johnny Kisch** – automatic: when you put a card in play, all other copies in
   play are discarded automatically.
 - **Jose Delgado** – popup: optionally discard equipment to draw two cards.
 - **Jourdonnais** – automatic: always has a Barrel.
-- **Kit Carlson** – popup: draw three cards and discard one. Can be triggered
-  again with **Use Ability**.
+ - **Kit Carlson** – popup: look at the top three cards of the deck, keep two and
+   put the third back on top. Can be triggered again with **Use Ability**.
 - **Lucky Duke** – popup: flip two cards for draws and choose one. The button can
   be used to pick again.
-- **Molly Stark** – automatic: draw a card each time you play or discard Bang!,
-  Missed! or Beer out of turn.
+ - **Molly Stark** – automatic: draw a card whenever you play or voluntarily
+   discard any card out of turn. If targeted by a Duel, draw for all Bangs played
+   after the Duel ends.
 - **Pat Brennan** – popup: may draw a card in play instead of from the deck.
 - **Paul Regret** – automatic: opponents see him at distance +1.
 - **Pedro Ramirez** – popup: choose whether to draw the top discard card.

--- a/bang_py/__init__.py
+++ b/bang_py/__init__.py
@@ -3,32 +3,30 @@
 from .game_manager import GameManager
 from .deck_factory import create_standard_deck
 from .player import Player, Role, PlayerMetadata
-from .characters import (
-    Character,
-    BartCassidy,
-    BlackJack,
-    CalamityJanet,
-    ElGringo,
-    JesseJones,
-    Jourdonnais,
-    KitCarlson,
-    LuckyDuke,
-    PaulRegret,
-    PedroRamirez,
-    RoseDoolan,
-    SidKetchum,
-    SlabTheKiller,
-    SuzyLafayette,
-    VultureSam,
-    WillyTheKid,
-)
+from .characters.base import BaseCharacter
+from .characters.bart_cassidy import BartCassidy
+from .characters.black_jack import BlackJack
+from .characters.calamity_janet import CalamityJanet
+from .characters.el_gringo import ElGringo
+from .characters.jesse_jones import JesseJones
+from .characters.jourdonnais import Jourdonnais
+from .characters.kit_carlson import KitCarlson
+from .characters.lucky_duke import LuckyDuke
+from .characters.paul_regret import PaulRegret
+from .characters.pedro_ramirez import PedroRamirez
+from .characters.rose_doolan import RoseDoolan
+from .characters.sid_ketchum import SidKetchum
+from .characters.slab_the_killer import SlabTheKiller
+from .characters.suzy_lafayette import SuzyLafayette
+from .characters.vulture_sam import VultureSam
+from .characters.willy_the_kid import WillyTheKid
 
 __all__ = [
     "GameManager",
     "Player",
     "Role",
     "PlayerMetadata",
-    "Character",
+    "BaseCharacter",
     "BartCassidy",
     "BlackJack",
     "CalamityJanet",

--- a/bang_py/cards/bang.py
+++ b/bang_py/cards/bang.py
@@ -3,9 +3,8 @@ from __future__ import annotations
 from .card import BaseCard
 from ..player import Player
 from typing import TYPE_CHECKING
-from ..helpers import is_heart
-from ..characters import Jourdonnais, LuckyDuke
 from .barrel import BarrelCard
+from ..characters.jourdonnais import Jourdonnais
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from ..deck import Deck
@@ -32,14 +31,8 @@ class BangCard(BaseCard):
                 if barrel.draw_check(deck, target):
                     target.metadata.dodged = True
                     return
-            if isinstance(target.character, Jourdonnais):
+            if isinstance(target.character, Jourdonnais) or target.metadata.virtual_barrel:
                 if BarrelCard().draw_check(deck, target):
-                    target.metadata.dodged = True
-                    return
-            if isinstance(target.character, LuckyDuke):
-                card1 = deck.draw()
-                card2 = deck.draw()
-                if is_heart(card1) or is_heart(card2):
                     target.metadata.dodged = True
                     return
         target.take_damage(1)

--- a/bang_py/cards/barrel.py
+++ b/bang_py/cards/barrel.py
@@ -7,7 +7,6 @@ from ..player import Player
 from typing import TYPE_CHECKING
 
 from ..helpers import is_heart
-from ..characters import LuckyDuke
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from ..deck import Deck
@@ -29,9 +28,18 @@ class BarrelCard(BaseCard):
 
     def draw_check(self, deck: Deck, player: Player | None = None) -> bool:
         """Perform the Barrel draw! check, returning True if Bang! is dodged."""
-        if player and isinstance(player.character, LuckyDuke):
+        gm = player.metadata.game if player else None
+        if player and player.metadata.lucky_duke:
             card1 = deck.draw()
             card2 = deck.draw()
-            return is_heart(card1) or is_heart(card2)
+            chosen = card1 if is_heart(card1) or not is_heart(card2) else card2
+            if gm:
+                if card1:
+                    gm.discard_pile.append(card1)
+                if card2:
+                    gm.discard_pile.append(card2)
+            return is_heart(chosen)
         card = deck.draw()
+        if gm and card:
+            gm.discard_pile.append(card)
         return is_heart(card)

--- a/bang_py/cards/beer.py
+++ b/bang_py/cards/beer.py
@@ -4,8 +4,6 @@ from .card import BaseCard
 from ..player import Player
 from typing import TYPE_CHECKING
 
-from ..helpers import has_ability
-from ..characters import TequilaJoe
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from ..game_manager import GameManager
@@ -42,8 +40,8 @@ class BeerCard(BaseCard):
         else:
             heal_amt = 1
 
-        if player and has_ability(player, TequilaJoe):
-            heal_amt += 1
+        if player and player.metadata.beer_heal_bonus:
+            heal_amt += player.metadata.beer_heal_bonus
 
         if target.health < target.max_health:
             before = target.health

--- a/bang_py/cards/buffalo_rifle.py
+++ b/bang_py/cards/buffalo_rifle.py
@@ -32,6 +32,10 @@ class BuffaloRifleCard(BaseCard):
         if game and game._auto_miss(target):
             return
         before = target.health
-        BangCard().play(target, d)
+        BangCard().play(
+            target,
+            d,
+            ignore_equipment=player.metadata.ignore_others_equipment if player else False,
+        )
         if game and player and target.health < before:
             game.on_player_damaged(target, player)

--- a/bang_py/cards/derringer.py
+++ b/bang_py/cards/derringer.py
@@ -35,7 +35,11 @@ class DerringerCard(BaseCard):
             game.draw_card(player)
             return
         before = target.health
-        BangCard().play(target, d)
+        BangCard().play(
+            target,
+            d,
+            ignore_equipment=player.metadata.ignore_others_equipment if game else False,
+        )
         if game and target.health < before:
             game.on_player_damaged(target, player)
         if game:

--- a/bang_py/cards/duel.py
+++ b/bang_py/cards/duel.py
@@ -24,6 +24,7 @@ class DuelCard(BaseCard):
 
         attacker = target
         defender = player
+        game._duel_counts = {}
         while True:
             bang = next((c for c in attacker.hand if isinstance(c, BangCard)), None)
             if bang:
@@ -37,3 +38,9 @@ class DuelCard(BaseCard):
                 if attacker.health < before:
                     game.on_player_damaged(attacker, defender)
                 break
+        for pname, count in getattr(game, "_duel_counts", {}).items():
+            pl = next((pl for pl in game.players if pl.name == pname), None)
+            if pl:
+                for _ in range(count):
+                    game.draw_card(pl)
+        game._duel_counts = None

--- a/bang_py/cards/dynamite.py
+++ b/bang_py/cards/dynamite.py
@@ -4,7 +4,6 @@ from .card import BaseCard
 from ..player import Player
 from typing import TYPE_CHECKING
 from ..helpers import is_spade_between
-from ..characters import LuckyDuke
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from ..deck import Deck
@@ -34,12 +33,20 @@ class DynamiteCard(BaseCard):
 
         Returns True if it exploded on the current player.
         """
-        if isinstance(current.character, LuckyDuke):
+        gm = current.metadata.game
+        if current.metadata.lucky_duke:
             c1 = deck.draw()
             c2 = deck.draw()
             card = c1 if not is_spade_between(c1, 2, 9) else c2
+            if gm:
+                if c1:
+                    gm.discard_pile.append(c1)
+                if c2:
+                    gm.discard_pile.append(c2)
         else:
             card = deck.draw()
+            if gm and card:
+                gm.discard_pile.append(card)
         current.unequip(self.card_name)
         if is_spade_between(card, 2, 9):
             current.take_damage(3)

--- a/bang_py/cards/gatling.py
+++ b/bang_py/cards/gatling.py
@@ -27,6 +27,10 @@ class GatlingCard(BaseCard):
             before = p.health
             from .bang import BangCard
 
-            BangCard().play(p, deck or game.deck)
+            BangCard().play(
+                p,
+                deck or game.deck,
+                ignore_equipment=player.metadata.ignore_others_equipment,
+            )
             if p.health < before:
                 game.on_player_damaged(p, player)

--- a/bang_py/cards/howitzer.py
+++ b/bang_py/cards/howitzer.py
@@ -29,6 +29,10 @@ class HowitzerCard(BaseCard):
             if p is player:
                 continue
             before = p.health
-            BangCard().play(p, deck or game.deck)
+            BangCard().play(
+                p,
+                deck or game.deck,
+                ignore_equipment=player.metadata.ignore_others_equipment,
+            )
             if p.health < before:
                 game.on_player_damaged(p, player)

--- a/bang_py/cards/jail.py
+++ b/bang_py/cards/jail.py
@@ -4,7 +4,6 @@ from .card import BaseCard
 from ..player import Player
 from typing import TYPE_CHECKING
 from ..helpers import is_heart
-from ..characters import LuckyDuke
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from ..deck import Deck
@@ -29,12 +28,21 @@ class JailCard(BaseCard):
 
         Returns True if the player's turn is skipped.
         """
-        if isinstance(player.character, LuckyDuke):
+        gm = player.metadata.game
+        if player.metadata.lucky_duke:
             card1 = deck.draw()
             card2 = deck.draw()
-            result = is_heart(card1) or is_heart(card2)
+            chosen = card1 if is_heart(card1) or not is_heart(card2) else card2
+            if gm:
+                if card1:
+                    gm.discard_pile.append(card1)
+                if card2:
+                    gm.discard_pile.append(card2)
+            result = is_heart(chosen)
         else:
-            card1 = deck.draw()
-            result = is_heart(card1)
+            card = deck.draw()
+            if gm and card:
+                gm.discard_pile.append(card)
+            result = is_heart(card)
         player.unequip(self.card_name)
         return not result

--- a/bang_py/cards/knife.py
+++ b/bang_py/cards/knife.py
@@ -29,7 +29,11 @@ class KnifeCard(BaseCard):
         deck = game.deck if game else None
         if game and game._auto_miss(target):
             return
-        BangCard().play(target, deck)
+        BangCard().play(
+            target,
+            deck,
+            ignore_equipment=player.metadata.ignore_others_equipment if game else False,
+        )
         if game and target.health < target.max_health:
             game.on_player_damaged(target, player)
 

--- a/bang_py/cards/pepperbox.py
+++ b/bang_py/cards/pepperbox.py
@@ -34,6 +34,10 @@ class PepperboxCard(BaseCard):
         if game and game._auto_miss(target):
             return
         before = target.health
-        BangCard().play(target, d)
+        BangCard().play(
+            target,
+            d,
+            ignore_equipment=player.metadata.ignore_others_equipment if game else False,
+        )
         if game and target.health < before:
             game.on_player_damaged(target, player)

--- a/bang_py/cards/springfield.py
+++ b/bang_py/cards/springfield.py
@@ -37,7 +37,11 @@ class SpringfieldCard(BaseCard):
         game.discard_pile.append(discard)
         handle_out_of_turn_discard(game, player, discard)
         if not game._auto_miss(target):
-            BangCard().play(target, game.deck)
+            BangCard().play(
+                target,
+                game.deck,
+                ignore_equipment=player.metadata.ignore_others_equipment,
+            )
             if target.health < target.max_health:
                 game.on_player_damaged(target, player)
 

--- a/bang_py/characters/__init__.py
+++ b/bang_py/characters/__init__.py
@@ -1,436 +1,73 @@
-from typing import TYPE_CHECKING
-import random
-
-if TYPE_CHECKING:  # pragma: no cover - for type hints only
-    from ..game_manager import GameManager
-    from ..player import Player
-
-
-class Character:
-    """Base class for Bang characters."""
-
-    name: str = "Character"
-    description: str = ""
-    range_modifier: int = 0
-    distance_modifier: int = 0
-    starting_health: int = 4
-
-    def draw_phase(self, gm: "GameManager", player: "Player", **_: object) -> bool:
-        """Handle draw phase effects. Return ``True`` if handled."""
-        return False
-
-
-class BartCassidy(Character):
-    name = "Bart Cassidy"
-    description = (
-        "When you lose a life point, draw a card from the deck."
-    )
-    starting_health = 4
-
-
-class BlackJack(Character):
-    name = "Black Jack"
-    description = (
-        "During your draw phase, reveal the second card. "
-        "If it's Heart or Diamond, draw one additional card."
-    )
-    starting_health = 4
-
-    def draw_phase(self, gm: "GameManager", player: "Player", **_: object) -> bool:
-        first = gm.deck.draw()
-        if first:
-            player.hand.append(first)
-        second = gm.deck.draw()
-        if second:
-            player.hand.append(second)
-            if getattr(second, "suit", None) in ("Hearts", "Diamonds"):
-                gm.draw_card(player)
-        return True
-
-
-class CalamityJanet(Character):
-    name = "Calamity Janet"
-    description = "You may play Bang! cards as Missed! and vice versa."
-    starting_health = 4
-
-
-class ElGringo(Character):
-    name = "El Gringo"
-    description = (
-        "When you lose a life point, draw a random card from the player who caused the damage."
-    )
-    starting_health = 4
-
-
-class JesseJones(Character):
-    name = "Jesse Jones"
-    description = (
-        "At the start of your draw phase, you may draw the first card from another "
-        "player's hand instead of the deck."
-    )
-    starting_health = 4
-
-    def draw_phase(
-        self,
-        gm: "GameManager",
-        player: "Player",
-        *,
-        jesse_target: "Player | None" = None,
-        **_: object,
-    ) -> bool:
-        opponents = [p for p in gm.players if p is not player and p.hand]
-        if not opponents:
-            return False
-        source = jesse_target if jesse_target in opponents else random.choice(opponents)
-        card = source.hand.pop()
-        player.hand.append(card)
-        gm.draw_card(player)
-        return True
-
-
-class Jourdonnais(Character):
-    name = "Jourdonnais"
-    description = "You are considered to have a Barrel in play at all times."
-    starting_health = 4
-
-
-class KitCarlson(Character):
-    name = "Kit Carlson"
-    description = (
-        "During your draw phase, draw one extra card, choose two and discard the third."
-    )
-    starting_health = 4
-
-    def draw_phase(
-        self,
-        gm: "GameManager",
-        player: "Player",
-        *,
-        kit_discard: int | None = None,
-        **_: object,
-    ) -> bool:
-        cards = [gm.deck.draw(), gm.deck.draw(), gm.deck.draw()]
-        keep_cards = []
-        for i, c in enumerate(cards):
-            if c is None:
-                continue
-            if kit_discard is not None and i == kit_discard:
-                gm.discard_pile.append(c)
-            elif len(keep_cards) < 2:
-                keep_cards.append(c)
-            else:
-                gm.discard_pile.append(c)
-        for c in keep_cards:
-            player.hand.append(c)
-        return True
-
-
-class LuckyDuke(Character):
-    name = "Lucky Duke"
-    description = (
-        "Whenever you must draw! you flip two cards and choose the result you prefer."
-    )
-    starting_health = 4
-
-
-class PaulRegret(Character):
-    name = "Paul Regret"
-    description = "Players see you at distance +1."
-    distance_modifier = 1
-    starting_health = 4
-
-
-class PedroRamirez(Character):
-    name = "Pedro Ramirez"
-    description = (
-        "At the start of your draw phase, you may take the top card from the discard "
-        "pile instead of drawing."
-    )
-    starting_health = 4
-
-    def draw_phase(
-        self,
-        gm: "GameManager",
-        player: "Player",
-        *,
-        pedro_use_discard: bool | None = None,
-        **_: object,
-    ) -> bool:
-        if not gm.discard_pile:
-            return False
-        if pedro_use_discard is False:
-            gm.draw_card(player, 2)
-        else:
-            player.hand.append(gm.discard_pile.pop())
-            gm.draw_card(player)
-        return True
-
-
-class RoseDoolan(Character):
-    name = "Rose Doolan"
-    description = "You see all players at a distance -1."
-    range_modifier = 1
-    starting_health = 4
-
-
-class SidKetchum(Character):
-    name = "Sid Ketchum"
-    description = "You may discard two cards to regain one life point."
-    starting_health = 4
-
-
-class SlabTheKiller(Character):
-    name = "Slab the Killer"
-    description = "Players need two Missed! cards to cancel your Bang!."
-    starting_health = 4
-
-
-class SuzyLafayette(Character):
-    name = "Suzy Lafayette"
-    description = "As soon as you have no cards in hand, draw a card."
-    starting_health = 4
-
-
-class VultureSam(Character):
-    name = "Vulture Sam"
-    description = (
-        "Whenever another player is eliminated, take all the cards from his hand."
-    )
-    starting_health = 4
-
-
-class WillyTheKid(Character):
-    name = "Willy the Kid"
-    description = "You may play any number of Bang! cards during your turn."
-    starting_health = 4
-
-
-class PixiePete(Character):
-    name = "Pixie Pete"
-    description = "During your draw phase, draw three cards instead of two."
-    starting_health = 4
-
-    def draw_phase(self, gm: "GameManager", player: "Player", **_: object) -> bool:
-        gm.draw_card(player, 3)
-        return True
-
-
-class JoseDelgado(Character):
-    name = "Jose Delgado"
-    description = "You may discard an equipment card to draw two cards."
-    starting_health = 4
-
-    def draw_phase(
-        self,
-        gm: "GameManager",
-        player: "Player",
-        *,
-        jose_equipment: int | None = None,
-        **_: object,
-    ) -> bool:
-        equips = [c for c in player.hand if hasattr(c, "slot")]
-        equip = None
-        if jose_equipment is not None and 0 <= jose_equipment < len(equips):
-            equip = equips[jose_equipment]
-        elif equips:
-            equip = equips[0]
-        if equip:
-            player.hand.remove(equip)
-            gm.discard_pile.append(equip)
-            gm.draw_card(player, 2)
-        gm.draw_card(player)
-        return True
-
-
-class SeanMallory(Character):
-    name = "Sean Mallory"
-    description = "You have no limit to the number of cards in hand."
-    starting_health = 4
-
-
-class TequilaJoe(Character):
-    name = "Tequila Joe"
-    description = "Beer cards heal you by 2 life points."
-    starting_health = 4
-
-
-class VeraCuster(Character):
-    name = "Vera Custer"
-    description = "At the start of your turn, copy another living character's ability."
-    starting_health = 4
-
-
-class ApacheKid(Character):
-    name = "Apache Kid"
-    description = "You are unaffected by Diamond suited cards."
-    starting_health = 4
-
-
-class GregDigger(Character):
-    name = "Greg Digger"
-    description = "Each time a player is eliminated, regain two life points."
-    starting_health = 4
-
-
-class BelleStar(Character):
-    name = "Belle Star"
-    description = (
-        "During your turn, cards in play in front of other players have no effect."
-    )
-    starting_health = 4
-
-
-class BillNoface(Character):
-    name = "Bill Noface"
-    description = (
-        "During phase 1 of your turn, draw 1 card plus 1 for each wound you have."
-    )
-    starting_health = 4
-
-    def draw_phase(self, gm: "GameManager", player: "Player", **_: object) -> bool:
-        wounds = player.max_health - player.health
-        gm.draw_card(player, 1 + wounds)
-        return True
-
-
-class ChuckWengam(Character):
-    name = "Chuck Wengam"
-    description = (
-        "During your turn, you may lose 1 life point to draw 2 cards."
-    )
-    starting_health = 4
-
-
-class DocHolyday(Character):
-    name = "Doc Holyday"
-    description = (
-        "Once during your turn, discard any two cards for a Bang! "
-        "that doesn't count toward your limit."
-    )
-    starting_health = 4
-
-
-class ElenaFuente(Character):
-    name = "Elena Fuente"
-    description = "You may play any card from your hand as a Missed!."
-    starting_health = 3
-
-
-class HerbHunter(Character):
-    name = "Herb Hunter"
-    description = (
-        "Whenever another player is eliminated, draw two extra cards."
-    )
-    starting_health = 4
-
-
-class MollyStark(Character):
-    name = "Molly Stark"
-    description = (
-        "Each time you play or discard a Missed!, Beer or Bang! out of turn, draw a card."
-    )
-    starting_health = 4
-
-
-class PatBrennan(Character):
-    name = "Pat Brennan"
-    description = (
-        "During phase 1 of your turn, you may draw a card in play instead of from the deck."
-    )
-    starting_health = 4
-
-    def draw_phase(
-        self,
-        gm: "GameManager",
-        player: "Player",
-        *,
-        pat_target: "Player | None" = None,
-        pat_card: str | None = None,
-        **_: object,
-    ) -> bool:
-        if not gm.pat_brennan_draw(player, pat_target, pat_card):
-            gm.draw_card(player)
-        gm.draw_card(player)
-        return True
-
-
-class UncleWill(Character):
-    name = "Uncle Will"
-    description = (
-        "Once during your turn, you may play any card from your hand as a General Store."
-    )
-    starting_health = 4
-
-
-class JohnnyKisch(Character):
-    name = "Johnny Kisch"
-    description = (
-        "Each time you put a card into play, discard all other cards with the same name in play."
-    )
-    starting_health = 4
-
-
-class ClausTheSaint(Character):
-    name = "Claus the Saint"
-    description = (
-        "During your draw phase, draw one more card than the number of players, "
-        "keep two, then give one to each other player."
-    )
-    starting_health = 3
-
-    def draw_phase(self, gm: "GameManager", player: "Player", **_: object) -> bool:
-        alive = [p for p in gm.players if p.is_alive()]
-        cards = []
-        for _ in range(len(alive) + 1):
-            card = gm.deck.draw()
-            if card:
-                cards.append(card)
-        keep = cards[:2]
-        for c in keep:
-            player.hand.append(c)
-        others = [p for p in alive if p is not player]
-        idx = 2
-        for p in others:
-            if idx < len(cards):
-                p.hand.append(cards[idx])
-                idx += 1
-        return True
-
+from .base import BaseCharacter
+from .apache_kid import ApacheKid
+from .bart_cassidy import BartCassidy
+from .belle_star import BelleStar
+from .bill_noface import BillNoface
+from .black_jack import BlackJack
+from .calamity_janet import CalamityJanet
+from .chuck_wengam import ChuckWengam
+from .claus_the_saint import ClausTheSaint
+from .doc_holyday import DocHolyday
+from .el_gringo import ElGringo
+from .elena_fuente import ElenaFuente
+from .greg_digger import GregDigger
+from .herb_hunter import HerbHunter
+from .jesse_jones import JesseJones
+from .johnny_kisch import JohnnyKisch
+from .jose_delgado import JoseDelgado
+from .jourdonnais import Jourdonnais
+from .kit_carlson import KitCarlson
+from .lucky_duke import LuckyDuke
+from .molly_stark import MollyStark
+from .pat_brennan import PatBrennan
+from .paul_regret import PaulRegret
+from .pedro_ramirez import PedroRamirez
+from .pixie_pete import PixiePete
+from .rose_doolan import RoseDoolan
+from .sean_mallory import SeanMallory
+from .sid_ketchum import SidKetchum
+from .slab_the_killer import SlabTheKiller
+from .suzy_lafayette import SuzyLafayette
+from .tequila_joe import TequilaJoe
+from .uncle_will import UncleWill
+from .vera_custer import VeraCuster
+from .vulture_sam import VultureSam
+from .willy_the_kid import WillyTheKid
 
 __all__ = [
-    "Character",
+    "BaseCharacter",
+    "ApacheKid",
     "BartCassidy",
+    "BelleStar",
+    "BillNoface",
     "BlackJack",
     "CalamityJanet",
+    "ChuckWengam",
+    "ClausTheSaint",
+    "DocHolyday",
     "ElGringo",
+    "ElenaFuente",
+    "GregDigger",
+    "HerbHunter",
     "JesseJones",
+    "JohnnyKisch",
+    "JoseDelgado",
     "Jourdonnais",
     "KitCarlson",
     "LuckyDuke",
+    "MollyStark",
+    "PatBrennan",
     "PaulRegret",
     "PedroRamirez",
+    "PixiePete",
     "RoseDoolan",
+    "SeanMallory",
     "SidKetchum",
     "SlabTheKiller",
     "SuzyLafayette",
-    "VultureSam",
-    "WillyTheKid",
-    "PixiePete",
-    "JoseDelgado",
-    "SeanMallory",
     "TequilaJoe",
-    "VeraCuster",
-    "ApacheKid",
-    "GregDigger",
-    "BelleStar",
-    "BillNoface",
-    "ChuckWengam",
-    "DocHolyday",
-    "ElenaFuente",
-    "HerbHunter",
-    "MollyStark",
-    "PatBrennan",
     "UncleWill",
-    "JohnnyKisch",
-    "ClausTheSaint",
+    "VeraCuster",
+    "VultureSam",
+    "WillyTheKid"
 ]

--- a/bang_py/characters/apache_kid.py
+++ b/bang_py/characters/apache_kid.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .base import BaseCharacter
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from ..game_manager import GameManager
+    from ..player import Player
+    from ..cards.card import BaseCard
+    from ..cards.duel import DuelCard
+
+class ApacheKid(BaseCharacter):
+    name = "Apache Kid"
+    description = "You are unaffected by Diamond suited cards."
+    starting_health = 4
+
+    def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
+        player.metadata.abilities.add(ApacheKid)
+
+        def check(p: "Player", card: "BaseCard", target: "Player | None") -> bool:
+            if (
+                p is not player
+                and target is player
+                and getattr(card, "suit", None) == "Diamonds"
+            ):
+                if gm._duel_counts is not None and not isinstance(card, DuelCard):
+                    return True
+                if card in getattr(p, "hand", []):
+                    p.hand.remove(card)
+                gm._pass_left_or_discard(p, card)
+                return False
+            return True
+
+        gm.card_play_checks.append(check)
+        return True

--- a/bang_py/characters/bart_cassidy.py
+++ b/bang_py/characters/bart_cassidy.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .base import BaseCharacter
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from ..game_manager import GameManager
+    from ..player import Player
+
+class BartCassidy(BaseCharacter):
+    name = "Bart Cassidy"
+    description = (
+        "When you lose a life point, draw a card from the deck."
+    )
+    starting_health = 4
+
+    def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
+        player.metadata.abilities.add(BartCassidy)
+        def on_damaged(p: "Player", _src: "Player | None", *__: object) -> None:
+            if p is player:
+                gm.draw_card(player)
+
+        gm.player_damaged_listeners.append(on_damaged)
+        return True

--- a/bang_py/characters/base.py
+++ b/bang_py/characters/base.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from ..game_manager import GameManager
+    from ..player import Player
+
+
+class BaseCharacter(ABC):
+    """Abstract base class for all Bang characters."""
+
+    name: str = "Character"
+    description: str = ""
+    range_modifier: int = 0
+    distance_modifier: int = 0
+    starting_health: int = 4
+
+    @abstractmethod
+    def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
+        """Perform the character's special ability."""
+        raise NotImplementedError
+

--- a/bang_py/characters/belle_star.py
+++ b/bang_py/characters/belle_star.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .base import BaseCharacter
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from ..game_manager import GameManager
+    from ..player import Player
+
+class BelleStar(BaseCharacter):
+    name = "Belle Star"
+    description = (
+        "During your turn, cards in play in front of other players have no effect."
+    )
+    starting_health = 4
+
+    def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
+        player.metadata.abilities.add(BelleStar)
+
+        def _toggle(p: "Player") -> None:
+            player.metadata.ignore_others_equipment = p is player
+
+        gm.turn_started_listeners.append(_toggle)
+        return True

--- a/bang_py/characters/bill_noface.py
+++ b/bang_py/characters/bill_noface.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .base import BaseCharacter
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from ..game_manager import GameManager
+    from ..player import Player
+
+class BillNoface(BaseCharacter):
+    name = "Bill Noface"
+    description = (
+        "During phase 1 of your turn, draw 1 card plus 1 for each wound you have."
+    )
+    starting_health = 4
+
+
+    def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
+        player.metadata.abilities.add(BillNoface)
+        def on_draw(p: "Player", _opts: dict) -> bool:
+            if p is not player:
+                return True
+            wounds = player.max_health - player.health
+            gm.draw_card(player, 1 + wounds)
+            return True
+
+        gm.draw_phase_listeners.append(on_draw)
+        return True

--- a/bang_py/characters/black_jack.py
+++ b/bang_py/characters/black_jack.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .base import BaseCharacter
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from ..game_manager import GameManager
+    from ..player import Player
+
+class BlackJack(BaseCharacter):
+    name = "Black Jack"
+    description = (
+        "During your draw phase, reveal the second card. "
+        "If it's Heart or Diamond, draw one additional card."
+    )
+    starting_health = 4
+
+
+    def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
+        player.metadata.abilities.add(BlackJack)
+        def on_draw(p: "Player", _k: object) -> bool:
+            if p is not player:
+                return True
+            first = gm._draw_from_deck()
+            if first:
+                player.hand.append(first)
+            second = gm._draw_from_deck()
+            if second:
+                player.hand.append(second)
+                if getattr(second, "suit", None) in ("Hearts", "Diamonds"):
+                    gm.draw_card(player)
+            return True
+
+        gm.draw_phase_listeners.append(on_draw)
+        return True

--- a/bang_py/characters/calamity_janet.py
+++ b/bang_py/characters/calamity_janet.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .base import BaseCharacter
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from ..game_manager import GameManager
+    from ..player import Player
+
+class CalamityJanet(BaseCharacter):
+    name = "Calamity Janet"
+    description = "You may play Bang! cards as Missed! and vice versa."
+    starting_health = 4
+
+    def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
+        player.metadata.abilities.add(CalamityJanet)
+        player.metadata.play_missed_as_bang = True
+        player.metadata.bang_as_missed = True
+        return True

--- a/bang_py/characters/chuck_wengam.py
+++ b/bang_py/characters/chuck_wengam.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .base import BaseCharacter
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from ..game_manager import GameManager
+    from ..player import Player
+
+class ChuckWengam(BaseCharacter):
+    name = "Chuck Wengam"
+    description = (
+        "During your turn, you may lose 1 life point to draw 2 cards."
+    )
+    starting_health = 4
+
+    def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
+        player.metadata.abilities.add(ChuckWengam)
+        return True
+
+    def use_ability(self, gm: "GameManager", player: "Player") -> bool:
+        if player.health <= 1:
+            return True
+        player.take_damage(1)
+        gm.on_player_damaged(player)
+        gm.draw_card(player, 2)
+        return True

--- a/bang_py/characters/claus_the_saint.py
+++ b/bang_py/characters/claus_the_saint.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .base import BaseCharacter
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from ..game_manager import GameManager
+    from ..player import Player
+
+class ClausTheSaint(BaseCharacter):
+    name = "Claus the Saint"
+    description = (
+        "During your draw phase, draw one more card than the number of players, "
+        "keep two, then give one to each other player."
+    )
+    starting_health = 3
+
+
+    def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
+        player.metadata.abilities.add(ClausTheSaint)
+        def on_draw(p: "Player", _opts: dict) -> bool:
+            if p is not player:
+                return True
+            alive = [pl for pl in gm.players if pl.is_alive()]
+            cards = []
+            for _ in range(len(alive) + 1):
+                card = gm._draw_from_deck()
+                if card:
+                    cards.append(card)
+            keep = cards[:2]
+            for c in keep:
+                player.hand.append(c)
+            others = [pl for pl in alive if pl is not player]
+            idx = 2
+            for pl in others:
+                if idx < len(cards):
+                    pl.hand.append(cards[idx])
+                    idx += 1
+            return True
+
+        gm.draw_phase_listeners.append(on_draw)
+        return True

--- a/bang_py/characters/doc_holyday.py
+++ b/bang_py/characters/doc_holyday.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .base import BaseCharacter
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from ..game_manager import GameManager
+    from ..player import Player
+
+class DocHolyday(BaseCharacter):
+    name = "Doc Holyday"
+    description = (
+        "Once during your turn, discard any two cards for a Bang! "
+        "that doesn't count toward your limit."
+    )
+    starting_health = 4
+
+    def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
+        player.metadata.abilities.add(DocHolyday)
+        return True
+
+    def use_ability(
+        self,
+        gm: "GameManager",
+        player: "Player",
+        indices: list[int] | None = None,
+    ) -> bool:
+        if player.metadata.doc_used or len(player.hand) < 2:
+            return True
+        discard_indices = sorted(indices or list(range(2)), reverse=True)[:2]
+        for idx in discard_indices:
+            if 0 <= idx < len(player.hand):
+                card = player.hand.pop(idx)
+                gm._pass_left_or_discard(player, card)
+        player.metadata.doc_used = True
+        player.metadata.doc_free_bang += 1
+        from ..cards.bang import BangCard
+
+        player.hand.append(BangCard())
+        return True

--- a/bang_py/characters/el_gringo.py
+++ b/bang_py/characters/el_gringo.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .base import BaseCharacter
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from ..game_manager import GameManager
+    from ..player import Player
+
+class ElGringo(BaseCharacter):
+    name = "El Gringo"
+    description = (
+        "When you lose a life point, take a card of your choice (blindly) from the player"
+        " who caused the damage."
+    )
+    starting_health = 4
+
+    def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
+        player.metadata.abilities.add(ElGringo)
+
+        def on_damaged(p: "Player", src: "Player | None", *__: object) -> None:
+            if p is player and src and src.hand:
+                idx = player.metadata.gringo_index or 0
+                if idx < 0 or idx >= len(src.hand):
+                    idx = 0
+                stolen = src.hand.pop(idx)
+                player.hand.append(stolen)
+                player.metadata.gringo_index = None
+
+        gm.player_damaged_listeners.append(on_damaged)
+        return True

--- a/bang_py/characters/elena_fuente.py
+++ b/bang_py/characters/elena_fuente.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .base import BaseCharacter
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from ..game_manager import GameManager
+    from ..player import Player
+
+class ElenaFuente(BaseCharacter):
+    name = "Elena Fuente"
+    description = "You may play any card from your hand as a Missed!."
+    starting_health = 3
+
+    def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
+        player.metadata.abilities.add(ElenaFuente)
+        player.metadata.any_card_as_missed = True
+        return True

--- a/bang_py/characters/greg_digger.py
+++ b/bang_py/characters/greg_digger.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .base import BaseCharacter
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from ..game_manager import GameManager
+    from ..player import Player
+
+class GregDigger(BaseCharacter):
+    name = "Greg Digger"
+    description = "Each time a player is eliminated, regain two life points."
+    starting_health = 4
+
+    def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
+        player.metadata.abilities.add(GregDigger)
+        def on_death(victim: "Player", _src: "Player | None") -> None:
+            if victim is not player and player.is_alive():
+                before = player.health
+                player.heal(2)
+                if player.health > before:
+                    gm.on_player_healed(player)
+
+        gm.player_death_listeners.append(on_death)
+        return True

--- a/bang_py/characters/herb_hunter.py
+++ b/bang_py/characters/herb_hunter.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .base import BaseCharacter
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from ..game_manager import GameManager
+    from ..player import Player
+
+class HerbHunter(BaseCharacter):
+    name = "Herb Hunter"
+    description = (
+        "Whenever another player is eliminated, draw two extra cards."
+    )
+    starting_health = 4
+
+    def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
+        player.metadata.abilities.add(HerbHunter)
+        def on_death(victim: "Player", _src: "Player | None") -> None:
+            if victim is not player:
+                gm.draw_card(player, 2)
+
+        gm.player_death_listeners.append(on_death)
+        return True

--- a/bang_py/characters/jesse_jones.py
+++ b/bang_py/characters/jesse_jones.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .base import BaseCharacter
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from ..game_manager import GameManager
+    from ..player import Player
+
+class JesseJones(BaseCharacter):
+    name = "Jesse Jones"
+    description = (
+        "At the start of your draw phase, you may draw the first card from another "
+        "player's hand instead of the deck."
+    )
+    starting_health = 4
+
+
+    def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
+        player.metadata.abilities.add(JesseJones)
+        def on_draw(p: "Player", opts: dict) -> bool:
+            if p is not player:
+                return True
+            opponents = [t for t in gm.players if t is not player and t.hand]
+            if opponents:
+                target = opts.get("jesse_target")
+                idx = opts.get("jesse_card", 0)
+                if target in opponents:
+                    if idx is None or idx < 0 or idx >= len(target.hand):
+                        idx = 0
+                    card = target.hand.pop(idx)
+                    player.hand.append(card)
+                    gm.draw_card(player)
+                else:
+                    gm.draw_card(player, 2)
+            else:
+                gm.draw_card(player, 2)
+            return True
+
+        gm.draw_phase_listeners.append(on_draw)
+        return True

--- a/bang_py/characters/johnny_kisch.py
+++ b/bang_py/characters/johnny_kisch.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .base import BaseCharacter
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from ..game_manager import GameManager
+    from ..player import Player
+    from ..cards.card import BaseCard
+
+class JohnnyKisch(BaseCharacter):
+    name = "Johnny Kisch"
+    description = (
+        "Each time you put a card into play, discard all other cards with the same name in play."
+    )
+    starting_health = 4
+
+    def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
+        player.metadata.abilities.add(JohnnyKisch)
+
+        def on_play(p: "Player", card: "BaseCard", _t: "Player | None") -> None:
+            if p is player and hasattr(card, "card_name"):
+                for o in gm.players:
+                    if card.card_name in o.equipment:
+                        existing = o.unequip(card.card_name)
+                        if existing and existing is not card:
+                            gm._pass_left_or_discard(o, existing)
+
+        gm.card_played_listeners.append(on_play)
+        return True

--- a/bang_py/characters/jose_delgado.py
+++ b/bang_py/characters/jose_delgado.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .base import BaseCharacter
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from ..game_manager import GameManager
+    from ..player import Player
+
+class JoseDelgado(BaseCharacter):
+    name = "Jose Delgado"
+    description = "You may discard an equipment card to draw two cards."
+    starting_health = 4
+
+
+    def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
+        player.metadata.abilities.add(JoseDelgado)
+        def on_draw(p: "Player", opts: dict) -> bool:
+            if p is not player:
+                return True
+            equips = [c for c in player.hand if hasattr(c, "slot")]
+            equip = None
+            sel = opts.get("jose_equipment")
+            if sel is not None and 0 <= sel < len(equips):
+                equip = equips[sel]
+            elif equips:
+                equip = equips[0]
+            if equip:
+                player.hand.remove(equip)
+                gm.discard_pile.append(equip)
+                gm.draw_card(player, 2)
+            gm.draw_card(player)
+            return True
+
+        gm.draw_phase_listeners.append(on_draw)
+        return True

--- a/bang_py/characters/jourdonnais.py
+++ b/bang_py/characters/jourdonnais.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .base import BaseCharacter
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from ..game_manager import GameManager
+    from ..player import Player
+
+class Jourdonnais(BaseCharacter):
+    name = "Jourdonnais"
+    description = "You are considered to have a Barrel in play at all times."
+    starting_health = 4
+
+    def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
+        player.metadata.abilities.add(Jourdonnais)
+        player.metadata.virtual_barrel = True
+        return True

--- a/bang_py/characters/kit_carlson.py
+++ b/bang_py/characters/kit_carlson.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .base import BaseCharacter
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from ..game_manager import GameManager
+    from ..player import Player
+
+class KitCarlson(BaseCharacter):
+    name = "Kit Carlson"
+    description = (
+        "During your draw phase, look at the top three cards of the deck, choose"
+        " two to keep and put the other back on top."
+    )
+    starting_health = 4
+
+
+    def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
+        player.metadata.abilities.add(KitCarlson)
+        def on_draw(p: "Player", opts: dict) -> bool:
+            if p is not player:
+                return True
+            cards = [gm._draw_from_deck(), gm._draw_from_deck(), gm._draw_from_deck()]
+            back_index = opts.get("kit_back")
+            if back_index is None or not (0 <= back_index < len(cards)):
+                back_index = len(cards) - 1
+            for i, c in enumerate(cards):
+                if c is None:
+                    continue
+                if i == back_index:
+                    gm.deck.cards.insert(0, c)
+                else:
+                    player.hand.append(c)
+            return True
+
+        gm.draw_phase_listeners.append(on_draw)
+        return True

--- a/bang_py/characters/lucky_duke.py
+++ b/bang_py/characters/lucky_duke.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .base import BaseCharacter
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from ..game_manager import GameManager
+    from ..player import Player
+
+class LuckyDuke(BaseCharacter):
+    name = "Lucky Duke"
+    description = (
+        "Whenever you must draw! you flip two cards and choose the result you prefer."
+    )
+    starting_health = 4
+
+    def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
+        player.metadata.abilities.add(LuckyDuke)
+        player.metadata.lucky_duke = True
+        return True

--- a/bang_py/characters/molly_stark.py
+++ b/bang_py/characters/molly_stark.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .base import BaseCharacter
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from ..game_manager import GameManager
+    from ..player import Player
+
+class MollyStark(BaseCharacter):
+    name = "Molly Stark"
+    description = (
+        "Whenever you play or voluntarily discard any card out of turn, draw a card. "
+        "If targeted by a Duel, draw for all Bangs played after the Duel ends."
+    )
+    starting_health = 4
+
+    def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
+        player.metadata.abilities.add(MollyStark)
+        return True
+
+    def on_out_of_turn_discard(self, gm: "GameManager", player: "Player", card: "BaseCard") -> None:
+        from ..cards.bang import BangCard
+
+        if isinstance(card, BangCard) and getattr(gm, "_duel_counts", None) is not None:
+            name = player.name
+            gm._duel_counts[name] = gm._duel_counts.get(name, 0) + 1
+        else:
+            gm.draw_card(player)

--- a/bang_py/characters/pat_brennan.py
+++ b/bang_py/characters/pat_brennan.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .base import BaseCharacter
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from ..game_manager import GameManager
+    from ..player import Player
+
+class PatBrennan(BaseCharacter):
+    name = "Pat Brennan"
+    description = (
+        "During phase 1 of your turn, you may draw a card in play instead of from the deck."
+    )
+    starting_health = 4
+
+
+    def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
+        player.metadata.abilities.add(PatBrennan)
+        def on_draw(p: "Player", opts: dict) -> bool:
+            if p is not player:
+                return True
+            target = opts.get("pat_target")
+            card_name = opts.get("pat_card")
+            if not gm.pat_brennan_draw(player, target, card_name):
+                gm.draw_card(player)
+            gm.draw_card(player)
+            return True
+
+        gm.draw_phase_listeners.append(on_draw)
+        return True

--- a/bang_py/characters/paul_regret.py
+++ b/bang_py/characters/paul_regret.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .base import BaseCharacter
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from ..game_manager import GameManager
+    from ..player import Player
+
+class PaulRegret(BaseCharacter):
+    name = "Paul Regret"
+    description = "Players see you at distance +1."
+    distance_modifier = 1
+    starting_health = 4
+
+    def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
+        player.metadata.abilities.add(PaulRegret)
+        return True

--- a/bang_py/characters/pedro_ramirez.py
+++ b/bang_py/characters/pedro_ramirez.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .base import BaseCharacter
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from ..game_manager import GameManager
+    from ..player import Player
+
+class PedroRamirez(BaseCharacter):
+    name = "Pedro Ramirez"
+    description = (
+        "At the start of your draw phase, you may take the top card from the discard "
+        "pile instead of drawing."
+    )
+    starting_health = 4
+
+
+    def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
+        player.metadata.abilities.add(PedroRamirez)
+        def on_draw(p: "Player", opts: dict) -> bool:
+            if p is not player or not gm.discard_pile:
+                return True
+            use_discard = opts.get("pedro_use_discard", True)
+            if use_discard:
+                player.hand.append(gm.discard_pile.pop())
+                gm.draw_card(player)
+            else:
+                gm.draw_card(player, 2)
+            return True
+
+        gm.draw_phase_listeners.append(on_draw)
+        return True

--- a/bang_py/characters/pixie_pete.py
+++ b/bang_py/characters/pixie_pete.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .base import BaseCharacter
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from ..game_manager import GameManager
+    from ..player import Player
+
+class PixiePete(BaseCharacter):
+    name = "Pixie Pete"
+    description = "During your draw phase, draw three cards instead of two."
+    starting_health = 4
+
+
+    def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
+        player.metadata.abilities.add(PixiePete)
+        def on_draw(p: "Player", _opts: dict) -> bool:
+            if p is not player:
+                return True
+            gm.draw_card(player, 3)
+            return True
+
+        gm.draw_phase_listeners.append(on_draw)
+        return True

--- a/bang_py/characters/rose_doolan.py
+++ b/bang_py/characters/rose_doolan.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .base import BaseCharacter
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from ..game_manager import GameManager
+    from ..player import Player
+
+class RoseDoolan(BaseCharacter):
+    name = "Rose Doolan"
+    description = "You see all players at a distance -1."
+    range_modifier = 1
+    starting_health = 4
+
+    def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
+        player.metadata.abilities.add(RoseDoolan)
+        return True

--- a/bang_py/characters/sean_mallory.py
+++ b/bang_py/characters/sean_mallory.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .base import BaseCharacter
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from ..game_manager import GameManager
+    from ..player import Player
+
+class SeanMallory(BaseCharacter):
+    name = "Sean Mallory"
+    description = "You may hold up to 10 cards in your hand."
+    starting_health = 4
+
+    def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
+        player.metadata.abilities.add(SeanMallory)
+        player.metadata.hand_limit = 10
+        return True

--- a/bang_py/characters/sid_ketchum.py
+++ b/bang_py/characters/sid_ketchum.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .base import BaseCharacter
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from ..game_manager import GameManager
+    from ..player import Player
+
+class SidKetchum(BaseCharacter):
+    name = "Sid Ketchum"
+    description = "You may discard two cards to regain one life point."
+    starting_health = 4
+
+    def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
+        player.metadata.abilities.add(SidKetchum)
+        return True
+
+    def use_ability(
+        self,
+        gm: "GameManager",
+        player: "Player",
+        indices: list[int] | None = None,
+    ) -> bool:
+        if len(player.hand) < 2 or player.health >= player.max_health:
+            return True
+        discard_indices = sorted(indices or list(range(2)), reverse=True)[:2]
+        for idx in discard_indices:
+            if 0 <= idx < len(player.hand):
+                card = player.hand.pop(idx)
+                gm._pass_left_or_discard(player, card)
+        player.heal(1)
+        gm.on_player_healed(player)
+        return True

--- a/bang_py/characters/slab_the_killer.py
+++ b/bang_py/characters/slab_the_killer.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .base import BaseCharacter
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from ..game_manager import GameManager
+    from ..player import Player
+
+class SlabTheKiller(BaseCharacter):
+    name = "Slab the Killer"
+    description = "Players need two Missed! cards to cancel your Bang!."
+    starting_health = 4
+
+    def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
+        player.metadata.abilities.add(SlabTheKiller)
+        player.metadata.double_miss = True
+        return True

--- a/bang_py/characters/suzy_lafayette.py
+++ b/bang_py/characters/suzy_lafayette.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .base import BaseCharacter
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from ..game_manager import GameManager
+    from ..player import Player
+
+class SuzyLafayette(BaseCharacter):
+    name = "Suzy Lafayette"
+    description = "As soon as you have no cards in hand, draw a card."
+    starting_health = 4
+
+    def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
+        player.metadata.abilities.add(SuzyLafayette)
+        player.metadata.draw_when_empty = True
+        return True

--- a/bang_py/characters/tequila_joe.py
+++ b/bang_py/characters/tequila_joe.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .base import BaseCharacter
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from ..game_manager import GameManager
+    from ..player import Player
+
+class TequilaJoe(BaseCharacter):
+    name = "Tequila Joe"
+    description = "Beer cards heal you by 2 life points."
+    starting_health = 4
+
+    def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
+        player.metadata.abilities.add(TequilaJoe)
+        player.metadata.beer_heal_bonus = 1
+        return True

--- a/bang_py/characters/uncle_will.py
+++ b/bang_py/characters/uncle_will.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .base import BaseCharacter
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from ..game_manager import GameManager
+    from ..player import Player
+
+class UncleWill(BaseCharacter):
+    name = "Uncle Will"
+    description = (
+        "Once during your turn, you may play any card from your hand as a General Store."
+    )
+    starting_health = 4
+
+    def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
+        player.metadata.abilities.add(UncleWill)
+        return True
+
+    def use_ability(
+        self,
+        gm: "GameManager",
+        player: "Player",
+        card,
+    ) -> bool:
+        if player.metadata.uncle_used or card not in player.hand:
+            return True
+        player.metadata.uncle_used = True
+        from ..cards.general_store import GeneralStoreCard
+
+        GeneralStoreCard().play(player, player, game=gm)
+        player.hand.remove(card)
+        gm._pass_left_or_discard(player, card)
+        return True

--- a/bang_py/characters/vera_custer.py
+++ b/bang_py/characters/vera_custer.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .base import BaseCharacter
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from ..game_manager import GameManager
+    from ..player import Player
+
+class VeraCuster(BaseCharacter):
+    name = "Vera Custer"
+    description = "At the start of your turn, copy another living character's ability."
+    starting_health = 4
+
+    def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
+        player.metadata.abilities.add(VeraCuster)
+        return True
+
+    def copy_ability(
+        self, gm: "GameManager", player: "Player", target: "Player"
+    ) -> bool:
+        if not target.is_alive() or target is player:
+            return True
+        player.metadata.vera_copy = target.character.__class__
+        player.metadata.abilities.add(target.character.__class__)
+        target.character.ability(gm, player)
+        return True

--- a/bang_py/characters/vulture_sam.py
+++ b/bang_py/characters/vulture_sam.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .base import BaseCharacter
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from ..game_manager import GameManager
+    from ..player import Player
+
+class VultureSam(BaseCharacter):
+    name = "Vulture Sam"
+    description = (
+        "Whenever another player is eliminated, take all the cards from his hand."
+    )
+    starting_health = 4
+
+    def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
+        player.metadata.abilities.add(VultureSam)
+        def on_death(victim: "Player", _src: "Player | None") -> None:
+            if victim is not player:
+                player.hand.extend(victim.hand)
+                victim.hand.clear()
+
+        gm.player_death_listeners.append(on_death)
+        return True

--- a/bang_py/characters/willy_the_kid.py
+++ b/bang_py/characters/willy_the_kid.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .base import BaseCharacter
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from ..game_manager import GameManager
+    from ..player import Player
+
+class WillyTheKid(BaseCharacter):
+    name = "Willy the Kid"
+    description = "You may play any number of Bang! cards during your turn."
+    starting_health = 4
+
+    def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
+        player.metadata.abilities.add(WillyTheKid)
+        player.metadata.unlimited_bang = True
+        return True

--- a/bang_py/network/server.py
+++ b/bang_py/network/server.py
@@ -12,15 +12,13 @@ except ModuleNotFoundError:  # pragma: no cover - handled in start()
 
 from ..game_manager import GameManager
 from ..player import Player, Role
-from ..characters import (
-    VeraCuster,
-    JesseJones,
-    KitCarlson,
-    PedroRamirez,
-    JoseDelgado,
-    PatBrennan,
-    LuckyDuke,
-)
+from ..characters.jesse_jones import JesseJones
+from ..characters.jose_delgado import JoseDelgado
+from ..characters.kit_carlson import KitCarlson
+from ..characters.lucky_duke import LuckyDuke
+from ..characters.pat_brennan import PatBrennan
+from ..characters.pedro_ramirez import PedroRamirez
+from ..characters.vera_custer import VeraCuster
 from ..cards.general_store import GeneralStoreCard
 
 
@@ -175,8 +173,9 @@ class BangServer:
                             self.game.vera_custer_copy(player, target)
                     elif ability == "jesse_jones":
                         idx = data.get("target")
+                        card_idx = data.get("card_index")
                         target = self.game._get_player_by_index(idx) if idx is not None else None
-                        self.game.draw_phase(player, jesse_target=target)
+                        self.game.draw_phase(player, jesse_target=target, jesse_card=card_idx)
                     elif ability == "kit_carlson":
                         discard = data.get("discard")
                         cards = player.metadata.kit_cards
@@ -188,7 +187,7 @@ class BangServer:
                                 else:
                                     player.hand.append(card)
                         else:
-                            self.game.draw_phase(player, kit_discard=discard)
+                            self.game.draw_phase(player, kit_back=discard)
                     elif ability == "pedro_ramirez":
                         use_discard = bool(data.get("use_discard", True))
                         self.game.draw_phase(player, pedro_use_discard=use_discard)
@@ -352,7 +351,7 @@ class BangServer:
                     asyncio.create_task(self.broadcast_state())
                 return
 
-    def _on_player_damaged(self, player: Player) -> None:
+    def _on_player_damaged(self, player: Player, _src: Player | None = None) -> None:
         msg = (
             f"{player.name} was eliminated"
             if not player.is_alive()

--- a/tests/test_base_character.py
+++ b/tests/test_base_character.py
@@ -1,0 +1,28 @@
+from bang_py.characters.base import BaseCharacter
+from bang_py.game_manager import GameManager
+from bang_py.player import Player
+import pytest
+
+
+class Dummy(BaseCharacter):
+    """Minimal concrete character for testing."""
+
+    def ability(self, gm: GameManager, player: Player, **_: object) -> bool:
+        return True
+
+
+def test_base_character_is_abstract() -> None:
+    with pytest.raises(TypeError):
+        BaseCharacter()
+
+
+class NullChar(BaseCharacter):
+    def ability(self, gm: GameManager, player: Player, **_: object) -> bool:
+        return False
+
+
+def test_simple_character_ability_returns_false() -> None:
+    gm = GameManager()
+    player = Player("Hero", character=NullChar())
+    gm.add_player(player)
+    assert player.character.ability(gm, player) is False

--- a/tests/test_characters.py
+++ b/tests/test_characters.py
@@ -1,30 +1,33 @@
 from bang_py.player import Player
 from bang_py.cards.scope import ScopeCard
-from bang_py.characters import (
-    BartCassidy,
-    BlackJack,
-    CalamityJanet,
-    ElGringo,
-    JesseJones,
-    Jourdonnais,
-    KitCarlson,
-    LuckyDuke,
-    JoseDelgado,
-    PaulRegret,
-    PedroRamirez,
-    RoseDoolan,
-    SidKetchum,
-    SlabTheKiller,
-    SuzyLafayette,
-    VultureSam,
-    WillyTheKid,
-)
+from bang_py.characters.bart_cassidy import BartCassidy
+from bang_py.characters.black_jack import BlackJack
+from bang_py.characters.calamity_janet import CalamityJanet
+from bang_py.characters.el_gringo import ElGringo
+from bang_py.characters.jesse_jones import JesseJones
+from bang_py.characters.jourdonnais import Jourdonnais
+from bang_py.characters.kit_carlson import KitCarlson
+from bang_py.characters.lucky_duke import LuckyDuke
+from bang_py.characters.jose_delgado import JoseDelgado
+from bang_py.characters.paul_regret import PaulRegret
+from bang_py.characters.pedro_ramirez import PedroRamirez
+from bang_py.characters.rose_doolan import RoseDoolan
+from bang_py.characters.sid_ketchum import SidKetchum
+from bang_py.characters.slab_the_killer import SlabTheKiller
+from bang_py.characters.suzy_lafayette import SuzyLafayette
+from bang_py.characters.vulture_sam import VultureSam
+from bang_py.characters.willy_the_kid import WillyTheKid
+from bang_py.characters.apache_kid import ApacheKid
+from bang_py.characters.sean_mallory import SeanMallory
 from bang_py.game_manager import GameManager
 from bang_py.deck_factory import create_standard_deck
+from bang_py.deck import Deck
 from bang_py.cards.bang import BangCard
 from bang_py.cards.beer import BeerCard
 from bang_py.cards.missed import MissedCard
 from bang_py.cards.jail import JailCard
+from bang_py.cards.duel import DuelCard
+from bang_py.cards.barrel import BarrelCard
 
 
 def test_rose_doolan_range_bonus():
@@ -63,6 +66,13 @@ def test_all_character_classes_instantiable():
     ]
     instances = [cls() for cls in chars]
     assert len(instances) == 16
+
+
+def test_character_ability_registered():
+    gm = GameManager()
+    player = Player("Kid", character=ApacheKid())
+    gm.add_player(player)
+    assert ApacheKid in player.metadata.abilities
 
 
 def test_bart_cassidy_draw_on_damage():
@@ -144,6 +154,21 @@ def test_jesse_jones_draws_from_opponent():
     assert len(other.hand) == 0
 
 
+def test_jesse_jones_selects_card_index():
+    deck = create_standard_deck()
+    deck.cards.append(BangCard())
+    gm = GameManager(deck=deck)
+    jj = Player("JJ", character=JesseJones())
+    other = Player("Other")
+    other.hand.extend([BangCard(), BeerCard()])
+    gm.add_player(jj)
+    gm.add_player(other)
+    gm.draw_phase(jj, jesse_target=other, jesse_card=1)
+    assert len(jj.hand) == 2
+    assert len(other.hand) == 1
+    assert isinstance(other.hand[0], BangCard)
+
+
 def test_jourdonnais_has_virtual_barrel():
     deck = create_standard_deck()
     deck.cards.append(BeerCard(suit="Hearts"))
@@ -158,19 +183,33 @@ def test_kit_carlson_draw_three_keep_two():
     gm = GameManager(deck=deck)
     kit = Player("Kit", character=KitCarlson())
     gm.add_player(kit)
-    gm.draw_phase(kit, kit_discard=1)
+    gm.draw_phase(kit, kit_back=1)
     assert len(kit.hand) == 2
-    assert len(gm.discard_pile) == 1
+    assert len(gm.discard_pile) == 0
 
 
 def test_lucky_duke_draw_two_on_jail():
     deck = create_standard_deck()
     deck.cards.extend([BangCard(suit="Clubs"), BangCard(suit="Hearts")])
+    gm = GameManager(deck=deck)
     player = Player("Lucky", character=LuckyDuke())
+    gm.add_player(player)
     jail = JailCard()
     jail.play(player)
     skipped = jail.check_turn(player, deck)
     assert skipped is False
+    assert len(gm.discard_pile) == 2
+
+
+def test_barrel_draw_card_discarded():
+    deck = Deck([BangCard()])
+    gm = GameManager(deck=deck)
+    player = Player("T")
+    gm.add_player(player)
+    barrel = BarrelCard()
+    barrel.play(player)
+    assert barrel.draw_check(deck, player) is False
+    assert len(gm.discard_pile) == 1
 
 
 def test_pedro_ramirez_takes_from_discard():
@@ -218,7 +257,7 @@ def test_sid_ketchum_discard_two_to_heal():
     gm.add_player(sid)
     sid.hand.extend([BangCard(), BeerCard()])
     sid.health -= 1
-    gm.sid_ketchum_ability(sid, [0, 1])
+    sid.character.use_ability(gm, sid, [0, 1])
     assert sid.health == sid.max_health
     assert len(sid.hand) == 0
 
@@ -288,3 +327,37 @@ def test_slab_the_killer_bang_hits_without_two_missed():
     gm.play_card(slab, slab.hand[0], target)
     assert target.health == target.max_health - 1
     assert len(target.hand) == 1
+
+
+def test_apache_kid_ignores_diamond_bang():
+    gm = GameManager()
+    kid = Player("Kid", character=ApacheKid())
+    att = Player("A")
+    gm.add_player(kid)
+    gm.add_player(att)
+    bang = BangCard(suit="Diamonds")
+    att.hand.append(bang)
+    gm.play_card(att, bang, kid)
+    assert kid.health == kid.max_health
+
+
+def test_apache_kid_cancels_diamond_duel():
+    gm = GameManager()
+    kid = Player("Kid", character=ApacheKid())
+    att = Player("A")
+    gm.add_player(kid)
+    gm.add_player(att)
+    duel = DuelCard(suit="Diamonds")
+    att.hand.append(duel)
+    gm.play_card(att, duel, kid)
+    assert kid.health == kid.max_health
+
+
+def test_sean_mallory_hand_limit_ten():
+    gm = GameManager()
+    sean = Player("Sean", character=SeanMallory())
+    gm.add_player(sean)
+    for _ in range(12):
+        sean.hand.append(BangCard())
+    gm.discard_phase(sean)
+    assert len(sean.hand) == 10

--- a/tests/test_draw_discard_equipment.py
+++ b/tests/test_draw_discard_equipment.py
@@ -6,7 +6,8 @@ from bang_py.cards.scope import ScopeCard
 from bang_py.cards.mustang import MustangCard
 from bang_py.cards.iron_plate import IronPlateCard
 from bang_py.cards.cat_balou import CatBalouCard
-from bang_py.characters import BlackJack, SidKetchum
+from bang_py.characters.black_jack import BlackJack
+from bang_py.characters.sid_ketchum import SidKetchum
 
 
 def test_draw_phase_black_jack_extra_card():
@@ -45,7 +46,7 @@ def test_sid_ketchum_discard_two_to_heal():
     gm.add_player(sid)
     sid.health = sid.max_health - 1
     sid.hand.extend([BangCard(), BangCard()])
-    gm.sid_ketchum_ability(sid, [0, 1])
+    sid.character.use_ability(gm, sid, [0, 1])
     assert sid.health == sid.max_health
     assert len(sid.hand) == 0
 

--- a/tests/test_full_game_simulation.py
+++ b/tests/test_full_game_simulation.py
@@ -3,24 +3,22 @@ from typing import List
 
 from bang_py.game_manager import GameManager
 from bang_py.player import Player, Role
-from bang_py.characters import (
-    BartCassidy,
-    BlackJack,
-    CalamityJanet,
-    ElGringo,
-    JesseJones,
-    Jourdonnais,
-    KitCarlson,
-    LuckyDuke,
-    PaulRegret,
-    PedroRamirez,
-    RoseDoolan,
-    SidKetchum,
-    SlabTheKiller,
-    SuzyLafayette,
-    VultureSam,
-    WillyTheKid,
-)
+from bang_py.characters.bart_cassidy import BartCassidy
+from bang_py.characters.black_jack import BlackJack
+from bang_py.characters.calamity_janet import CalamityJanet
+from bang_py.characters.el_gringo import ElGringo
+from bang_py.characters.jesse_jones import JesseJones
+from bang_py.characters.jourdonnais import Jourdonnais
+from bang_py.characters.kit_carlson import KitCarlson
+from bang_py.characters.lucky_duke import LuckyDuke
+from bang_py.characters.paul_regret import PaulRegret
+from bang_py.characters.pedro_ramirez import PedroRamirez
+from bang_py.characters.rose_doolan import RoseDoolan
+from bang_py.characters.sid_ketchum import SidKetchum
+from bang_py.characters.slab_the_killer import SlabTheKiller
+from bang_py.characters.suzy_lafayette import SuzyLafayette
+from bang_py.characters.vulture_sam import VultureSam
+from bang_py.characters.willy_the_kid import WillyTheKid
 from bang_py.cards import (
     BangCard,
     BeerCard,
@@ -96,6 +94,9 @@ def auto_turn(gm: GameManager) -> None:
             gm.current_turn %= len(gm.turn_order)
             gm.end_turn()
         return
+    if player.metadata.awaiting_draw:
+        gm.draw_phase(player)
+        player.metadata.awaiting_draw = False
     played = True
     while played:
         played = False

--- a/tests/test_new_features.py
+++ b/tests/test_new_features.py
@@ -2,7 +2,7 @@ from bang_py.game_manager import GameManager
 from bang_py.deck_factory import create_standard_deck
 from bang_py.player import Player
 from bang_py.cards.bang import BangCard
-from bang_py.characters import BartCassidy
+from bang_py.characters.bart_cassidy import BartCassidy
 
 
 def test_drawing_and_playing():

--- a/tests/test_player_health.py
+++ b/tests/test_player_health.py
@@ -1,8 +1,10 @@
 from bang_py.player import Player, Role
-from bang_py.characters import Character
+from bang_py.characters.base import BaseCharacter
 
 
-class BonusLife(Character):
+class BonusLife(BaseCharacter):
+    def ability(self, *_: object, **__: object) -> bool:
+        return False
     starting_health = 5
 
 

--- a/tests/test_start_turn_effects.py
+++ b/tests/test_start_turn_effects.py
@@ -20,7 +20,7 @@ def test_jail_auto_skip_turn():
     gm._begin_turn()
     assert gm.current_turn == 1
     assert "Jail" not in p1.equipment
-    assert len(gm.discard_pile) == 1
+    assert len(gm.discard_pile) == 2
     assert len(p1.hand) == 0
 
 
@@ -38,7 +38,7 @@ def test_dynamite_explodes_on_turn_start():
     gm._begin_turn()
     assert p1.health == p1.max_health - 3
     assert "Dynamite" not in p1.equipment
-    assert len(gm.discard_pile) == 1
+    assert len(gm.discard_pile) == 2
 
 
 def test_dynamite_passes_to_next_player():
@@ -55,4 +55,4 @@ def test_dynamite_passes_to_next_player():
     gm._begin_turn()
     assert "Dynamite" not in p1.equipment
     assert "Dynamite" in p2.equipment
-    assert len(gm.discard_pile) == 0
+    assert len(gm.discard_pile) == 1

--- a/tests/test_turn_rules.py
+++ b/tests/test_turn_rules.py
@@ -2,7 +2,7 @@ from bang_py.game_manager import GameManager
 from bang_py.deck import Deck
 from bang_py.player import Player, Role
 from bang_py.cards.bang import BangCard
-from bang_py.characters import WillyTheKid
+from bang_py.characters.willy_the_kid import WillyTheKid
 
 
 def test_bang_limit_default():

--- a/tests/test_vera_custer.py
+++ b/tests/test_vera_custer.py
@@ -1,6 +1,7 @@
 from bang_py.game_manager import GameManager
 from bang_py.player import Player
-from bang_py.characters import VeraCuster, WillyTheKid
+from bang_py.characters.vera_custer import VeraCuster
+from bang_py.characters.willy_the_kid import WillyTheKid
 from bang_py.cards.bang import BangCard
 from bang_py.helpers import has_ability
 
@@ -14,7 +15,7 @@ def test_vera_custer_copies_other_ability() -> None:
     gm.add_player(willy)
     gm.add_player(target)
 
-    gm.vera_custer_copy(vera, willy)
+    vera.character.copy_ability(gm, vera, willy)
     assert has_ability(vera, WillyTheKid)
 
     vera.hand.extend([BangCard(), BangCard()])


### PR DESCRIPTION
## Summary
- refine ability implementations for Apache Kid, Belle Star, Johnny Kisch, Lucky Duke and Sean Mallory
- equipment-ignore toggled during Belle Star's turn
- green action cards respect the ignore-equipment flag
- enforce Sean Mallory hand limit and keep turn order stable on deaths
- expand tests for new behaviour
- discard drawn cards when resolving Barrel, Jail and Dynamite
- remove unused last card tracking

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68757c48cc1083239c938d7ea130a806