### PR TITLE
Use logging in network client/server

### DIFF
--- a/bang_py/network/client.py
+++ b/bang_py/network/client.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import logging
 
 try:  # Optional websockets import for test environments
     import websockets
@@ -29,23 +30,23 @@ async def main(
     console along with the list of players.
     """
     if websockets is None:
-        print("websockets package is required for networking")
+        logging.error("websockets package is required for networking")
         return
 
     async with websockets.connect(uri) as websocket:
         prompt = await websocket.recv()
-        print(prompt)
+        logging.info(prompt)
         await websocket.send(room_code)
         response = await websocket.recv()
         if response != "Enter your name:":
-            print(response)
+            logging.info(response)
             return
-        print(response)
+        logging.info(response)
         if name is None:
             name = input()
         await websocket.send(name)
         join_msg = await websocket.recv()
-        print(join_msg)
+        logging.info(join_msg)
 
         async for message in websocket:
             try:
@@ -55,10 +56,10 @@ async def main(
             if isinstance(data, dict):
                 msg = data.get("message")
                 if msg:
-                    print(msg)
-                print("Players:", data.get("players"))
+                    logging.info(msg)
+                logging.info("Players: %s", data.get("players"))
             else:
-                print(data)
+                logging.info(str(data))
 
 
 def run() -> None:

--- a/bang_py/network/server.py
+++ b/bang_py/network/server.py
@@ -511,8 +511,11 @@ class BangServer:
                 "websockets package is required to run the server"
             )
         async with serve(self.handler, self.host, self.port):
-            print(
-                f"Server started on {self.host}:{self.port} (code: {self.room_code})"
+            logger.info(
+                "Server started on %s:%s (code: %s)",
+                self.host,
+                self.port,
+                self.room_code,
             )
             await asyncio.Future()  # run forever
 


### PR DESCRIPTION
## Summary
- use the `logging` module in the console client and server
- drop all remaining `print()` calls

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d6840e8408323bb2d6745394965ee