### PR TITLE
Fix tests by installing PyInstaller

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -18,6 +18,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install PySide6
+          pip install pyinstaller
           pip install -e .
           pip install pytest
       - name: Run tests


### PR DESCRIPTION
## Summary
- ensure PyInstaller is installed in CI

## Testing
- `pytest tests/test_bang_executable.py::test_bang_executable_exits -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68796b42bd14832390c9e7f207531703