### PR TITLE
Add rank/suit icon loader

### DIFF
--- a/bang_py/__init__.py
+++ b/bang_py/__init__.py
@@ -27,6 +27,7 @@ from .characters.slab_the_killer import SlabTheKiller
 from .characters.suzy_lafayette import SuzyLafayette
 from .characters.vulture_sam import VultureSam
 from .characters.willy_the_kid import WillyTheKid
+from .helpers import RankSuitIconLoader
 
 __all__ = [
     "GameManager",
@@ -55,6 +56,7 @@ __all__ = [
     "VultureSam",
     "WillyTheKid",
     "create_standard_deck",
+    "RankSuitIconLoader",
 ]
 try:
     from .network.server import BangServer

--- a/bang_py/helpers.py
+++ b/bang_py/helpers.py
@@ -4,7 +4,13 @@ from .cards.card import BaseCard
 from .player import Player
 from .characters.base import BaseCharacter
 from .characters.vera_custer import VeraCuster
+from pathlib import Path
 from typing import TYPE_CHECKING, Type
+
+try:  # Qt is optional for non-UI use
+    from PySide6 import QtCore, QtGui, QtSvg
+except Exception:  # pragma: no cover - Qt may not be installed
+    QtCore = QtGui = QtSvg = None  # type: ignore
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from .game_manager import GameManager
@@ -48,3 +54,69 @@ def handle_out_of_turn_discard(game: "GameManager", player: Player, card: BaseCa
         return
     if player.character and hasattr(player.character, "on_out_of_turn_discard"):
         player.character.on_out_of_turn_discard(game, player, card)
+
+
+class RankSuitIconLoader:
+    """Return ``QPixmap`` fragments for ranks and suits from the SVG sheet."""
+
+    _rank_order = ["A", "2", "3", "4", "5", "6", "7", "8", "9", "10", "J", "Q", "K"]
+    _suit_order = ["Clubs", "Hearts", "Spades", "Diamonds"]
+
+    def __init__(self, svg_path: str | None = None) -> None:
+        if QtGui is None or QtSvg is None:
+            raise ImportError("PySide6 is required for RankSuitIconLoader")
+        if svg_path is None:
+            svg_path = str(Path(__file__).with_name("assets") / "ranks_and_suits_sheet.svg")
+        self.svg_path = svg_path
+        self.cell_w = 64
+        self.cell_h = 89
+        self.sheet_w = self.cell_w * 13
+        self.sheet_h = self.cell_h * 4
+        self._sheet = self._load_sheet()
+        self._cache: dict[tuple[str, str], QtGui.QPixmap] = {}
+
+    def _load_sheet(self) -> QtGui.QPixmap:
+        renderer = QtSvg.QSvgRenderer(self.svg_path)
+        pixmap = QtGui.QPixmap(self.sheet_w, self.sheet_h)
+        pixmap.fill(QtCore.Qt.transparent)
+        painter = QtGui.QPainter(pixmap)
+        renderer.render(painter)
+        painter.end()
+        return pixmap
+
+    def _norm_rank(self, rank: int | str) -> str:
+        if isinstance(rank, int):
+            if rank == 1:
+                return "A"
+            if 2 <= rank <= 10:
+                return str(rank)
+            if rank == 11:
+                return "J"
+            if rank == 12:
+                return "Q"
+            if rank == 13:
+                return "K"
+            raise ValueError(f"Invalid rank: {rank}")
+        return rank.upper()
+
+    def get_pixmap(self, rank: int | str, suit: str) -> QtGui.QPixmap:
+        """Return an icon for ``rank`` and ``suit`` from the SVG sheet."""
+
+        rank_str = self._norm_rank(rank)
+        suit_name = suit.capitalize()
+        key = (rank_str, suit_name)
+        if key in self._cache:
+            return self._cache[key]
+
+        try:
+            col = self._rank_order.index(rank_str)
+        except ValueError as exc:  # pragma: no cover - checked via norm_rank
+            raise ValueError(f"Unknown rank {rank}") from exc
+        try:
+            row = self._suit_order.index(suit_name)
+        except ValueError as exc:
+            raise ValueError(f"Unknown suit {suit}") from exc
+
+        pix = self._sheet.copy(col * self.cell_w, row * self.cell_h, self.cell_w, self.cell_h)
+        self._cache[key] = pix
+        return pix

--- a/tests/test_icon_loader.py
+++ b/tests/test_icon_loader.py
@@ -1,0 +1,25 @@
+import os
+import pytest
+
+pytest.importorskip("PySide6")
+from PySide6 import QtWidgets, QtGui
+from bang_py.helpers import RankSuitIconLoader
+
+
+@pytest.fixture
+def qt_app():
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    app = QtWidgets.QApplication.instance()
+    created = app is None
+    if created:
+        app = QtWidgets.QApplication([])
+    yield app
+    if created:
+        app.quit()
+
+
+def test_loader_returns_pixmap(qt_app):
+    loader = RankSuitIconLoader()
+    pix = loader.get_pixmap("A", "Hearts")
+    assert isinstance(pix, QtGui.QPixmap)
+    assert not pix.isNull()


### PR DESCRIPTION
## Summary
- provide `RankSuitIconLoader` to grab card rank+ suit icons from the SVG sprite
- expose the class via `bang_py.__init__`
- test that a pixmap is returned when Qt is available

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c25993c9083239e73f60f4257076d