### PR TITLE
Improve room code generation security

### DIFF
--- a/bang_py/network/server.py
+++ b/bang_py/network/server.py
@@ -1,6 +1,6 @@
 import asyncio
 import json
-import random
+import secrets
 from dataclasses import dataclass
 from typing import Any, Dict, List
 
@@ -55,7 +55,9 @@ class BangServer:
     ) -> None:
         self.host = host
         self.port = port
-        self.room_code = room_code or str(random.randint(1000, 9999))
+        # Generate a random 4-digit room code using a cryptographically
+        # secure RNG to avoid predictable codes.
+        self.room_code = room_code or f"{secrets.randbelow(9000) + 1000:04d}"
         self.game = GameManager(expansions=expansions or [])
         self.connections: Dict[WebSocketServerProtocol, Connection] = {}
         self.max_players = max_players

--- a/tests/test_server_room_code.py
+++ b/tests/test_server_room_code.py
@@ -1,0 +1,19 @@
+import secrets
+from bang_py.network.server import BangServer
+
+
+def test_default_room_code_format(monkeypatch) -> None:
+    monkeypatch.setattr(secrets, "randbelow", lambda _: 123)
+    server = BangServer()
+    assert server.room_code == "1123"
+    assert server.room_code.isdigit()
+    assert len(server.room_code) == 4
+
+
+def test_default_room_code_unique(monkeypatch) -> None:
+    values = iter([1, 2])
+    monkeypatch.setattr(secrets, "randbelow", lambda _: next(values))
+    server1 = BangServer()
+    server2 = BangServer()
+    assert server1.room_code != server2.room_code
+


### PR DESCRIPTION
## Summary
- use `secrets.randbelow` for generating server room codes
- test that default room codes are four-digit strings
- test that default codes differ across instances

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687704aaaff083238062240a87ce4dc5