### PR TITLE
Ensure players join lobby without role

### DIFF
--- a/bang_py/network/server.py
+++ b/bang_py/network/server.py
@@ -15,7 +15,6 @@ except ModuleNotFoundError:  # pragma: no cover - handled in start()
 
 from ..game_manager import GameManager
 from ..player import Player
-from ..cards.roles import OutlawRoleCard
 from ..characters.jesse_jones import JesseJones
 from ..characters.jose_delgado import JoseDelgado
 from ..characters.kit_carlson import KitCarlson
@@ -102,7 +101,7 @@ class BangServer:
             await websocket.send("Game full")
             return
 
-        player = Player(name, role=OutlawRoleCard())
+        player = Player(name)
         player.metadata.auto_miss = True
         self.game.add_player(player)
         self.connections[websocket] = Connection(websocket, player)

--- a/tests/test_network_integration.py
+++ b/tests/test_network_integration.py
@@ -31,6 +31,8 @@ def test_server_client_play_flow() -> None:
 
                 assert len(server.game.players) == 2
                 alice, bob = server.game.players[0], server.game.players[1]
+                assert alice.role is None
+                assert bob.role is None
                 alice.health = 1
                 bob.hand.append(BangCard())
 

--- a/tests/test_network_serialization.py
+++ b/tests/test_network_serialization.py
@@ -39,3 +39,16 @@ def test_serialize_players_with_health_changes():
             "equipment": [],
         }
     ]
+
+
+def test_serialize_players_without_role():
+    player = Player("Alice")
+    data = _serialize_players([player])
+    assert data == [
+        {
+            "name": "Alice",
+            "health": player.health,
+            "role": "",
+            "equipment": [],
+        }
+    ]


### PR DESCRIPTION
## Summary
- stop giving players an Outlaw role when connecting over the network
- update network integration test to confirm no role is set when players join
- add serialization test for players without roles

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68793c5823b88323825bdf0d56d1d798