### PR TITLE
Fix PySide6 import issues in tests

### DIFF
--- a/tests/test_bang_executable.py
+++ b/tests/test_bang_executable.py
@@ -4,7 +4,11 @@ import sys
 from pathlib import Path
 import shutil
 
+import pytest
 
+
+@pytest.mark.skipif(shutil.which("pyinstaller") is None,
+                    reason="pyinstaller not installed")
 def test_bang_executable_exits(tmp_path):
     try:
         subprocess.run(["make", "build-exe"], check=True)

--- a/tests/test_qt_ui.py
+++ b/tests/test_qt_ui.py
@@ -3,8 +3,10 @@ import json
 
 import pytest
 
-from bang_py.ui import BangUI, GameBoard
+pytest.importorskip("PySide6")
+
 from PySide6 import QtWidgets, QtCore, QtGui
+from bang_py.ui import BangUI, GameBoard
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- skip UI tests if PySide6 isn't installed
- skip executable build test if pyinstaller isn't available

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879b3f64bf483238d9c0486a7abc4d1