### PR TITLE
Improve client fallback when websockets missing

### DIFF
--- a/bang_py/network/client.py
+++ b/bang_py/network/client.py
@@ -1,6 +1,10 @@
 import asyncio
 import json
-import websockets
+
+try:  # Optional websockets import for test environments
+    import websockets
+except ModuleNotFoundError:  # pragma: no cover - handled in main()
+    websockets = None  # type: ignore[assignment]
 
 
 async def main(
@@ -24,6 +28,10 @@ async def main(
     Incoming messages are parsed as JSON when possible and printed to the
     console along with the list of players.
     """
+    if websockets is None:
+        print("websockets package is required for networking")
+        return
+
     async with websockets.connect(uri) as websocket:
         prompt = await websocket.recv()
         print(prompt)

--- a/tests/test_network_client.py
+++ b/tests/test_network_client.py
@@ -1,0 +1,19 @@
+import builtins
+import importlib
+import sys
+
+
+def test_client_import_without_websockets(monkeypatch):
+    """Client module should import even if websockets is missing."""
+    original_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "websockets":
+            raise ModuleNotFoundError
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    sys.modules.pop("bang_py.network.client", None)
+
+    module = importlib.import_module("bang_py.network.client")
+    assert module.websockets is None


### PR DESCRIPTION
## Summary
- make `bang_py.network.client` import websockets optionally
- show an error message and exit if websockets isn't present
- add unit test confirming the client module loads without websockets

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d4581561c8323b68f3030240cd048