### PR TITLE
Enable dataclass slots for Player objects

### DIFF
--- a/bang_py/player.py
+++ b/bang_py/player.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from .game_manager import GameManager
 
 
-@dataclass
+@dataclass(slots=True)
 class PlayerMetadata:
     """State information associated with a player."""
 
@@ -54,7 +54,7 @@ class PlayerMetadata:
     beer_heal_bonus: int = 0
 
 
-@dataclass
+@dataclass(slots=True)
 class Player:
     name: str
     role: BaseRole | None = None


### PR DESCRIPTION
## Summary
- use `dataclass(slots=True)` for `PlayerMetadata` and `Player`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d73e82400832384296504a40a79c7