### PR TITLE
Update room code generation to alphanumeric

### DIFF
--- a/bang_py/network/server.py
+++ b/bang_py/network/server.py
@@ -58,9 +58,9 @@ class BangServer:
     ) -> None:
         self.host = host
         self.port = port
-        # Generate a random 4-digit room code using a cryptographically
+        # Generate a random six-character room code using a cryptographically
         # secure RNG to avoid predictable codes.
-        self.room_code = room_code or f"{secrets.randbelow(9000) + 1000:04d}"
+        self.room_code = room_code or secrets.token_hex(3)
         self.game = GameManager(expansions=expansions or [])
         self.connections: Dict[WebSocketServerProtocol, Connection] = {}
         self.max_players = max_players

--- a/bang_py/ui.py
+++ b/bang_py/ui.py
@@ -236,7 +236,7 @@ class BangUI:
     def _start_host(self) -> None:
         port = int(self.port_var.get())
         max_players = int(self.max_players_var.get())
-        room_code = str(secrets.randbelow(9000) + 1000)
+        room_code = secrets.token_hex(3)
         expansions = []
         if self.exp_dodge_city.get():
             expansions.append("dodge_city")

--- a/tests/test_server_room_code.py
+++ b/tests/test_server_room_code.py
@@ -3,16 +3,16 @@ from bang_py.network.server import BangServer
 
 
 def test_default_room_code_format(monkeypatch) -> None:
-    monkeypatch.setattr(secrets, "randbelow", lambda _: 123)
+    monkeypatch.setattr(secrets, "token_hex", lambda n=3: "abc123")
     server = BangServer()
-    assert server.room_code == "1123"
-    assert server.room_code.isdigit()
-    assert len(server.room_code) == 4
+    assert server.room_code == "abc123"
+    assert server.room_code.isalnum()
+    assert len(server.room_code) == 6
 
 
 def test_default_room_code_unique(monkeypatch) -> None:
-    values = iter([1, 2])
-    monkeypatch.setattr(secrets, "randbelow", lambda _: next(values))
+    values = iter(["aaaaaa", "bbbbbb"])
+    monkeypatch.setattr(secrets, "token_hex", lambda n=3: next(values))
     server1 = BangServer()
     server2 = BangServer()
     assert server1.room_code != server2.room_code


### PR DESCRIPTION
## Summary
- generate six-character alphanumeric room codes on the server
- update UI to create new style codes when hosting
- adapt tests for new room code format

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68771ec468e48323bb9601d9cf7d9844