### PR TITLE
Fix E303 in characters

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 100

--- a/bang_py/characters/apache_kid.py
+++ b/bang_py/characters/apache_kid.py
@@ -19,7 +19,6 @@ class ApacheKid(BaseCharacter):
     def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
         player.metadata.abilities.add(ApacheKid)
 
-
         def check(p: "Player", card: "BaseCard", target: "Player | None") -> bool:
             if (
                 p is not player

--- a/bang_py/characters/belle_star.py
+++ b/bang_py/characters/belle_star.py
@@ -19,7 +19,6 @@ class BelleStar(BaseCharacter):
     def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
         player.metadata.abilities.add(BelleStar)
 
-
         def _toggle(p: "Player") -> None:
             player.metadata.ignore_others_equipment = p is player
 

--- a/bang_py/characters/bill_noface.py
+++ b/bang_py/characters/bill_noface.py
@@ -16,7 +16,6 @@ class BillNoface(BaseCharacter):
     )
     starting_health = 4
 
-
     def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
         player.metadata.abilities.add(BillNoface)
 

--- a/bang_py/characters/black_jack.py
+++ b/bang_py/characters/black_jack.py
@@ -17,7 +17,6 @@ class BlackJack(BaseCharacter):
     )
     starting_health = 4
 
-
     def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
         player.metadata.abilities.add(BlackJack)
 

--- a/bang_py/characters/claus_the_saint.py
+++ b/bang_py/characters/claus_the_saint.py
@@ -17,7 +17,6 @@ class ClausTheSaint(BaseCharacter):
     )
     starting_health = 3
 
-
     def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
         player.metadata.abilities.add(ClausTheSaint)
 

--- a/bang_py/characters/el_gringo.py
+++ b/bang_py/characters/el_gringo.py
@@ -20,7 +20,6 @@ class ElGringo(BaseCharacter):
     def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
         player.metadata.abilities.add(ElGringo)
 
-
         def on_damaged(p: "Player", src: "Player | None", *__: object) -> None:
             if p is player and src and src.hand:
                 idx = player.metadata.gringo_index or 0

--- a/bang_py/characters/jesse_jones.py
+++ b/bang_py/characters/jesse_jones.py
@@ -17,7 +17,6 @@ class JesseJones(BaseCharacter):
     )
     starting_health = 4
 
-
     def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
         player.metadata.abilities.add(JesseJones)
 

--- a/bang_py/characters/johnny_kisch.py
+++ b/bang_py/characters/johnny_kisch.py
@@ -20,7 +20,6 @@ class JohnnyKisch(BaseCharacter):
     def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
         player.metadata.abilities.add(JohnnyKisch)
 
-
         def on_play(p: "Player", card: "BaseCard", _t: "Player | None") -> None:
             if p is player and hasattr(card, "card_name"):
                 for o in gm.players:

--- a/bang_py/characters/jose_delgado.py
+++ b/bang_py/characters/jose_delgado.py
@@ -14,7 +14,6 @@ class JoseDelgado(BaseCharacter):
     description = "You may discard an equipment card to draw two cards."
     starting_health = 4
 
-
     def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
         player.metadata.abilities.add(JoseDelgado)
 

--- a/bang_py/characters/kit_carlson.py
+++ b/bang_py/characters/kit_carlson.py
@@ -17,7 +17,6 @@ class KitCarlson(BaseCharacter):
     )
     starting_health = 4
 
-
     def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
         player.metadata.abilities.add(KitCarlson)
 

--- a/bang_py/characters/pat_brennan.py
+++ b/bang_py/characters/pat_brennan.py
@@ -16,7 +16,6 @@ class PatBrennan(BaseCharacter):
     )
     starting_health = 4
 
-
     def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
         player.metadata.abilities.add(PatBrennan)
 

--- a/bang_py/characters/pedro_ramirez.py
+++ b/bang_py/characters/pedro_ramirez.py
@@ -17,7 +17,6 @@ class PedroRamirez(BaseCharacter):
     )
     starting_health = 4
 
-
     def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
         player.metadata.abilities.add(PedroRamirez)
 

--- a/bang_py/characters/pixie_pete.py
+++ b/bang_py/characters/pixie_pete.py
@@ -14,7 +14,6 @@ class PixiePete(BaseCharacter):
     description = "During your draw phase, draw three cards instead of two."
     starting_health = 4
 
-
     def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
         player.metadata.abilities.add(PixiePete)
 


### PR DESCRIPTION
## Summary
- allow 100 char lines in flake8 config
- keep single blank line before nested functions in character abilities

## Testing
- `flake8 bang_py/characters --select=E303`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6877edee9a18832398603640e1b63fde