### PR TITLE
Update game board rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,14 @@ Once connected you will see:
 1. A list of players with their current health and any equipped items.
 2. A log area for game messages.
 3. Buttons representing the cards in your hand that can be clicked to play them.
+4. A board canvas showing the draw deck and discard pile.
 
 Use the **End Turn** button or press the configured key (default `e`) when you are
 finished. Win or elimination messages are shown both in the log and as a popup
 dialog.
+
+The card backs and small heart icons are generated at runtime so the GUI does not
+require any external image files.
 
 ## Building a Windows Executable
 

--- a/bang_py/ui.py
+++ b/bang_py/ui.py
@@ -347,6 +347,16 @@ class BangUI:
         )
         self.board_canvas.grid(row=1, column=1, padx=10, pady=10)
 
+        # Draw a simple green table background
+        self.board_canvas.create_oval(5, 5, 295, 195, fill="forestgreen", outline="")
+
+        # Draw the draw deck and discard pile using the generated card image
+        self.board_canvas.create_image(90, 100, image=self.card_image)
+        self.board_canvas.create_text(90, 160, text="Draw", fill="white")
+
+        self.board_canvas.create_image(210, 100, image=self.card_image)
+        self.board_canvas.create_text(210, 160, text="Discard", fill="white")
+
         positions = [
             (0, 1),
             (1, 2),


### PR DESCRIPTION
## Summary
- render a small draw/discard setup on the board canvas
- document runtime-generated images used by the GUI

## Testing
- `pytest -q`
- `python -m bang_py.ui` *(fails: no $DISPLAY available)*

------
https://chatgpt.com/codex/tasks/task_e_6878cb8a2f7483239bb6ec34cd8a5595