### PR TITLE
Ensure cleanup after bang executable test

### DIFF
--- a/tests/test_bang_executable.py
+++ b/tests/test_bang_executable.py
@@ -2,13 +2,20 @@ import os
 import subprocess
 import sys
 from pathlib import Path
+import shutil
 
 
 def test_bang_executable_exits(tmp_path):
-    subprocess.run(["make", "build-exe"], check=True)
-    exe = Path("dist/bang.exe" if sys.platform.startswith("win") else "dist/bang")
-    env = os.environ.copy()
-    env["QT_QPA_PLATFORM"] = "offscreen"
-    env["BANG_AUTO_CLOSE"] = "1"
-    proc = subprocess.run([str(exe)], env=env, timeout=10)
-    assert proc.returncode == 0
+    try:
+        subprocess.run(["make", "build-exe"], check=True)
+        exe = Path(
+            "dist/bang.exe" if sys.platform.startswith("win") else "dist/bang"
+        )
+        env = os.environ.copy()
+        env["QT_QPA_PLATFORM"] = "offscreen"
+        env["BANG_AUTO_CLOSE"] = "1"
+        proc = subprocess.run([str(exe)], env=env, timeout=10)
+        assert proc.returncode == 0
+    finally:
+        shutil.rmtree("build", ignore_errors=True)
+        shutil.rmtree("dist", ignore_errors=True)


### PR DESCRIPTION
## Summary
- clean up `build/` and `dist/` in `test_bang_executable_exits`

## Testing
- `pytest tests/test_bang_executable.py::test_bang_executable_exits -vv`
- `PATH=/root/.pyenv/shims:/root/.pyenv/bin:/bin pytest tests/test_bang_executable.py::test_bang_executable_exits -vv` *(fails)*

------
https://chatgpt.com/codex/tasks/task_e_68796f92daa083238cd12821f5e53c4c