### PR TITLE
Implement Blood Brothers health transfer

### DIFF
--- a/bang_py/event_decks.py
+++ b/bang_py/event_decks.py
@@ -159,6 +159,11 @@ def _hard_liquor(game: GameManager) -> None:
     HardLiquorEventCard().play(game=game)
 
 
+def _blood_brothers(game: GameManager) -> None:
+    """Allow players to transfer health at the start of their turn."""
+    BloodBrothersEventCard().play(game=game)
+
+
 def _prison_break(game: GameManager) -> None:
     """Jail cards are discarded."""
     PrisonBreakEventCard().play(game=game)

--- a/tests/test_event_deck_effects.py
+++ b/tests/test_event_deck_effects.py
@@ -20,6 +20,7 @@ from bang_py.event_decks import (
     _sermon,
     _hangover,
     _ambush_event,
+    _blood_brothers,
     _ranch,
     _prison_break,
     _high_noon,
@@ -315,6 +316,22 @@ def test_high_stakes_allows_multiple_bangs():
     gm.play_card(p1, p1.hand[0], p2)
     gm.play_card(p1, p1.hand[0], p2)
     assert p2.health == p2.max_health - 2
+
+
+def test_blood_brothers_transfer_during_turn():
+    gm = GameManager()
+    p1 = Player("A")
+    p2 = Player("B")
+    gm.add_player(p1)
+    gm.add_player(p2)
+    p2.health -= 1
+    gm.event_deck = [EventCard("Blood Brothers", _blood_brothers, "")]
+    gm.turn_order = [0]
+    gm.current_turn = 0
+    gm.draw_event_card()
+    gm._begin_turn(blood_target=p2)
+    assert p1.health == p1.max_health - 1
+    assert p2.health == p2.max_health
 
 
 def test_high_noon_deck_contents_full_list():


### PR DESCRIPTION
## Summary
- add `_blood_brothers` helper in `event_decks`
- allow an optional `blood_target` during draw phase
- add `blood_brothers_transfer` ability
- expose option via `_begin_turn`
- test automatic prompt for Blood Brothers event

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68769c2920a8832388483746af9d89e1