### PR TITLE
Wrap docstrings in event cards

### DIFF
--- a/bang_py/cards/events/abandoned_mine.py
+++ b/bang_py/cards/events/abandoned_mine.py
@@ -9,11 +9,15 @@ if TYPE_CHECKING:
 
 
 class AbandonedMineEventCard(BaseEventCard):
-    """During draw, draw from discard pile if possible. Discards go face down on top of the deck."""
+    """During draw, draw from discard pile if possible.
+    Discards go face down on top of the deck."""
 
     card_name = "Abandoned Mine"
     card_set = "fistful_of_cards"
-    description = "During draw, draw from discard pile if possible. Discards go face down on top of the deck."
+    description = (
+        "During draw, draw from discard pile if possible. "
+        "Discards go face down on top of the deck."
+    )
 
     def play(
         self,

--- a/bang_py/cards/events/ambush.py
+++ b/bang_py/cards/events/ambush.py
@@ -9,11 +9,15 @@ if TYPE_CHECKING:
 
 
 class AmbushEventCard(BaseEventCard):
-    """The distance between any two players is 1. Only other cards in play may modify this."""
+    """The distance between any two players is 1.
+    Only other cards in play may modify this."""
 
     card_name = "Ambush"
     card_set = "fistful_of_cards"
-    description = "The distance between any two players is 1. Only other cards in play may modify this."
+    description = (
+        "The distance between any two players is 1. "
+        "Only other cards in play may modify this."
+    )
 
     def play(
         self,

--- a/bang_py/cards/events/blood_brothers.py
+++ b/bang_py/cards/events/blood_brothers.py
@@ -14,7 +14,10 @@ class BloodBrothersEventCard(BaseEventCard):
 
     card_name = "Blood Brothers"
     card_set = "fistful_of_cards"
-    description = "At the beginning of his turn, each player may choose to lose 1 life (but not their last life) to give 1 life point to any player."
+    description = (
+        "At the beginning of his turn, each player may choose to lose 1 life "
+        "(but not their last life) to give 1 life point to any player."
+    )
 
     def play(
         self,

--- a/bang_py/cards/events/dead_man.py
+++ b/bang_py/cards/events/dead_man.py
@@ -9,11 +9,15 @@ if TYPE_CHECKING:
 
 
 class DeadManEventCard(BaseEventCard):
-    """During his turn, the player that was eliminated first comes back with 2 life and 2 cards."""
+    """During his turn, the player that was eliminated first comes back with 2 life
+    and 2 cards."""
 
     card_name = "Dead Man"
     card_set = "fistful_of_cards"
-    description = "During his turn, the player that was eliminated first comes back with 2 life and 2 cards."
+    description = (
+        "During his turn, the player that was eliminated first comes back with 2 life "
+        "and 2 cards."
+    )
 
     def play(
         self,

--- a/bang_py/cards/events/fistful_of_cards.py
+++ b/bang_py/cards/events/fistful_of_cards.py
@@ -9,11 +9,15 @@ if TYPE_CHECKING:
 
 
 class FistfulOfCardsEventCard(BaseEventCard):
-    """At the beginning of his turn, each player is the target of as many Bangs! as cards in their hand."""
+    """At the beginning of his turn, each player is the target of as many Bangs!
+    as cards in their hand."""
 
     card_name = "A Fistful of Cards"
     card_set = "fistful_of_cards"
-    description = "At the beginning of his turn, each player is the target of as many Bangs! as cards in their hand."
+    description = (
+        "At the beginning of his turn, each player is the target of as many Bangs! "
+        "as cards in their hand."
+    )
 
     def play(
         self,

--- a/bang_py/cards/events/ghost_town.py
+++ b/bang_py/cards/events/ghost_town.py
@@ -9,12 +9,15 @@ if TYPE_CHECKING:
 
 
 class GhostTownEventCard(BaseEventCard):
-    """During their turn, eliminated players come back as ghosts with 3 cards and cannot die.
-    At the end of their turn, they are eliminated again."""
+    """During their turn, eliminated players come back as ghosts with 3 cards and
+    cannot die. At the end of their turn, they are eliminated again."""
 
     card_name = "Ghost Town"
     card_set = "high_noon"
-    description = "During their turn, eliminated players come back as ghosts with 3 cards and cannot die. At the end of their turn, they are eliminated again."
+    description = (
+        "During their turn, eliminated players come back as ghosts with 3 cards and "
+        "cannot die. At the end of their turn, they are eliminated again."
+    )
 
     def play(
         self,

--- a/bang_py/cards/events/handcuffs.py
+++ b/bang_py/cards/events/handcuffs.py
@@ -9,12 +9,15 @@ if TYPE_CHECKING:
 
 
 class HandcuffsEventCard(BaseEventCard):
-    """After their draw phase, each player announces a suit and can only play that suit
-    for the rest of their turn."""
+    """After their draw phase, each player announces a suit and can only play that
+    suit for the rest of their turn."""
 
     card_name = "Handcuffs"
     card_set = "high_noon"
-    description = "After their draw phase, each player announces a suit and can only play that suit for the rest of their turn."
+    description = (
+        "After their draw phase, each player announces a suit and can only play "
+        "that suit for the rest of their turn."
+    )
 
     def play(
         self,

--- a/bang_py/cards/events/law_of_the_west.py
+++ b/bang_py/cards/events/law_of_the_west.py
@@ -14,7 +14,10 @@ class LawOfTheWestEventCard(BaseEventCard):
 
     card_name = "Law of the West"
     card_set = "fistful_of_cards"
-    description = "During their draw phase, each player must reveal the second card they drew and play it immediately if possible."
+    description = (
+        "During their draw phase, each player must reveal the second card they drew "
+        "and play it immediately if possible."
+    )
 
     def play(
         self,

--- a/bang_py/cards/events/new_identity.py
+++ b/bang_py/cards/events/new_identity.py
@@ -9,12 +9,15 @@ if TYPE_CHECKING:
 
 
 class NewIdentityEventCard(BaseEventCard):
-    """At the start of their turn, each player may look at their other face down character card
-    and switch to it with 2 life."""
+    """At the start of their turn, each player may look at their other face down
+    character card and switch to it with 2 life."""
 
     card_name = "New Identity"
     card_set = "high_noon"
-    description = "At the start of their turn, each player may look at their other face down character card and switch to it with 2 life."
+    description = (
+        "At the start of their turn, each player may look at their other face down "
+        "character card and switch to it with 2 life."
+    )
 
     def play(
         self,

--- a/bang_py/cards/events/peyote.py
+++ b/bang_py/cards/events/peyote.py
@@ -9,12 +9,15 @@ if TYPE_CHECKING:
 
 
 class PeyoteEventCard(BaseEventCard):
-    """During their draw phase, each player guesses red or black. They reveal the top card;
-    if correct they repeat until wrong."""
+    """During their draw phase, each player guesses red or black. They reveal the
+    top card; if correct they repeat until wrong."""
 
     card_name = "Peyote"
     card_set = "fistful_of_cards"
-    description = "During their draw phase, each player guesses red or black. They reveal the top card; if correct they repeat until wrong."
+    description = (
+        "During their draw phase, each player guesses red or black. They reveal the "
+        "top card; if correct they repeat until wrong."
+    )
 
     def play(
         self,

--- a/bang_py/cards/events/russian_roulette.py
+++ b/bang_py/cards/events/russian_roulette.py
@@ -11,12 +11,15 @@ if TYPE_CHECKING:
 
 
 class RussianRouletteEventCard(BaseEventCard):
-    """When Russian Roulette enters play, starting with the Sheriff each player discards a Missed!
-    The first not to do so loses 2 life points."""
+    """When Russian Roulette enters play, starting with the Sheriff each player
+    discards a Missed! The first not to do so loses 2 life points."""
 
     card_name = "Russian Roulette"
     card_set = "fistful_of_cards"
-    description = "When Russian Roulette enters play, starting with the Sheriff each player discards a Missed! The first not to do so loses 2 life points."
+    description = (
+        "When Russian Roulette enters play, starting with the Sheriff each player "
+        "discards a Missed! The first not to do so loses 2 life points."
+    )
 
     def play(
         self,

--- a/bang_py/cards/events/sniper.py
+++ b/bang_py/cards/events/sniper.py
@@ -9,12 +9,15 @@ if TYPE_CHECKING:
 
 
 class SniperEventCard(BaseEventCard):
-    """During their turn, each player may discard 2 Bang! cards together against a player.
-    It counts as 1 Bang!, but can only be countered by 2 Missed!"""
+    """During their turn, each player may discard 2 Bang! cards together against a
+    player. It counts as 1 Bang!, but can only be countered by 2 Missed!"""
 
     card_name = "Sniper"
     card_set = "fistful_of_cards"
-    description = "During their turn, each player may discard 2 Bang! cards together against a player. It counts as 1 Bang!, but can only be countered by 2 Missed!"
+    description = (
+        "During their turn, each player may discard 2 Bang! cards together against a "
+        "player. It counts as 1 Bang!, but can only be countered by 2 Missed!"
+    )
 
     def play(
         self,

--- a/bang_py/cards/events/the_daltons.py
+++ b/bang_py/cards/events/the_daltons.py
@@ -9,12 +9,15 @@ if TYPE_CHECKING:
 
 
 class TheDaltonsEventCard(BaseEventCard):
-    """When The Daltons enters play, each player that has any blue (equipment) cards in front of them
-    must choose one to discard."""
+    """When The Daltons enters play, each player that has any blue (equipment)
+    cards in front of them must choose one to discard."""
 
     card_name = "The Daltons"
     card_set = "high_noon"
-    description = "When The Daltons enters play, each player that has any blue (equipment) cards in front of them must choose one to discard."
+    description = (
+        "When The Daltons enters play, each player that has any blue (equipment) "
+        "cards in front of them must choose one to discard."
+    )
 
     def play(
         self,

--- a/bang_py/cards/events/the_doctor.py
+++ b/bang_py/cards/events/the_doctor.py
@@ -13,7 +13,10 @@ class TheDoctorEventCard(BaseEventCard):
 
     card_name = "The Doctor"
     card_set = "high_noon"
-    description = "When The Doctor enters play, the player(s) still in the game with the fewest life points regain 1 life point."
+    description = (
+        "When The Doctor enters play, the player(s) still in the game with the fewest "
+        "life points regain 1 life point."
+    )
 
     def play(
         self,

--- a/bang_py/cards/events/vendetta.py
+++ b/bang_py/cards/events/vendetta.py
@@ -9,12 +9,15 @@ if TYPE_CHECKING:
 
 
 class VendettaEventCard(BaseEventCard):
-    """At the end of their turn, each player draws! On a heart, they may play another turn.
-    They cannot benefit again."""
+    """At the end of their turn, each player draws! On a heart, they may play
+    another turn. They cannot benefit again."""
 
     card_name = "Vendetta"
     card_set = "fistful_of_cards"
-    description = "At the end of their turn, each player draws! On a heart, they may play another turn. They cannot benefit again."
+    description = (
+        "At the end of their turn, each player draws! On a heart, they may play "
+        "another turn. They cannot benefit again."
+    )
 
     def play(
         self,


### PR DESCRIPTION
## Summary
- keep event card docstrings and descriptions under 100 characters
- no behavioral changes

## Testing
- `flake8 bang_py/cards/events --max-line-length=100`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68772eca659483239cf5617d679dd1d0