### PR TITLE
Upgrade PyInstaller requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ screenshots and are **not** used by the program.
 ## Building a Windows Executable
 
 `pyinstaller` can bundle the UI into a standalone Windows executable. Install the
-build dependencies and run the target:
+build dependencies (PyInstaller 6.2 or newer) and run the target:
 
 ```bash
 pip install -r requirements.txt

--- a/pyinstaller_entry.py
+++ b/pyinstaller_entry.py
@@ -1,4 +1,13 @@
+import os
+from pathlib import Path
+
+import PySide6
 from bang_py.ui import main
+
+if "QT_QPA_PLATFORM_PLUGIN_PATH" not in os.environ:
+    os.environ["QT_QPA_PLATFORM_PLUGIN_PATH"] = str(
+        Path(PySide6.__file__).resolve().with_name("Qt") / "plugins"
+    )
 
 if __name__ == "__main__":
     main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 websockets>=10.0
-pyinstaller>=5.6
+pyinstaller>=6.2
 PySide6>=6.5


### PR DESCRIPTION
## Summary
- bump PyInstaller to 6.2
- document new version requirement in README
- ensure PySide plugins load by setting `QT_QPA_PLATFORM_PLUGIN_PATH` in `pyinstaller_entry.py`

## Testing
- `CI=true pytest -q`
- `make build-exe`

------
https://chatgpt.com/codex/tasks/task_e_687d3e91113c8323b272c7a24ab6d4df