### PR TITLE
Fix PyInstaller test with Qt app initialization

### DIFF
--- a/bang_py/ui.py
+++ b/bang_py/ui.py
@@ -239,7 +239,9 @@ class BangUI(QtWidgets.QMainWindow):
 
 def main() -> None:
     """Start the Qt interface."""
-    app = QtWidgets.QApplication([])
+    app = QtWidgets.QApplication.instance()
+    if app is None:
+        app = QtWidgets.QApplication([])
     ui = BangUI()
     ui.showMaximized()
     if os.getenv("BANG_AUTO_CLOSE"):

--- a/pyinstaller_entry.py
+++ b/pyinstaller_entry.py
@@ -1,7 +1,13 @@
 import os
 from pathlib import Path
 
+from PySide6 import QtWidgets
 import PySide6
+
+app = QtWidgets.QApplication.instance()
+if app is None:
+    app = QtWidgets.QApplication([])
+
 from bang_py.ui import main
 
 if "QT_QPA_PLATFORM_PLUGIN_PATH" not in os.environ:


### PR DESCRIPTION
## Summary
- ensure QApplication exists before using Qt GUI helpers
- initialize Qt app early in PyInstaller entry script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d51c97ea0832394c4410692083451