### PR TITLE
Fix release permissions

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -6,6 +6,9 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: write
+
 jobs:
   build-exe:
     runs-on: windows-latest

--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ from the command line:
 bang.exe
 ```
 A GitHub Actions workflow builds this executable for each tagged release and
-automatically attaches `bang.exe` to the release as a downloadable asset.
+automatically attaches `bang.exe` to the release as a downloadable asset. The workflow
+needs the `contents: write` permission (or a PAT) to upload the file.
 
 
 ## Characters


### PR DESCRIPTION
## Summary
- grant `contents: write` permission for Windows release workflow
- clarify permission requirement in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878b5a7ae008323b51540c673de745e