### PR TITLE
Refactor CardImageLoader template selection

### DIFF
--- a/bang_py/ui_components/card_images.py
+++ b/bang_py/ui_components/card_images.py
@@ -86,19 +86,23 @@ class CardImageLoader:
 
     @staticmethod
     def _template_for(card_type: str, card_set: str | None) -> str:
-        if card_type == "blue":
-            return "blue"
-        if card_type == "green":
-            return "green"
-        if card_type == "character":
-            return "character"
-        if card_type == "role":
-            return "role"
-        if card_type == "event":
-            if card_set == "fistful_of_cards":
+        """Return template name based on card ``type`` and ``set``."""
+
+        match (card_type, card_set):
+            case ("event", "fistful_of_cards"):
                 return "fistful"
-            return "high_noon"
-        return "brown"
+            case ("event", _):
+                return "high_noon"
+            case ("blue", _):
+                return "blue"
+            case ("green", _):
+                return "green"
+            case ("character", _):
+                return "character"
+            case ("role", _):
+                return "role"
+            case _:
+                return "brown"
 
 
 card_image_loader = CardImageLoader(*DEFAULT_SIZE)


### PR DESCRIPTION
## Summary
- use Python `match` statement in `_template_for` to make card template selection clearer

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d7108e8c88323b0956ac52539f126