### PR TITLE
Handle optional websockets in UI threads

### DIFF
--- a/bang_py/ui_components/network_threads.py
+++ b/bang_py/ui_components/network_threads.py
@@ -4,9 +4,18 @@ import asyncio
 import json
 import logging
 
+from typing import Any
+
 from PySide6 import QtCore
-import websockets
-from websockets import WebSocketException
+
+try:  # Optional websockets import for test environments
+    import websockets
+    from websockets import WebSocketException
+    WebSocketClientProtocol = websockets.WebSocketClientProtocol
+except ModuleNotFoundError:  # pragma: no cover - handled in _run()
+    websockets = None  # type: ignore[assignment]
+    WebSocketException = Exception  # type: ignore[assignment]
+    WebSocketClientProtocol = Any  # type: ignore[assignment]
 
 from ..network.server import BangServer
 
@@ -56,7 +65,7 @@ class ClientThread(QtCore.QThread):
         self.room_code = room_code
         self.name = name
         self.loop = asyncio.new_event_loop()
-        self.websocket: websockets.WebSocketClientProtocol | None = None
+        self.websocket: WebSocketClientProtocol | None = None
 
     def run(self) -> None:  # type: ignore[override]
         asyncio.set_event_loop(self.loop)
@@ -75,6 +84,11 @@ class ClientThread(QtCore.QThread):
             self.loop.call_soon_threadsafe(self.loop.stop)
 
     async def _run(self) -> None:
+        if websockets is None:
+            msg = "websockets package is required for networking"
+            logging.error(msg)
+            self.message_received.emit(msg)
+            return
         try:
             self.websocket = await websockets.connect(self.uri)
             await self.websocket.recv()


### PR DESCRIPTION
## Summary
- avoid ImportError in network_threads by making websockets optional
- show a helpful message if websockets isn't installed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d358b13888323914de3a86314f72e