### PR TITLE
Remove unused JPEG backgrounds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,3 +17,7 @@ when making changes.
 
 ## Pull Requests
 - Summarize key changes and mention test results in the PR body.
+
+The JPEG files `example-bang-menu-ui.jpg` and `example_bang_ui.jpg` located in
+the repository root are provided only as reference screenshots. They should not
+be loaded or otherwise used by the application code.

--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ dialog.
 The card backs and small heart icons are generated at runtime so the GUI does not
 require any external image files.
 
+Two JPEGs, `example-bang-menu-ui.jpg` and `example_bang_ui.jpg`, live in the
+repository root. They are only screenshots demonstrating a possible layout and
+are **not** loaded by the program.
+
 ## Building a Windows Executable
 
 `pyinstaller` can bundle the UI into a standalone Windows executable. Install the

--- a/bang_py/game_manager.py
+++ b/bang_py/game_manager.py
@@ -1388,11 +1388,11 @@ class GameManager:
     def _determine_winner(self, alive: List[Player], has_sheriff: bool) -> Optional[str]:
         """Return a victory message if a win condition is met."""
         if not has_sheriff and len(self.players) == 3:
-            if len(alive) == 1:
+            if len(alive) == 1 and alive[0].role:
                 return alive[0].role.victory_message
             return None
         for player in alive:
-            if player.role.check_win(self, player):
+            if player.role and player.role.check_win(self, player):
                 return player.role.victory_message
         return None
 


### PR DESCRIPTION
## Summary
- add note in AGENTS.md not to load example images
- clarify in README that JPEG screenshots are reference-only
- guard against missing player roles in `GameManager`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6879495ef950832382b3063afc7167ba