### PR TITLE
Update CI to install Qt dependencies

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -11,8 +11,13 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.11'
+      - name: Install system packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libxcb-cursor0 libxkbcommon-x11-0
       - name: Install dependencies
         run: |
+          pip install PySide6
           pip install -e .
           pip install pytest
       - name: Run tests


### PR DESCRIPTION
## Summary
- add step to install system packages for Qt on CI
- explicitly install PySide6 before the repo
- confirm `pip install -e .` works and `pytest` passes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68795ac6deec83239e837962d91716cb