### PR TITLE
Add Windows build workflow

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -1,0 +1,28 @@
+name: Windows Executable
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build-exe:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+      - name: Build executable
+        run: |
+          make build-exe
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: bang-exe
+          path: dist/bang.exe

--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ from the command line:
 ```cmd
 bang.exe
 ```
+A GitHub Actions workflow builds this executable for each tagged release and
+provides `bang.exe` as a download artifact.
+
 
 ## Characters
 


### PR DESCRIPTION
## Summary
- build a Windows executable via PyInstaller in CI
- mention that the workflow publishes bang.exe

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6876f739b51c8323851f3b375368e87f