### PR TITLE
Fix shutdown in Tkinter UI

### DIFF
--- a/bang_py/ui.py
+++ b/bang_py/ui.py
@@ -787,6 +787,9 @@ class BangUI:
             self.server_thread.stop()
             self.server_thread.join(timeout=1)
             self.server_thread = None
+        # Quit the mainloop before destroying the root window to ensure
+        # any pending events are processed and the application exits cleanly.
+        self.root.quit()
         self.root.destroy()
 
     def run(self) -> None:


### PR DESCRIPTION
## Summary
- quit Tkinter mainloop before destroying root window

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878be4aef2c83239cb29a3db910c424