### PR TITLE
Add PySide6 and update PyInstaller spec

### DIFF
--- a/bang.spec
+++ b/bang.spec
@@ -1,12 +1,13 @@
 # -*- mode: python ; coding: utf-8 -*-
 
+from PyInstaller.utils.hooks import collect_dynamic_libs, collect_submodules
 
 a = Analysis(
     ['pyinstaller_entry.py'],
     pathex=[],
-    binaries=[],
+    binaries=collect_dynamic_libs('PySide6'),
     datas=[],
-    hiddenimports=[],
+    hiddenimports=collect_submodules('PySide6'),
     hookspath=[],
     hooksconfig={},
     runtime_hooks=[],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ license = {file = "LICENSE"}
 requires-python = ">=3.10"
 dependencies = [
     "websockets>=10.0",
+    "PySide6>=6.5",
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 websockets>=10.0
 pyinstaller>=5.6
+PySide6>=6.5


### PR DESCRIPTION
## Summary
- depend on PySide6 6.5+
- include PySide6 Qt libraries in PyInstaller build

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687954a0db3083238291dcfcd524075f