### PR TITLE
Fix trailing blank lines flagged by flake8

### DIFF
--- a/bang_py/cards/binoculars.py
+++ b/bang_py/cards/binoculars.py
@@ -21,4 +21,3 @@ class BinocularsCard(BaseCard):
         if not target:
             return
         target.equip(self, active=self.active)
-

--- a/bang_py/cards/brawl.py
+++ b/bang_py/cards/brawl.py
@@ -46,5 +46,3 @@ class BrawlCard(BaseCard):
                 card = p.hand.pop(idx)
                 game.discard_pile.append(card)
                 handle_out_of_turn_discard(game, p, card)
-
-

--- a/bang_py/cards/hideout.py
+++ b/bang_py/cards/hideout.py
@@ -21,4 +21,3 @@ class HideoutCard(BaseCard):
         if not target:
             return
         target.equip(self, active=self.active)
-

--- a/bang_py/cards/knife.py
+++ b/bang_py/cards/knife.py
@@ -35,4 +35,3 @@ class KnifeCard(BaseCard):
         )
         if game and target.health < target.max_health:
             game.on_player_damaged(target, player)
-

--- a/bang_py/cards/rag_time.py
+++ b/bang_py/cards/rag_time.py
@@ -44,4 +44,3 @@ class RagTimeCard(BaseCard):
             card = next(iter(target.equipment.values()))
             target.unequip(card.card_name)
             player.hand.append(card)
-

--- a/bang_py/cards/springfield.py
+++ b/bang_py/cards/springfield.py
@@ -43,5 +43,3 @@ class SpringfieldCard(BaseCard):
             )
             if target.health < target.max_health:
                 game.on_player_damaged(target, player)
-
-

--- a/bang_py/cards/tequila.py
+++ b/bang_py/cards/tequila.py
@@ -37,4 +37,3 @@ class TequilaCard(BaseCard):
         target.heal(1)
         if target.health > before:
             game.on_player_healed(target)
-

--- a/bang_py/cards/whisky.py
+++ b/bang_py/cards/whisky.py
@@ -37,4 +37,3 @@ class WhiskyCard(BaseCard):
         target.heal(2)
         if target.health > before:
             game.on_player_healed(target)
-

--- a/bang_py/characters/base.py
+++ b/bang_py/characters/base.py
@@ -21,4 +21,3 @@ class BaseCharacter(ABC):
     def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
         """Perform the character's special ability."""
         raise NotImplementedError
-


### PR DESCRIPTION
## Summary
- clean up blank lines at end of module files
- ensure flake8 W391 passes

## Testing
- `flake8 bang_py --select=W391`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6877162931dc832394267d861e96ae88