### PR TITLE
Improve Qt UI state handling

### DIFF
--- a/tests/test_qt_ui.py
+++ b/tests/test_qt_ui.py
@@ -1,4 +1,5 @@
 import os
+import json
 
 import pytest
 
@@ -20,4 +21,23 @@ def qt_app():
 def test_bang_ui_creation(qt_app):
     ui = BangUI()
     assert ui.windowTitle() == "Bang!"
+    ui.close()
+
+
+def test_broadcast_state_updates_ui(qt_app):
+    ui = BangUI()
+    ui._build_game_view()
+    state = {
+        "players": [
+            {"name": "Alice", "health": 4, "role": "Sheriff", "equipment": []},
+            {"name": "Bob", "health": 3, "role": "Outlaw", "equipment": []},
+        ],
+        "hand": ["Bang", "Missed"],
+        "character": "Test",
+        "event": "",
+    }
+    ui._append_message(json.dumps(state))
+    assert ui.player_list.count() == 2
+    assert ui.board.players == state["players"]
+    assert ui.hand_layout.count() == 2
     ui.close()


### PR DESCRIPTION
## Summary
- parse JSON messages in UI and update board and hand
- add simple card widgets to send actions
- show general prompts and player info
- test broadcast_state integration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68795c93e8a8832383f06067235f616a