### PR TITLE
Remove doctor draw phase check

### DIFF
--- a/bang_py/game_manager.py
+++ b/bang_py/game_manager.py
@@ -420,9 +420,6 @@ class GameManager:
         the ability is used.
         """
 
-        if self.event_flags.get("doctor"):
-            player.heal(1)
-            return
 
         custom_draw = self.event_flags.get("draw_count")
         if custom_draw is not None:

--- a/tests/test_event_deck_effects.py
+++ b/tests/test_event_deck_effects.py
@@ -422,19 +422,6 @@ def test_daltons_all_draw():
     assert len(p1.hand) == 1
     assert len(p2.hand) == 1
 
-
-def test_doctor_heals_instead_of_draw():
-    gm = GameManager()
-    p = Player("Sheriff", role=SheriffRoleCard())
-    gm.add_player(p)
-    gm.event_deck = [EventCard("The Doctor", _doctor_event, "")]
-    gm.draw_event_card()
-    p.health -= 1
-    gm.draw_phase(p)
-    assert p.health == p.max_health
-    assert not p.hand
-
-
 def test_reverend_limits_hand_size():
     gm = GameManager()
     p = Player("Sheriff", role=SheriffRoleCard())
@@ -444,7 +431,6 @@ def test_reverend_limits_hand_size():
     gm.draw_event_card()
     gm.discard_phase(p)
     assert len(p.hand) == 2
-
 
 def test_train_arrival_all_draw():
     gm = GameManager()


### PR DESCRIPTION
## Summary
- remove Doctor event check from draw phase
- drop obsolete Doctor event test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876909ab1e48323a7fdd9c4bb0f54ef