### PR TITLE
Ensure UI cleanup and binary exit

### DIFF
--- a/bang_py/ui.py
+++ b/bang_py/ui.py
@@ -4,6 +4,7 @@ import logging
 import math
 import secrets
 from pathlib import Path
+import os
 
 from PySide6 import QtCore, QtGui, QtWidgets
 import websockets
@@ -457,6 +458,7 @@ class BangUI(QtWidgets.QMainWindow):
             self.server_thread.stop()
             self.server_thread.wait(1000)
             self.server_thread = None
+        QtWidgets.QApplication.quit()
         super().closeEvent(event)
 
 
@@ -464,6 +466,8 @@ def main() -> None:
     app = QtWidgets.QApplication([])
     ui = BangUI()
     ui.show()
+    if os.getenv("BANG_AUTO_CLOSE"):
+        QtCore.QTimer.singleShot(100, ui.close)
     app.exec()
 
 

--- a/tests/test_bang_executable.py
+++ b/tests/test_bang_executable.py
@@ -1,0 +1,14 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_bang_executable_exits(tmp_path):
+    subprocess.run(["make", "build-exe"], check=True)
+    exe = Path("dist/bang.exe" if sys.platform.startswith("win") else "dist/bang")
+    env = os.environ.copy()
+    env["QT_QPA_PLATFORM"] = "offscreen"
+    env["BANG_AUTO_CLOSE"] = "1"
+    proc = subprocess.run([str(exe)], env=env, timeout=10)
+    assert proc.returncode == 0


### PR DESCRIPTION
## Summary
- quit QApplication in `BangUI.closeEvent`
- allow auto-closing the UI via `BANG_AUTO_CLOSE` for tests
- verify packaged executable exits cleanly

## Testing
- `pytest tests/test_bang_executable.py::test_bang_executable_exits -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879622c1ed4832390149d62bec47a26