### PR TITLE
Introduce base role system

### DIFF
--- a/bang_py/__init__.py
+++ b/bang_py/__init__.py
@@ -2,7 +2,14 @@
 
 from .game_manager import GameManager
 from .deck_factory import create_standard_deck
-from .player import Player, Role, PlayerMetadata
+from .player import Player, PlayerMetadata
+from .cards.roles import (
+    BaseRole,
+    SheriffRoleCard,
+    DeputyRoleCard,
+    OutlawRoleCard,
+    RenegadeRoleCard,
+)
 from .characters.base import BaseCharacter
 from .characters.bart_cassidy import BartCassidy
 from .characters.black_jack import BlackJack
@@ -24,8 +31,12 @@ from .characters.willy_the_kid import WillyTheKid
 __all__ = [
     "GameManager",
     "Player",
-    "Role",
     "PlayerMetadata",
+    "BaseRole",
+    "SheriffRoleCard",
+    "DeputyRoleCard",
+    "OutlawRoleCard",
+    "RenegadeRoleCard",
     "BaseCharacter",
     "BartCassidy",
     "BlackJack",

--- a/bang_py/cards/__init__.py
+++ b/bang_py/cards/__init__.py
@@ -44,6 +44,13 @@ from .conestoga import ConestogaCard
 from .can_can import CanCanCard
 from .ten_gallon_hat import TenGallonHatCard
 from .rev_carabine import RevCarabineCard
+from .roles import (
+    BaseRole,
+    SheriffRoleCard,
+    DeputyRoleCard,
+    OutlawRoleCard,
+    RenegadeRoleCard,
+)
 
 __all__ = [
     "BaseCard",
@@ -92,4 +99,9 @@ __all__ = [
     "CanCanCard",
     "TenGallonHatCard",
     "RevCarabineCard",
+    "BaseRole",
+    "SheriffRoleCard",
+    "DeputyRoleCard",
+    "OutlawRoleCard",
+    "RenegadeRoleCard",
 ]

--- a/bang_py/cards/card.py
+++ b/bang_py/cards/card.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from ..player import Player
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - import for type checking only
+    from ..player import Player
 
 
 class BaseCard(ABC):

--- a/bang_py/cards/roles/__init__.py
+++ b/bang_py/cards/roles/__init__.py
@@ -1,0 +1,13 @@
+from .base import BaseRole
+from .sheriff import SheriffRoleCard
+from .deputy import DeputyRoleCard
+from .outlaw import OutlawRoleCard
+from .renegade import RenegadeRoleCard
+
+__all__ = [
+    "BaseRole",
+    "SheriffRoleCard",
+    "DeputyRoleCard",
+    "OutlawRoleCard",
+    "RenegadeRoleCard",
+]

--- a/bang_py/cards/roles/base.py
+++ b/bang_py/cards/roles/base.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from ...game_manager import GameManager
+    from ...player import Player
+
+
+class BaseRole(ABC):
+    """Base class for all role cards."""
+
+    card_name: str = "Role"
+    card_type: str = "role"
+    victory_message: str = ""
+
+    @abstractmethod
+    def check_win(self, gm: GameManager, player: Player) -> bool:
+        """Return ``True`` if this role's winning condition is met."""
+        raise NotImplementedError

--- a/bang_py/cards/roles/deputy.py
+++ b/bang_py/cards/roles/deputy.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .base import BaseRole
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from ...game_manager import GameManager
+    from ...player import Player
+
+
+class DeputyRoleCard(BaseRole):
+    """Role card representing a Deputy."""
+
+    card_name = "Deputy"
+    victory_message = "Sheriff and Deputies win!"
+
+    def check_win(self, gm: GameManager, player: Player) -> bool:
+        from .outlaw import OutlawRoleCard
+        from .renegade import RenegadeRoleCard
+
+        alive = [p for p in gm.players if p.is_alive()]
+        outlaws = any(isinstance(p.role, OutlawRoleCard) for p in alive)
+        renegades = any(isinstance(p.role, RenegadeRoleCard) for p in alive)
+        return not outlaws and not renegades

--- a/bang_py/cards/roles/outlaw.py
+++ b/bang_py/cards/roles/outlaw.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .base import BaseRole
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from ...game_manager import GameManager
+    from ...player import Player
+
+
+class OutlawRoleCard(BaseRole):
+    """Role card representing an Outlaw."""
+
+    card_name = "Outlaw"
+    victory_message = "Outlaws win!"
+
+    def check_win(self, gm: GameManager, player: Player) -> bool:
+        from .sheriff import SheriffRoleCard
+
+        return not any(
+            isinstance(p.role, SheriffRoleCard) and p.is_alive() for p in gm.players
+        )

--- a/bang_py/cards/roles/renegade.py
+++ b/bang_py/cards/roles/renegade.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .base import BaseRole
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from ...game_manager import GameManager
+    from ...player import Player
+
+
+class RenegadeRoleCard(BaseRole):
+    """Role card representing the Renegade."""
+
+    card_name = "Renegade"
+    victory_message = "Renegade wins!"
+
+    def check_win(self, gm: GameManager, player: Player) -> bool:
+        from .sheriff import SheriffRoleCard
+
+        alive = [p for p in gm.players if p.is_alive()]
+        return len(alive) == 1 and alive[0] is player and not any(
+            isinstance(p.role, SheriffRoleCard) for p in gm.players if p.is_alive()
+        )

--- a/bang_py/cards/roles/sheriff.py
+++ b/bang_py/cards/roles/sheriff.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .base import BaseRole
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from ...game_manager import GameManager
+    from ...player import Player
+
+
+class SheriffRoleCard(BaseRole):
+    """Role card representing the Sheriff."""
+
+    card_name = "Sheriff"
+    victory_message = "Sheriff and Deputies win!"
+
+    def check_win(self, gm: GameManager, player: Player) -> bool:
+        from .outlaw import OutlawRoleCard
+        from .renegade import RenegadeRoleCard
+
+        alive = [p for p in gm.players if p.is_alive()]
+        outlaws = any(isinstance(p.role, OutlawRoleCard) for p in alive)
+        renegades = any(isinstance(p.role, RenegadeRoleCard) for p in alive)
+        return not outlaws and not renegades

--- a/bang_py/network/server.py
+++ b/bang_py/network/server.py
@@ -11,7 +11,8 @@ except ModuleNotFoundError:  # pragma: no cover - handled in start()
     WebSocketServerProtocol = Any  # type: ignore[assignment]
 
 from ..game_manager import GameManager
-from ..player import Player, Role
+from ..player import Player
+from ..cards.roles import OutlawRoleCard
 from ..characters.jesse_jones import JesseJones
 from ..characters.jose_delgado import JoseDelgado
 from ..characters.kit_carlson import KitCarlson
@@ -34,7 +35,7 @@ def _serialize_players(players: List[Player]) -> List[dict]:
         {
             "name": p.name,
             "health": p.health,
-            "role": p.role.name,
+            "role": p.role.card_name,
             "equipment": [eq.card_name for eq in p.equipment.values()],
         }
         for p in players
@@ -75,7 +76,7 @@ class BangServer:
         if len(self.game.players) >= self.max_players:
             await websocket.send("Game full")
             return
-        player = Player(name, role=Role.OUTLAW)
+        player = Player(name, role=OutlawRoleCard())
         player.metadata.auto_miss = True
         self.game.add_player(player)
         self.connections[websocket] = Connection(websocket, player)

--- a/tests/test_bullet_event_cards.py
+++ b/tests/test_bullet_event_cards.py
@@ -1,5 +1,6 @@
 from bang_py.game_manager import GameManager
-from bang_py.player import Player, Role
+from bang_py.player import Player
+from bang_py.cards.roles import SheriffRoleCard, OutlawRoleCard
 from bang_py.event_decks import create_high_noon_deck, create_fistful_deck
 from bang_py.cards.events import (
     HandcuffsEventCard,
@@ -14,8 +15,8 @@ from bang_py.deck import Deck
 
 def test_handcuffs_event_skips_turn():
     gm = GameManager()
-    sheriff = Player("S", role=Role.SHERIFF)
-    outlaw = Player("O")
+    sheriff = Player("S", role=SheriffRoleCard())
+    outlaw = Player("O", role=OutlawRoleCard())
     gm.add_player(sheriff)
     gm.add_player(outlaw)
     gm.event_deck = [HandcuffsEventCard()]
@@ -29,7 +30,7 @@ def test_handcuffs_event_skips_turn():
 def test_new_identity_event_redraw():
     deck = Deck([BangCard(), BangCard(), BangCard(), BangCard(), BangCard()])
     gm = GameManager(deck=deck)
-    p = Player("P", role=Role.SHERIFF)
+    p = Player("P", role=SheriffRoleCard())
     gm.add_player(p)
     p.hand = [BangCard(), BangCard()]
     gm.event_deck = [NewIdentityEventCard()]
@@ -52,7 +53,7 @@ def test_lasso_event_transfers_card():
 
 def test_sniper_event_unlimited_range():
     gm = GameManager()
-    p = Player("P", role=Role.SHERIFF)
+    p = Player("P", role=SheriffRoleCard())
     gm.add_player(p)
     gm.event_deck = [SniperEventCard()]
     gm.draw_event_card()

--- a/tests/test_event_deck_effects.py
+++ b/tests/test_event_deck_effects.py
@@ -32,7 +32,13 @@ from bang_py.event_decks import (
     _train_arrival_event,
 )
 from bang_py.game_manager import GameManager
-from bang_py.player import Player, Role
+from bang_py.player import Player
+from bang_py.cards.roles import (
+    SheriffRoleCard,
+    DeputyRoleCard,
+    OutlawRoleCard,
+    RenegadeRoleCard,
+)
 from bang_py.cards import BangCard, BeerCard, MissedCard
 from bang_py.cards.jail import JailCard
 from bang_py.deck import Deck
@@ -41,7 +47,7 @@ from bang_py.deck import Deck
 def test_thirst_event_draw_one():
     gm = GameManager()
     gm.event_deck = [EventCard("Thirst", _thirst, "")]
-    p = Player("Sheriff", role=Role.SHERIFF)
+    p = Player("Sheriff", role=SheriffRoleCard())
     gm.add_player(p)
     gm.draw_event_card()
     gm.draw_phase(p)
@@ -50,7 +56,7 @@ def test_thirst_event_draw_one():
 
 def test_fistful_event_damage_by_hand():
     gm = GameManager()
-    p = Player("Sheriff", role=Role.SHERIFF)
+    p = Player("Sheriff", role=SheriffRoleCard())
     gm.add_player(p)
     p.hand = [BangCard(), BangCard()]
     gm.event_deck = [EventCard("A Fistful of Cards", _fistful, "")]
@@ -66,7 +72,7 @@ def _enable_no_bang(game: GameManager) -> None:
 
 def test_sermon_event_blocks_bang():
     gm = GameManager()
-    sheriff = Player("Sheriff", role=Role.SHERIFF)
+    sheriff = Player("Sheriff", role=SheriffRoleCard())
     outlaw = Player("Outlaw")
     gm.add_player(sheriff)
     gm.add_player(outlaw)
@@ -84,7 +90,7 @@ def _enable_no_beer(game: GameManager) -> None:
 
 def test_hangover_event_disables_beer():
     gm = GameManager()
-    sheriff = Player("Sheriff", role=Role.SHERIFF)
+    sheriff = Player("Sheriff", role=SheriffRoleCard())
     gm.add_player(sheriff)
     gm.event_deck = [EventCard("Hangover", _enable_no_beer, "")]
     gm.draw_event_card()
@@ -96,7 +102,7 @@ def test_hangover_event_disables_beer():
 
 def test_judge_prevents_beer_play():
     gm = GameManager()
-    sheriff = Player("Sheriff", role=Role.SHERIFF)
+    sheriff = Player("Sheriff", role=SheriffRoleCard())
     gm.add_player(sheriff)
     gm.event_deck = [EventCard("The Judge", _judge, "")]
     gm.draw_event_card()
@@ -109,7 +115,7 @@ def test_judge_prevents_beer_play():
 
 def test_ghost_town_revives_players():
     gm = GameManager()
-    sheriff = Player("Sheriff", role=Role.SHERIFF)
+    sheriff = Player("Sheriff", role=SheriffRoleCard())
     outlaw = Player("Outlaw")
     gm.add_player(sheriff)
     gm.add_player(outlaw)
@@ -121,7 +127,7 @@ def test_ghost_town_revives_players():
 
 def test_ghost_town_players_disappear_next_event():
     gm = GameManager()
-    sheriff = Player("Sheriff", role=Role.SHERIFF)
+    sheriff = Player("Sheriff", role=SheriffRoleCard())
     outlaw = Player("Outlaw")
     gm.add_player(sheriff)
     gm.add_player(outlaw)
@@ -142,7 +148,7 @@ def test_ghost_town_players_disappear_next_event():
 def test_bounty_rewards_elimination():
     deck = Deck([BangCard(), BangCard(), BangCard()])
     gm = GameManager(deck=deck)
-    sheriff = Player("Sheriff", role=Role.SHERIFF)
+    sheriff = Player("Sheriff", role=SheriffRoleCard())
     outlaw = Player("Outlaw")
     gm.add_player(sheriff)
     gm.add_player(outlaw)
@@ -170,7 +176,7 @@ def test_blessing_heals_everyone():
 
 def test_gold_rush_draws_three():
     gm = GameManager()
-    p = Player("Sheriff", role=Role.SHERIFF)
+    p = Player("Sheriff", role=SheriffRoleCard())
     gm.add_player(p)
     gm.event_deck = [EventCard("Gold Rush", _gold_rush, "")]
     gm.draw_event_card()
@@ -180,7 +186,7 @@ def test_gold_rush_draws_three():
 
 def test_siesta_draws_three():
     gm = GameManager()
-    p = Player("Sheriff", role=Role.SHERIFF)
+    p = Player("Sheriff", role=SheriffRoleCard())
     gm.add_player(p)
     gm.event_deck = [EventCard("Siesta", _siesta, "")]
     gm.draw_event_card()
@@ -190,7 +196,7 @@ def test_siesta_draws_three():
 
 def test_vendetta_outlaw_range_bonus():
     gm = GameManager()
-    outlaw = Player("Out", role=Role.OUTLAW)
+    outlaw = Player("Out", role=OutlawRoleCard())
     target = Player("T")
     gm.add_player(outlaw)
     gm.add_player(target)
@@ -201,7 +207,7 @@ def test_vendetta_outlaw_range_bonus():
 
 def test_sermon_blocks_bang_real():
     gm = GameManager()
-    sheriff = Player("Sheriff", role=Role.SHERIFF)
+    sheriff = Player("Sheriff", role=SheriffRoleCard())
     outlaw = Player("Outlaw")
     gm.add_player(sheriff)
     gm.add_player(outlaw)
@@ -215,7 +221,7 @@ def test_sermon_blocks_bang_real():
 
 def test_hangover_no_beer_real():
     gm = GameManager()
-    p = Player("Sheriff", role=Role.SHERIFF)
+    p = Player("Sheriff", role=SheriffRoleCard())
     gm.add_player(p)
     gm.event_deck = [EventCard("Hangover", _hangover, "")]
     gm.draw_event_card()
@@ -272,7 +278,7 @@ def test_ranch_heals_everyone():
 
 def test_prison_break_discards_jail():
     gm = GameManager()
-    p = Player("Sheriff", role=Role.SHERIFF)
+    p = Player("Sheriff", role=SheriffRoleCard())
     gm.add_player(p)
     jail = JailCard()
     p.equipment["Jail"] = jail
@@ -287,7 +293,7 @@ def test_prison_break_discards_jail():
 
 def test_high_noon_start_damage():
     gm = GameManager()
-    p = Player("Sheriff", role=Role.SHERIFF)
+    p = Player("Sheriff", role=SheriffRoleCard())
     gm.add_player(p)
     gm.event_deck = [EventCard("High Noon", _high_noon, "")]
     gm.turn_order = [0]
@@ -299,7 +305,7 @@ def test_high_noon_start_damage():
 
 def test_high_stakes_allows_multiple_bangs():
     gm = GameManager()
-    p1 = Player("Sheriff", role=Role.SHERIFF)
+    p1 = Player("Sheriff", role=SheriffRoleCard())
     p2 = Player("Outlaw")
     gm.add_player(p1)
     gm.add_player(p2)
@@ -357,11 +363,11 @@ def test_fistful_deck_contents_full_list():
 
 def test_event_deck_order_fistful():
     gm = GameManager(expansions=["fistful_of_cards"])
-    sheriff = Player("Sheriff", role=Role.SHERIFF)
+    sheriff = Player("Sheriff", role=SheriffRoleCard())
     outlaw = Player("Outlaw")
     gm.add_player(sheriff)
     gm.add_player(outlaw)
-    gm.start_game()
+    gm.start_game(deal_roles=False)
     assert gm.current_event is not None
     assert gm.event_deck[-1].name == "A Fistful of Cards"
 
@@ -385,7 +391,7 @@ def test_river_passes_discard_left():
 
 def test_peyote_extra_draw():
     gm = GameManager()
-    p = Player("Sheriff", role=Role.SHERIFF)
+    p = Player("Sheriff", role=SheriffRoleCard())
     gm.add_player(p)
     gm.event_deck = [EventCard("Peyote", _peyote, "")]
     gm.draw_event_card()
@@ -419,7 +425,7 @@ def test_daltons_all_draw():
 
 def test_doctor_heals_instead_of_draw():
     gm = GameManager()
-    p = Player("Sheriff", role=Role.SHERIFF)
+    p = Player("Sheriff", role=SheriffRoleCard())
     gm.add_player(p)
     gm.event_deck = [EventCard("The Doctor", _doctor_event, "")]
     gm.draw_event_card()
@@ -431,7 +437,7 @@ def test_doctor_heals_instead_of_draw():
 
 def test_reverend_limits_hand_size():
     gm = GameManager()
-    p = Player("Sheriff", role=Role.SHERIFF)
+    p = Player("Sheriff", role=SheriffRoleCard())
     gm.add_player(p)
     gm.event_deck = [EventCard("The Reverend", _reverend_event, "")]
     p.hand = [BangCard(), BangCard(), BangCard()]
@@ -454,7 +460,7 @@ def test_train_arrival_all_draw():
 
 def test_hard_liquor_beer_heals_two():
     gm = GameManager()
-    p = Player("Sheriff", role=Role.SHERIFF)
+    p = Player("Sheriff", role=SheriffRoleCard())
     gm.add_player(p)
     gm.add_player(Player("Other"))
     gm.add_player(Player("Third"))
@@ -468,7 +474,7 @@ def test_hard_liquor_beer_heals_two():
 
 def test_law_of_west_unlimited_range():
     gm = GameManager()
-    p = Player("Sheriff", role=Role.SHERIFF)
+    p = Player("Sheriff", role=SheriffRoleCard())
     gm.add_player(p)
     gm.event_deck = [EventCard("Law of the West", _law_of_the_west, "")]
     gm.draw_event_card()
@@ -490,7 +496,7 @@ def test_cattle_drive_discards_one_each():
 
 def test_shootout_allows_multiple_bangs():
     gm = GameManager()
-    p1 = Player("Sheriff", role=Role.SHERIFF)
+    p1 = Player("Sheriff", role=SheriffRoleCard())
     p2 = Player("Outlaw")
     gm.add_player(p1)
     gm.add_player(p2)
@@ -504,11 +510,11 @@ def test_shootout_allows_multiple_bangs():
 
 def test_event_deck_order_high_noon():
     gm = GameManager(expansions=["high_noon"])
-    sheriff = Player("Sheriff", role=Role.SHERIFF)
+    sheriff = Player("Sheriff", role=SheriffRoleCard())
     outlaw = Player("Outlaw")
     gm.add_player(sheriff)
     gm.add_player(outlaw)
-    gm.start_game()
+    gm.start_game(deal_roles=False)
     assert gm.current_event is not None
     assert gm.event_deck[-1].name == "High Noon"
 
@@ -517,12 +523,12 @@ def test_event_sequence_progresses_each_sheriff_turn():
     e1 = EventCard("E1", lambda g: g.event_flags.update(test=1))
     e2 = EventCard("E2", lambda g: g.event_flags.update(test=2))
     gm = GameManager()
-    sheriff = Player("Sheriff", role=Role.SHERIFF)
+    sheriff = Player("Sheriff", role=SheriffRoleCard())
     outlaw = Player("Outlaw")
     gm.add_player(sheriff)
     gm.add_player(outlaw)
     gm.event_deck = [e1, e2]
-    gm.start_game()
+    gm.start_game(deal_roles=False)
     assert gm.current_event.name == "E1"
     gm.end_turn()  # sheriff end -> outlaw turn
     gm.end_turn()  # outlaw end -> sheriff turn, draw next

--- a/tests/test_expansions.py
+++ b/tests/test_expansions.py
@@ -1,6 +1,7 @@
 from bang_py.deck_factory import create_standard_deck
 from bang_py.game_manager import GameManager
-from bang_py.player import Player, Role
+from bang_py.player import Player
+from bang_py.cards.roles import SheriffRoleCard
 from bang_py.deck import Deck
 from bang_py.cards import (
     PunchCard,
@@ -369,11 +370,11 @@ def test_bullet_characters_instantiable():
 
 def test_high_noon_event_deck_draw():
     gm = GameManager(expansions=["high_noon"])
-    sheriff = Player("Sheriff", role=Role.SHERIFF)
+    sheriff = Player("Sheriff", role=SheriffRoleCard())
     outlaw = Player("Outlaw")
     gm.add_player(sheriff)
     gm.add_player(outlaw)
-    gm.start_game()
+    gm.start_game(deal_roles=False)
     assert gm.current_event is not None
 
 
@@ -384,7 +385,7 @@ def test_pepperbox_acts_as_bang():
     p2 = Player("Target")
     gm.add_player(p1)
     gm.add_player(p2)
-    gm.start_game()
+    gm.start_game(deal_roles=False)
     card = PepperboxCard()
     p1.hand.append(card)
     gm.play_card(p1, card, p2)
@@ -397,7 +398,7 @@ def test_binoculars_and_hideout_activate_after_turn():
     p2 = Player("B")
     gm.add_player(p1)
     gm.add_player(p2)
-    gm.start_game()
+    gm.start_game(deal_roles=False)
     b = BinocularsCard()
     h = HideoutCard()
     p1.hand.extend([b, h])

--- a/tests/test_full_game_simulation.py
+++ b/tests/test_full_game_simulation.py
@@ -2,7 +2,13 @@ import random
 from typing import List
 
 from bang_py.game_manager import GameManager
-from bang_py.player import Player, Role
+from bang_py.player import Player
+from bang_py.cards.roles import (
+    SheriffRoleCard,
+    DeputyRoleCard,
+    OutlawRoleCard,
+    RenegadeRoleCard,
+)
 from bang_py.characters.bart_cassidy import BartCassidy
 from bang_py.characters.black_jack import BlackJack
 from bang_py.characters.calamity_janet import CalamityJanet
@@ -53,24 +59,30 @@ CHAR_CLASSES = [
 ]
 
 ROLE_MAP = {
-    4: [Role.SHERIFF, Role.RENEGADE, Role.OUTLAW, Role.OUTLAW],
-    5: [Role.SHERIFF, Role.RENEGADE, Role.DEPUTY, Role.OUTLAW, Role.OUTLAW],
+    4: [SheriffRoleCard, RenegadeRoleCard, OutlawRoleCard, OutlawRoleCard],
+    5: [
+        SheriffRoleCard,
+        RenegadeRoleCard,
+        DeputyRoleCard,
+        OutlawRoleCard,
+        OutlawRoleCard,
+    ],
     6: [
-        Role.SHERIFF,
-        Role.RENEGADE,
-        Role.DEPUTY,
-        Role.OUTLAW,
-        Role.OUTLAW,
-        Role.OUTLAW,
+        SheriffRoleCard,
+        RenegadeRoleCard,
+        DeputyRoleCard,
+        OutlawRoleCard,
+        OutlawRoleCard,
+        OutlawRoleCard,
     ],
     7: [
-        Role.SHERIFF,
-        Role.RENEGADE,
-        Role.DEPUTY,
-        Role.DEPUTY,
-        Role.OUTLAW,
-        Role.OUTLAW,
-        Role.OUTLAW,
+        SheriffRoleCard,
+        RenegadeRoleCard,
+        DeputyRoleCard,
+        DeputyRoleCard,
+        OutlawRoleCard,
+        OutlawRoleCard,
+        OutlawRoleCard,
     ],
 }
 
@@ -162,7 +174,7 @@ def simulate_game(num_players: int) -> str:
     chars = CHAR_CLASSES[:]
     random.shuffle(chars)
     for i in range(num_players):
-        player = Player(f"P{i}", role=roles[i], character=chars[i]())
+        player = Player(f"P{i}", role=roles[i](), character=chars[i]())
         gm.add_player(player)
     result: List[str] = []
 
@@ -170,7 +182,7 @@ def simulate_game(num_players: int) -> str:
         result.append(res)
 
     gm.game_over_listeners.append(_record_result)
-    gm.start_game()
+    gm.start_game(deal_roles=False)
     steps = 0
     while not result and steps < 2000:
         auto_turn(gm)

--- a/tests/test_gamemanager.py
+++ b/tests/test_gamemanager.py
@@ -15,7 +15,7 @@ def test_start_game_initializes_turn_order_and_calls_listener():
 
     gm.turn_started_listeners.append(_record_start)
 
-    gm.start_game()
+    gm.start_game(deal_roles=False)
 
     assert gm.turn_order == [0, 1]
     assert gm.current_turn == 0

--- a/tests/test_missing_rules.py
+++ b/tests/test_missing_rules.py
@@ -1,5 +1,6 @@
 from bang_py.game_manager import GameManager
-from bang_py.player import Player, Role
+from bang_py.player import Player
+from bang_py.cards.roles import SheriffRoleCard
 from bang_py.cards.bang import BangCard
 from bang_py.cards.beer import BeerCard
 from bang_py.cards.panic import PanicCard
@@ -56,7 +57,7 @@ def test_beer_no_effect_with_two_players():
 
 def test_jail_cannot_target_sheriff():
     gm = GameManager()
-    sheriff = Player("Sheriff", role=Role.SHERIFF)
+    sheriff = Player("Sheriff", role=SheriffRoleCard())
     outlaw = Player("Outlaw")
     gm.add_player(sheriff)
     gm.add_player(outlaw)

--- a/tests/test_network_serialization.py
+++ b/tests/test_network_serialization.py
@@ -1,10 +1,11 @@
 import json
-from bang_py.player import Player, Role
+from bang_py.player import Player
+from bang_py.cards.roles import SheriffRoleCard
 from bang_py.network.server import _serialize_players
 
 
 def test_serialize_players_json_roundtrip():
-    players = [Player("Alice"), Player("Bob", role=Role.SHERIFF)]
+    players = [Player("Alice"), Player("Bob", role=SheriffRoleCard())]
     assert players[0].max_health == 4
     assert players[1].max_health == 5
     serialized = _serialize_players(players)
@@ -14,27 +15,27 @@ def test_serialize_players_json_roundtrip():
         {
             "name": "Alice",
             "health": players[0].health,
-            "role": "OUTLAW",
+            "role": "Outlaw",
             "equipment": [],
         },
         {
             "name": "Bob",
             "health": players[1].health,
-            "role": "SHERIFF",
+            "role": "Sheriff",
             "equipment": [],
         },
     ]
 
 
 def test_serialize_players_with_health_changes():
-    sheriff = Player("Bill", role=Role.SHERIFF)
+    sheriff = Player("Bill", role=SheriffRoleCard())
     sheriff.health = 3
     data = _serialize_players([sheriff])
     assert data == [
         {
             "name": "Bill",
             "health": 3,
-            "role": "SHERIFF",
+            "role": "Sheriff",
             "equipment": [],
         }
     ]

--- a/tests/test_player_health.py
+++ b/tests/test_player_health.py
@@ -1,4 +1,5 @@
-from bang_py.player import Player, Role
+from bang_py.player import Player
+from bang_py.cards.roles import SheriffRoleCard, OutlawRoleCard
 from bang_py.characters.base import BaseCharacter
 
 
@@ -9,9 +10,9 @@ class BonusLife(BaseCharacter):
 
 
 def test_bonus_life_character_increases_max_health():
-    p = Player("Hero", role=Role.OUTLAW, character=BonusLife())
+    p = Player("Hero", role=OutlawRoleCard(), character=BonusLife())
     assert p.max_health == 5
     assert p.health == 5
-    sheriff = Player("Sheriff", role=Role.SHERIFF, character=BonusLife())
+    sheriff = Player("Sheriff", role=SheriffRoleCard(), character=BonusLife())
     assert sheriff.max_health == 6
     assert sheriff.health == 6

--- a/tests/test_turn_rules.py
+++ b/tests/test_turn_rules.py
@@ -1,6 +1,7 @@
 from bang_py.game_manager import GameManager
 from bang_py.deck import Deck
-from bang_py.player import Player, Role
+from bang_py.player import Player
+from bang_py.cards.roles import SheriffRoleCard, OutlawRoleCard
 from bang_py.cards.bang import BangCard
 from bang_py.characters.willy_the_kid import WillyTheKid
 
@@ -47,8 +48,8 @@ def test_discard_phase():
 
 def test_outlaws_win_when_sheriff_dies():
     gm = GameManager()
-    sheriff = Player("S", role=Role.SHERIFF)
-    outlaw = Player("O", role=Role.OUTLAW)
+    sheriff = Player("S", role=SheriffRoleCard())
+    outlaw = Player("O", role=OutlawRoleCard())
     gm.add_player(sheriff)
     gm.add_player(outlaw)
     results: list[str] = []


### PR DESCRIPTION
## Summary
- create `BaseRole` and update role cards to inherit from it
- implement role and character deck dealing in `GameManager.start_game`
- update players to use new role objects and recompute stats when assigned
- adapt tests for explicit `deal_roles=False` flag
- support 3-8 players and drop no-op `play` on role cards

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875c766d070832397fbcf8e571a6ae8