### PR TITLE
Remove UnknownRoleCard

### DIFF
--- a/bang_py/network/server.py
+++ b/bang_py/network/server.py
@@ -40,7 +40,7 @@ def _serialize_players(players: List[Player]) -> List[dict]:
         {
             "name": p.name,
             "health": p.health,
-            "role": p.role.card_name,
+            "role": "" if p.role is None else p.role.card_name,
             "equipment": [eq.card_name for eq in p.equipment.values()],
         }
         for p in players

--- a/bang_py/player.py
+++ b/bang_py/player.py
@@ -56,7 +56,7 @@ class PlayerMetadata:
 @dataclass
 class Player:
     name: str
-    role: BaseRole = field(default_factory=OutlawRoleCard)
+    role: BaseRole | None = None
     character: "BaseCharacter | None" = None
     max_health: int = 4
     health: int = field(init=False)

--- a/tests/test_network_serialization.py
+++ b/tests/test_network_serialization.py
@@ -1,11 +1,11 @@
 import json
 from bang_py.player import Player
-from bang_py.cards.roles import SheriffRoleCard
+from bang_py.cards.roles import SheriffRoleCard, OutlawRoleCard
 from bang_py.network.server import _serialize_players
 
 
 def test_serialize_players_json_roundtrip():
-    players = [Player("Alice"), Player("Bob", role=SheriffRoleCard())]
+    players = [Player("Alice", role=OutlawRoleCard()), Player("Bob", role=SheriffRoleCard())]
     assert players[0].max_health == 4
     assert players[1].max_health == 5
     serialized = _serialize_players(players)


### PR DESCRIPTION
## Summary
- drop `UnknownRoleCard` placeholder role
- simplify player serialization for missing roles

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6878d062715483238b01a6c5b090a291