### PR TITLE
Fix blank line formatting in character modules

### DIFF
--- a/bang_py/characters/apache_kid.py
+++ b/bang_py/characters/apache_kid.py
@@ -10,6 +10,7 @@ if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from ..cards.card import BaseCard
     from ..cards.duel import DuelCard
 
+
 class ApacheKid(BaseCharacter):
     name = "Apache Kid"
     description = "You are unaffected by Diamond suited cards."
@@ -17,6 +18,7 @@ class ApacheKid(BaseCharacter):
 
     def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
         player.metadata.abilities.add(ApacheKid)
+
 
         def check(p: "Player", card: "BaseCard", target: "Player | None") -> bool:
             if (

--- a/bang_py/characters/bart_cassidy.py
+++ b/bang_py/characters/bart_cassidy.py
@@ -8,6 +8,7 @@ if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from ..game_manager import GameManager
     from ..player import Player
 
+
 class BartCassidy(BaseCharacter):
     name = "Bart Cassidy"
     description = (
@@ -17,6 +18,7 @@ class BartCassidy(BaseCharacter):
 
     def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
         player.metadata.abilities.add(BartCassidy)
+
         def on_damaged(p: "Player", _src: "Player | None", *__: object) -> None:
             if p is player:
                 gm.draw_card(player)

--- a/bang_py/characters/belle_star.py
+++ b/bang_py/characters/belle_star.py
@@ -8,6 +8,7 @@ if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from ..game_manager import GameManager
     from ..player import Player
 
+
 class BelleStar(BaseCharacter):
     name = "Belle Star"
     description = (
@@ -17,6 +18,7 @@ class BelleStar(BaseCharacter):
 
     def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
         player.metadata.abilities.add(BelleStar)
+
 
         def _toggle(p: "Player") -> None:
             player.metadata.ignore_others_equipment = p is player

--- a/bang_py/characters/bill_noface.py
+++ b/bang_py/characters/bill_noface.py
@@ -8,6 +8,7 @@ if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from ..game_manager import GameManager
     from ..player import Player
 
+
 class BillNoface(BaseCharacter):
     name = "Bill Noface"
     description = (
@@ -18,6 +19,7 @@ class BillNoface(BaseCharacter):
 
     def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
         player.metadata.abilities.add(BillNoface)
+
         def on_draw(p: "Player", _opts: dict) -> bool:
             if p is not player:
                 return True

--- a/bang_py/characters/black_jack.py
+++ b/bang_py/characters/black_jack.py
@@ -8,6 +8,7 @@ if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from ..game_manager import GameManager
     from ..player import Player
 
+
 class BlackJack(BaseCharacter):
     name = "Black Jack"
     description = (
@@ -19,6 +20,7 @@ class BlackJack(BaseCharacter):
 
     def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
         player.metadata.abilities.add(BlackJack)
+
         def on_draw(p: "Player", _k: object) -> bool:
             if p is not player:
                 return True

--- a/bang_py/characters/calamity_janet.py
+++ b/bang_py/characters/calamity_janet.py
@@ -8,6 +8,7 @@ if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from ..game_manager import GameManager
     from ..player import Player
 
+
 class CalamityJanet(BaseCharacter):
     name = "Calamity Janet"
     description = "You may play Bang! cards as Missed! and vice versa."

--- a/bang_py/characters/chuck_wengam.py
+++ b/bang_py/characters/chuck_wengam.py
@@ -8,6 +8,7 @@ if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from ..game_manager import GameManager
     from ..player import Player
 
+
 class ChuckWengam(BaseCharacter):
     name = "Chuck Wengam"
     description = (

--- a/bang_py/characters/claus_the_saint.py
+++ b/bang_py/characters/claus_the_saint.py
@@ -8,6 +8,7 @@ if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from ..game_manager import GameManager
     from ..player import Player
 
+
 class ClausTheSaint(BaseCharacter):
     name = "Claus the Saint"
     description = (
@@ -19,6 +20,7 @@ class ClausTheSaint(BaseCharacter):
 
     def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
         player.metadata.abilities.add(ClausTheSaint)
+
         def on_draw(p: "Player", _opts: dict) -> bool:
             if p is not player:
                 return True

--- a/bang_py/characters/doc_holyday.py
+++ b/bang_py/characters/doc_holyday.py
@@ -8,6 +8,7 @@ if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from ..game_manager import GameManager
     from ..player import Player
 
+
 class DocHolyday(BaseCharacter):
     name = "Doc Holyday"
     description = (

--- a/bang_py/characters/el_gringo.py
+++ b/bang_py/characters/el_gringo.py
@@ -8,6 +8,7 @@ if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from ..game_manager import GameManager
     from ..player import Player
 
+
 class ElGringo(BaseCharacter):
     name = "El Gringo"
     description = (
@@ -18,6 +19,7 @@ class ElGringo(BaseCharacter):
 
     def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
         player.metadata.abilities.add(ElGringo)
+
 
         def on_damaged(p: "Player", src: "Player | None", *__: object) -> None:
             if p is player and src and src.hand:

--- a/bang_py/characters/elena_fuente.py
+++ b/bang_py/characters/elena_fuente.py
@@ -8,6 +8,7 @@ if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from ..game_manager import GameManager
     from ..player import Player
 
+
 class ElenaFuente(BaseCharacter):
     name = "Elena Fuente"
     description = "You may play any card from your hand as a Missed!."

--- a/bang_py/characters/greg_digger.py
+++ b/bang_py/characters/greg_digger.py
@@ -8,6 +8,7 @@ if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from ..game_manager import GameManager
     from ..player import Player
 
+
 class GregDigger(BaseCharacter):
     name = "Greg Digger"
     description = "Each time a player is eliminated, regain two life points."
@@ -15,6 +16,7 @@ class GregDigger(BaseCharacter):
 
     def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
         player.metadata.abilities.add(GregDigger)
+
         def on_death(victim: "Player", _src: "Player | None") -> None:
             if victim is not player and player.is_alive():
                 before = player.health

--- a/bang_py/characters/herb_hunter.py
+++ b/bang_py/characters/herb_hunter.py
@@ -8,6 +8,7 @@ if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from ..game_manager import GameManager
     from ..player import Player
 
+
 class HerbHunter(BaseCharacter):
     name = "Herb Hunter"
     description = (
@@ -17,6 +18,7 @@ class HerbHunter(BaseCharacter):
 
     def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
         player.metadata.abilities.add(HerbHunter)
+
         def on_death(victim: "Player", _src: "Player | None") -> None:
             if victim is not player:
                 gm.draw_card(player, 2)

--- a/bang_py/characters/jesse_jones.py
+++ b/bang_py/characters/jesse_jones.py
@@ -8,6 +8,7 @@ if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from ..game_manager import GameManager
     from ..player import Player
 
+
 class JesseJones(BaseCharacter):
     name = "Jesse Jones"
     description = (
@@ -19,6 +20,7 @@ class JesseJones(BaseCharacter):
 
     def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
         player.metadata.abilities.add(JesseJones)
+
         def on_draw(p: "Player", opts: dict) -> bool:
             if p is not player:
                 return True

--- a/bang_py/characters/johnny_kisch.py
+++ b/bang_py/characters/johnny_kisch.py
@@ -9,6 +9,7 @@ if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from ..player import Player
     from ..cards.card import BaseCard
 
+
 class JohnnyKisch(BaseCharacter):
     name = "Johnny Kisch"
     description = (
@@ -18,6 +19,7 @@ class JohnnyKisch(BaseCharacter):
 
     def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
         player.metadata.abilities.add(JohnnyKisch)
+
 
         def on_play(p: "Player", card: "BaseCard", _t: "Player | None") -> None:
             if p is player and hasattr(card, "card_name"):

--- a/bang_py/characters/jose_delgado.py
+++ b/bang_py/characters/jose_delgado.py
@@ -8,6 +8,7 @@ if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from ..game_manager import GameManager
     from ..player import Player
 
+
 class JoseDelgado(BaseCharacter):
     name = "Jose Delgado"
     description = "You may discard an equipment card to draw two cards."
@@ -16,6 +17,7 @@ class JoseDelgado(BaseCharacter):
 
     def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
         player.metadata.abilities.add(JoseDelgado)
+
         def on_draw(p: "Player", opts: dict) -> bool:
             if p is not player:
                 return True

--- a/bang_py/characters/jourdonnais.py
+++ b/bang_py/characters/jourdonnais.py
@@ -8,6 +8,7 @@ if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from ..game_manager import GameManager
     from ..player import Player
 
+
 class Jourdonnais(BaseCharacter):
     name = "Jourdonnais"
     description = "You are considered to have a Barrel in play at all times."

--- a/bang_py/characters/kit_carlson.py
+++ b/bang_py/characters/kit_carlson.py
@@ -8,6 +8,7 @@ if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from ..game_manager import GameManager
     from ..player import Player
 
+
 class KitCarlson(BaseCharacter):
     name = "Kit Carlson"
     description = (
@@ -19,6 +20,7 @@ class KitCarlson(BaseCharacter):
 
     def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
         player.metadata.abilities.add(KitCarlson)
+
         def on_draw(p: "Player", opts: dict) -> bool:
             if p is not player:
                 return True

--- a/bang_py/characters/lucky_duke.py
+++ b/bang_py/characters/lucky_duke.py
@@ -8,6 +8,7 @@ if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from ..game_manager import GameManager
     from ..player import Player
 
+
 class LuckyDuke(BaseCharacter):
     name = "Lucky Duke"
     description = (

--- a/bang_py/characters/molly_stark.py
+++ b/bang_py/characters/molly_stark.py
@@ -9,6 +9,7 @@ if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from ..player import Player
     from ..cards.card import BaseCard
 
+
 class MollyStark(BaseCharacter):
     name = "Molly Stark"
     description = (

--- a/bang_py/characters/pat_brennan.py
+++ b/bang_py/characters/pat_brennan.py
@@ -8,6 +8,7 @@ if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from ..game_manager import GameManager
     from ..player import Player
 
+
 class PatBrennan(BaseCharacter):
     name = "Pat Brennan"
     description = (
@@ -18,6 +19,7 @@ class PatBrennan(BaseCharacter):
 
     def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
         player.metadata.abilities.add(PatBrennan)
+
         def on_draw(p: "Player", opts: dict) -> bool:
             if p is not player:
                 return True

--- a/bang_py/characters/paul_regret.py
+++ b/bang_py/characters/paul_regret.py
@@ -8,6 +8,7 @@ if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from ..game_manager import GameManager
     from ..player import Player
 
+
 class PaulRegret(BaseCharacter):
     name = "Paul Regret"
     description = "Players see you at distance +1."

--- a/bang_py/characters/pedro_ramirez.py
+++ b/bang_py/characters/pedro_ramirez.py
@@ -8,6 +8,7 @@ if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from ..game_manager import GameManager
     from ..player import Player
 
+
 class PedroRamirez(BaseCharacter):
     name = "Pedro Ramirez"
     description = (
@@ -19,6 +20,7 @@ class PedroRamirez(BaseCharacter):
 
     def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
         player.metadata.abilities.add(PedroRamirez)
+
         def on_draw(p: "Player", opts: dict) -> bool:
             if p is not player or not gm.discard_pile:
                 return True

--- a/bang_py/characters/pixie_pete.py
+++ b/bang_py/characters/pixie_pete.py
@@ -8,6 +8,7 @@ if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from ..game_manager import GameManager
     from ..player import Player
 
+
 class PixiePete(BaseCharacter):
     name = "Pixie Pete"
     description = "During your draw phase, draw three cards instead of two."
@@ -16,6 +17,7 @@ class PixiePete(BaseCharacter):
 
     def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
         player.metadata.abilities.add(PixiePete)
+
         def on_draw(p: "Player", _opts: dict) -> bool:
             if p is not player:
                 return True

--- a/bang_py/characters/rose_doolan.py
+++ b/bang_py/characters/rose_doolan.py
@@ -8,6 +8,7 @@ if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from ..game_manager import GameManager
     from ..player import Player
 
+
 class RoseDoolan(BaseCharacter):
     name = "Rose Doolan"
     description = "You see all players at a distance -1."

--- a/bang_py/characters/sean_mallory.py
+++ b/bang_py/characters/sean_mallory.py
@@ -8,6 +8,7 @@ if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from ..game_manager import GameManager
     from ..player import Player
 
+
 class SeanMallory(BaseCharacter):
     name = "Sean Mallory"
     description = "You may hold up to 10 cards in your hand."

--- a/bang_py/characters/sid_ketchum.py
+++ b/bang_py/characters/sid_ketchum.py
@@ -8,6 +8,7 @@ if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from ..game_manager import GameManager
     from ..player import Player
 
+
 class SidKetchum(BaseCharacter):
     name = "Sid Ketchum"
     description = "You may discard two cards to regain one life point."

--- a/bang_py/characters/slab_the_killer.py
+++ b/bang_py/characters/slab_the_killer.py
@@ -8,6 +8,7 @@ if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from ..game_manager import GameManager
     from ..player import Player
 
+
 class SlabTheKiller(BaseCharacter):
     name = "Slab the Killer"
     description = "Players need two Missed! cards to cancel your Bang!."

--- a/bang_py/characters/suzy_lafayette.py
+++ b/bang_py/characters/suzy_lafayette.py
@@ -8,6 +8,7 @@ if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from ..game_manager import GameManager
     from ..player import Player
 
+
 class SuzyLafayette(BaseCharacter):
     name = "Suzy Lafayette"
     description = "As soon as you have no cards in hand, draw a card."

--- a/bang_py/characters/tequila_joe.py
+++ b/bang_py/characters/tequila_joe.py
@@ -8,6 +8,7 @@ if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from ..game_manager import GameManager
     from ..player import Player
 
+
 class TequilaJoe(BaseCharacter):
     name = "Tequila Joe"
     description = "Beer cards heal you by 2 life points."

--- a/bang_py/characters/uncle_will.py
+++ b/bang_py/characters/uncle_will.py
@@ -8,6 +8,7 @@ if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from ..game_manager import GameManager
     from ..player import Player
 
+
 class UncleWill(BaseCharacter):
     name = "Uncle Will"
     description = (

--- a/bang_py/characters/vera_custer.py
+++ b/bang_py/characters/vera_custer.py
@@ -8,6 +8,7 @@ if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from ..game_manager import GameManager
     from ..player import Player
 
+
 class VeraCuster(BaseCharacter):
     name = "Vera Custer"
     description = "At the start of your turn, copy another living character's ability."

--- a/bang_py/characters/vulture_sam.py
+++ b/bang_py/characters/vulture_sam.py
@@ -8,6 +8,7 @@ if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from ..game_manager import GameManager
     from ..player import Player
 
+
 class VultureSam(BaseCharacter):
     name = "Vulture Sam"
     description = (
@@ -17,6 +18,7 @@ class VultureSam(BaseCharacter):
 
     def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
         player.metadata.abilities.add(VultureSam)
+
         def on_death(victim: "Player", _src: "Player | None") -> None:
             if victim is not player:
                 player.hand.extend(victim.hand)

--- a/bang_py/characters/willy_the_kid.py
+++ b/bang_py/characters/willy_the_kid.py
@@ -8,6 +8,7 @@ if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from ..game_manager import GameManager
     from ..player import Player
 
+
 class WillyTheKid(BaseCharacter):
     name = "Willy the Kid"
     description = "You may play any number of Bang! cards during your turn."


### PR DESCRIPTION
## Summary
- ensure two blank lines before class definitions in `bang_py/characters`
- ensure a blank line before nested function definitions

## Testing
- `flake8 bang_py/characters --select=E302,E306`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68773c29b0088323829b17a1ace78c9d