### PR TITLE
Use screen dimensions for board

### DIFF
--- a/bang_py/ui.py
+++ b/bang_py/ui.py
@@ -131,8 +131,14 @@ class GameBoard(QtWidgets.QGraphicsView):
         self.setRenderHint(QtGui.QPainter.Antialiasing)
         self._scene = QtWidgets.QGraphicsScene(self)
         self.setScene(self._scene)
-        self.max_width = 800
-        self.max_height = 600
+        screen = QtGui.QGuiApplication.primaryScreen()
+        if screen is not None:
+            geom = screen.availableGeometry()
+            self.max_width = geom.width()
+            self.max_height = geom.height()
+        else:
+            self.max_width = 800
+            self.max_height = 600
         self.card_width = 60
         self.card_height = 90
         self.card_pixmap = self._create_card_pixmap()

--- a/tests/test_qt_ui.py
+++ b/tests/test_qt_ui.py
@@ -3,8 +3,8 @@ import json
 
 import pytest
 
-from bang_py.ui import BangUI
-from PySide6 import QtWidgets
+from bang_py.ui import BangUI, GameBoard
+from PySide6 import QtWidgets, QtCore, QtGui
 
 
 @pytest.fixture
@@ -41,3 +41,17 @@ def test_broadcast_state_updates_ui(qt_app):
     assert ui.board.players == state["players"]
     assert ui.hand_layout.count() == 2
     ui.close()
+
+
+def test_gameboard_uses_available_geometry(qt_app, monkeypatch):
+    rect = QtCore.QRect(0, 0, 1234, 987)
+
+    class DummyScreen:
+        def availableGeometry(self):
+            return rect
+
+    monkeypatch.setattr(QtGui.QGuiApplication, "primaryScreen", lambda: DummyScreen())
+    board = GameBoard()
+    assert board.max_width == rect.width()
+    assert board.max_height == rect.height()
+    board.close()


### PR DESCRIPTION
## Summary
- size board using the available screen geometry
- test that GameBoard uses QScreen dimensions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68795e91bd788323a92ec199d2083d5e