### PR TITLE
Update Python version to 3.13

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: '3.13'
       - name: Install system packages
         run: |
           sudo apt-get update

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: '3.13'
       - name: Install dependencies
         run: |
           pip install -r requirements.txt

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ websocket server, and a Qt-based interface. To maintain consistency, follow
 these rules when making changes.
 
 ## Development
-- Use Python 3.10+.
+ - Use Python 3.13+.
 - After modifying code, run `pytest` from the repository root to ensure tests
   pass.
 - Keep tests deterministic. If randomness is needed, seed the RNG inside the tests or offer hooks to bypass shuffling.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Bang card game with optional websocket server and Qt UI"
 authors = [{name = "Unknown"}]
 readme = "README.md"
 license = {file = "LICENSE"}
-requires-python = ">=3.10"
+requires-python = ">=3.13"
 dependencies = [
     "websockets>=10.0",
     "PySide6>=6.5",


### PR DESCRIPTION
## Summary
- require Python 3.13+ in project metadata
- update agent guidelines for Python 3.13
- use Python 3.13 in CI workflows

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d4ac7d0648323972927aeda063607