### PR TITLE
Attach Windows exe to releases

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -26,3 +26,8 @@ jobs:
         with:
           name: bang-exe
           path: dist/bang.exe
+      - name: Attach to release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v1
+        with:
+          files: dist/bang.exe

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ from the command line:
 bang.exe
 ```
 A GitHub Actions workflow builds this executable for each tagged release and
-provides `bang.exe` as a download artifact.
+automatically attaches `bang.exe` to the release as a downloadable asset.
 
 
 ## Characters


### PR DESCRIPTION
## Summary
- automatically attach the built executable to tagged releases
- mention this auto attachment in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878b2bd06ec832397b3509557136e29