### PR TITLE
Add event deck timing and phase tracking

### DIFF
--- a/tests/test_expansions.py
+++ b/tests/test_expansions.py
@@ -375,6 +375,9 @@ def test_high_noon_event_deck_draw():
     gm.add_player(sheriff)
     gm.add_player(outlaw)
     gm.start_game(deal_roles=False)
+    assert gm.current_event is None
+    gm.end_turn()
+    gm.end_turn()
     assert gm.current_event is not None
 
 


### PR DESCRIPTION
## Summary
- add `sheriff_turns` counter
- draw event cards starting with the sheriff's second turn
- adjust tests for new event timing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876ed509a788323b82d986c93d0400e