### PR TITLE
Encapsulate player internals

### DIFF
--- a/bang_py/game_manager.py
+++ b/bang_py/game_manager.py
@@ -464,7 +464,7 @@ class GameManager:
         if not jail:
             return True
         if self.event_flags.get("no_jail"):
-            player.equipment.pop("Jail", None)
+            player.unequip("Jail")
             self.discard_pile.append(jail)
             return True
         if getattr(jail, "check_turn", None):


### PR DESCRIPTION
## Summary
- introduce read-only properties for `metadata`, `equipment`, and `health`
- use private backing fields inside `Player`
- remove direct mutation of equipment when clearing Jail

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a992ae2b08323acae5584f98e596e