### PR TITLE
Fix PyInstaller entrypoint

### DIFF
--- a/bang.spec
+++ b/bang.spec
@@ -2,7 +2,7 @@
 
 
 a = Analysis(
-    ['bang_py/ui.py'],
+    ['pyinstaller_entry.py'],
     pathex=[],
     binaries=[],
     datas=[],

--- a/pyinstaller_entry.py
+++ b/pyinstaller_entry.py
@@ -1,0 +1,4 @@
+from bang_py.ui import main
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add an entry script so PyInstaller runs the UI package
- update `bang.spec` to use the new entry file

## Testing
- `pytest -q`
- `make build-exe`
- `./dist/bang --help` *(fails: no display name and no $DISPLAY environment variable)*


------
https://chatgpt.com/codex/tasks/task_e_6878b7b188f483239d8ac8d566844566