### PR TITLE
Fix PySide6 tests by installing libegl

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install system packages
         run: |
           sudo apt-get update
-          sudo apt-get install -y libxcb-cursor0 libxkbcommon-x11-0
+          sudo apt-get install -y libxcb-cursor0 libxkbcommon-x11-0 libegl1
       - name: Install dependencies
         run: |
           pip install -r requirements.txt


### PR DESCRIPTION
## Summary
- update system packages in CI to include `libegl1`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879baa32db08323ab866244ebe7a366