### PR TITLE
Fix pyinstaller launch

### DIFF
--- a/bang_py/ui.py
+++ b/bang_py/ui.py
@@ -10,6 +10,13 @@ import logging
 import websockets
 from websockets import WebSocketException
 
+if __package__ in {None, ""}:
+    from pathlib import Path
+    import sys
+
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    __package__ = "bang_py"
+
 from .network.server import BangServer
 
 


### PR DESCRIPTION
## Summary
- add dynamic path adjustment in `bang_py.ui` so pyinstaller-built executables
  can resolve package relative imports

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878b36e939883238566e5dcc7705799