### PR TITLE
Improve docstrings

### DIFF
--- a/bang_py/__init__.py
+++ b/bang_py/__init__.py
@@ -1,4 +1,4 @@
-"""Bang card game modules"""
+"""Bang card game modules."""
 
 from .game_manager import GameManager
 from .deck_factory import create_standard_deck

--- a/bang_py/cards/events/peyote.py
+++ b/bang_py/cards/events/peyote.py
@@ -9,8 +9,10 @@ if TYPE_CHECKING:
 
 
 class PeyoteEventCard(BaseEventCard):
-    """During their draw phase, each player guesses red or black. They reveal the
-    top card; if correct they repeat until wrong."""
+    """During their draw phase, each player guesses red or black.
+
+    They reveal the top card; if correct they repeat until wrong.
+    """
 
     card_name = "Peyote"
     card_set = "fistful_of_cards"

--- a/bang_py/cards/events/vendetta.py
+++ b/bang_py/cards/events/vendetta.py
@@ -9,8 +9,9 @@ if TYPE_CHECKING:
 
 
 class VendettaEventCard(BaseEventCard):
-    """At the end of their turn, each player draws! On a heart, they may play
-    another turn. They cannot benefit again."""
+    """At the end of their turn, each player draws! On a heart, they may play another turn.
+    They cannot benefit again.
+    """
 
     card_name = "Vendetta"
     card_set = "fistful_of_cards"

--- a/bang_py/game_manager.py
+++ b/bang_py/game_manager.py
@@ -1,3 +1,5 @@
+"""Manage overall game state and turn progression for Bang."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field
@@ -63,8 +65,10 @@ from .event_decks import (
 
 @dataclass
 class GameManager:
-    """Manage players, deck and discard pile while controlling turn order and
-    triggering game events."""
+    """Manage players, deck and discard pile.
+
+    Controls turn order and triggers game events.
+    """
 
     players: List[Player] = field(default_factory=list)
     deck: Deck | None = None

--- a/bang_py/player.py
+++ b/bang_py/player.py
@@ -1,3 +1,5 @@
+"""Player representation and related helper data for Bang."""
+
 from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Dict, List, TYPE_CHECKING
@@ -119,6 +121,7 @@ class Player:
 
     @property
     def gun_range(self) -> int:
+        """Return the base firing range provided by the equipped gun."""
         game = self.metadata.game
         if getattr(game, "event_flags", {}).get("lasso"):
             return 1
@@ -190,7 +193,6 @@ class Player:
     @staticmethod
     def _seated_distance(player: "Player", other: "Player", players: List["Player"]) -> int:
         """Return the seat distance between two players counting only the living."""
-
         alive = [p for p in players if p.is_alive()]
         p_index = alive.index(player)
         o_index = alive.index(other)
@@ -198,10 +200,13 @@ class Player:
         return min(diff, len(alive) - diff)
 
     def take_damage(self, amount: int) -> None:
+        """Decrease health but not below zero."""
         self.health = max(0, self.health - amount)
 
     def heal(self, amount: int) -> None:
+        """Restore health up to ``max_health``."""
         self.health = min(self.max_health, self.health + amount)
 
     def is_alive(self) -> bool:
+        """Return ``True`` if the player still has health remaining."""
         return self.health > 0


### PR DESCRIPTION
## Summary
- add module docs to `player` and `game_manager`
- document range and health helpers in `Player`
- tidy `GameManager` class docstring formatting
- standardize wording for Peyote and Vendetta event cards
- tweak package docstring

## Testing
- `pytest -q`
- `pydocstyle bang_py | head -n 5`

------
https://chatgpt.com/codex/tasks/task_e_68780e7170ec83238566436104b579a5