### PR TITLE
Add module docstrings for menu dialogs

### DIFF
--- a/bang_py/ui_components/host_join_dialog.py
+++ b/bang_py/ui_components/host_join_dialog.py
@@ -2,6 +2,12 @@ from __future__ import annotations
 
 from PySide6 import QtCore, QtWidgets
 
+"""Dialog widgets for hosting or joining a game.
+
+Defines :class:`HostJoinDialog` that collects the network information
+needed to start or join a game room.
+"""
+
 
 class HostJoinDialog(QtWidgets.QDialog):
     """Dialog for hosting or joining a game."""

--- a/bang_py/ui_components/start_menu.py
+++ b/bang_py/ui_components/start_menu.py
@@ -2,6 +2,12 @@ from __future__ import annotations
 
 from PySide6 import QtCore, QtWidgets
 
+"""Widgets for the initial menu.
+
+Contains :class:`StartMenu` which asks for the player's name and offers
+buttons to host or join a game or open settings.
+"""
+
 
 class StartMenu(QtWidgets.QWidget):
     """Main menu with options to host or join a game."""


### PR DESCRIPTION
## Summary
- document StartMenu widget module
- document HostJoinDialog module

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d7024209c83238688f5ad24219f14