### PR TITLE
Return players as read-only sequence

### DIFF
--- a/bang_py/game_manager.py
+++ b/bang_py/game_manager.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Callable, List, Optional
+from typing import Callable, List, Optional, Sequence
 import random
 
 from .deck import Deck
@@ -111,9 +111,9 @@ class GameManager:
     _duel_counts: dict | None = field(default=None, init=False, repr=False)
 
     @property
-    def players(self) -> List[Player]:
-        """List of players in turn order."""
-        return self._players
+    def players(self) -> Sequence[Player]:
+        """Players in turn order as a read-only sequence."""
+        return tuple(self._players)
 
     def prompt_new_identity(self, player: Player) -> bool:
         """Return True if the player opts to switch characters."""

--- a/bang_py/network/server.py
+++ b/bang_py/network/server.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 import secrets
 from dataclasses import dataclass
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Sequence
 import logging
 
 try:  # Optional websockets import for test environments
@@ -33,7 +33,7 @@ class Connection:
     player: Player
 
 
-def _serialize_players(players: List[Player]) -> List[dict]:
+def _serialize_players(players: Sequence[Player]) -> List[dict]:
     """Return minimal player info for the UI."""
     return [
         {

--- a/bang_py/player.py
+++ b/bang_py/player.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 from dataclasses import dataclass, field
 from types import MappingProxyType
-from typing import Dict, List, TYPE_CHECKING
+from typing import Dict, List, Sequence, TYPE_CHECKING
 
 from .cards.roles import (
     BaseRole,
@@ -211,7 +211,7 @@ class Player:
         return max(1, distance)
 
     @staticmethod
-    def _seated_distance(player: "Player", other: "Player", players: List["Player"]) -> int:
+    def _seated_distance(player: "Player", other: "Player", players: Sequence["Player"]) -> int:
         """Return the seat distance between two players counting only the living."""
         alive = [p for p in players if p.is_alive()]
         p_index = alive.index(player)


### PR DESCRIPTION
## Summary
- expose `GameManager.players` as a tuple instead of the internal list
- adjust type hints in `server` and `player` modules
- keep tests passing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d65f9a8588323a33459ad812956fb