### PR TITLE
Fix long event card docstring lines

### DIFF
--- a/bang_py/cards/events/blood_brothers.py
+++ b/bang_py/cards/events/blood_brothers.py
@@ -9,7 +9,8 @@ if TYPE_CHECKING:
 
 
 class BloodBrothersEventCard(BaseEventCard):
-    """At the beginning of his turn, each player may choose to lose 1 life (but not their last life) to give 1 life point to any player."""
+    """At the beginning of his turn, each player may choose to lose 1 life
+    (but not their last life) to give 1 life point to any player."""
 
     card_name = "Blood Brothers"
     card_set = "fistful_of_cards"

--- a/bang_py/cards/events/ghost_town.py
+++ b/bang_py/cards/events/ghost_town.py
@@ -9,7 +9,8 @@ if TYPE_CHECKING:
 
 
 class GhostTownEventCard(BaseEventCard):
-    """During their turn, eliminated players come back as ghosts with 3 cards and cannot die. At the end of their turn, they are eliminated again."""
+    """During their turn, eliminated players come back as ghosts with 3 cards and cannot die.
+    At the end of their turn, they are eliminated again."""
 
     card_name = "Ghost Town"
     card_set = "high_noon"

--- a/bang_py/cards/events/handcuffs.py
+++ b/bang_py/cards/events/handcuffs.py
@@ -9,7 +9,8 @@ if TYPE_CHECKING:
 
 
 class HandcuffsEventCard(BaseEventCard):
-    """After their draw phase, each player announces a suit and can only play that suit for the rest of their turn."""
+    """After their draw phase, each player announces a suit and can only play that suit
+    for the rest of their turn."""
 
     card_name = "Handcuffs"
     card_set = "high_noon"

--- a/bang_py/cards/events/law_of_the_west.py
+++ b/bang_py/cards/events/law_of_the_west.py
@@ -9,7 +9,8 @@ if TYPE_CHECKING:
 
 
 class LawOfTheWestEventCard(BaseEventCard):
-    """During their draw phase, each player must reveal the second card they drew and play it immediately if possible."""
+    """During their draw phase, each player must reveal the second card they drew
+    and play it immediately if possible."""
 
     card_name = "Law of the West"
     card_set = "fistful_of_cards"

--- a/bang_py/cards/events/new_identity.py
+++ b/bang_py/cards/events/new_identity.py
@@ -9,7 +9,8 @@ if TYPE_CHECKING:
 
 
 class NewIdentityEventCard(BaseEventCard):
-    """At the start of their turn, each player may look at their other face down character card and switch to it with 2 life."""
+    """At the start of their turn, each player may look at their other face down character card
+    and switch to it with 2 life."""
 
     card_name = "New Identity"
     card_set = "high_noon"

--- a/bang_py/cards/events/peyote.py
+++ b/bang_py/cards/events/peyote.py
@@ -9,7 +9,8 @@ if TYPE_CHECKING:
 
 
 class PeyoteEventCard(BaseEventCard):
-    """During their draw phase, each player guesses red or black. They reveal the top card; if correct they repeat until wrong."""
+    """During their draw phase, each player guesses red or black. They reveal the top card;
+    if correct they repeat until wrong."""
 
     card_name = "Peyote"
     card_set = "fistful_of_cards"

--- a/bang_py/cards/events/russian_roulette.py
+++ b/bang_py/cards/events/russian_roulette.py
@@ -11,7 +11,8 @@ if TYPE_CHECKING:
 
 
 class RussianRouletteEventCard(BaseEventCard):
-    """When Russian Roulette enters play, starting with the Sheriff each player discards a Missed! The first not to do so loses 2 life points."""
+    """When Russian Roulette enters play, starting with the Sheriff each player discards a Missed!
+    The first not to do so loses 2 life points."""
 
     card_name = "Russian Roulette"
     card_set = "fistful_of_cards"

--- a/bang_py/cards/events/sniper.py
+++ b/bang_py/cards/events/sniper.py
@@ -9,7 +9,8 @@ if TYPE_CHECKING:
 
 
 class SniperEventCard(BaseEventCard):
-    """During their turn, each player may discard 2 Bang! cards together against a player. It counts as 1 Bang!, but can only be countered by 2 Missed!"""
+    """During their turn, each player may discard 2 Bang! cards together against a player.
+    It counts as 1 Bang!, but can only be countered by 2 Missed!"""
 
     card_name = "Sniper"
     card_set = "fistful_of_cards"

--- a/bang_py/cards/events/the_daltons.py
+++ b/bang_py/cards/events/the_daltons.py
@@ -9,7 +9,8 @@ if TYPE_CHECKING:
 
 
 class TheDaltonsEventCard(BaseEventCard):
-    """When The Daltons enters play, each player that has any blue (equipment) cards in front of them must choose one to discard."""
+    """When The Daltons enters play, each player that has any blue (equipment) cards in front of them
+    must choose one to discard."""
 
     card_name = "The Daltons"
     card_set = "high_noon"

--- a/bang_py/cards/events/vendetta.py
+++ b/bang_py/cards/events/vendetta.py
@@ -9,7 +9,8 @@ if TYPE_CHECKING:
 
 
 class VendettaEventCard(BaseEventCard):
-    """At the end of their turn, each player draws! On a heart, they may play another turn. They cannot benefit again."""
+    """At the end of their turn, each player draws! On a heart, they may play another turn.
+    They cannot benefit again."""
 
     card_name = "Vendetta"
     card_set = "fistful_of_cards"


### PR DESCRIPTION
## Summary
- wrap initial docstrings in event cards so lines stay under 100 chars

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877113b30388323bdaf443cf26bf4c4