### PR TITLE
Improve networking docs and asset loading

### DIFF
--- a/bang_py/network/client.py
+++ b/bang_py/network/client.py
@@ -1,3 +1,5 @@
+"""Console client for connecting to a Bang websocket server."""
+
 import asyncio
 import json
 import logging

--- a/bang_py/network/server.py
+++ b/bang_py/network/server.py
@@ -1,3 +1,5 @@
+"""Websocket server implementation for hosting a Bang game."""
+
 import asyncio
 import json
 import secrets
@@ -329,7 +331,7 @@ class BangServer:
         ) -> None:
             try:
                 await conn.websocket.send(json.dumps(payload))
-            except Exception as exc:
+            except (OSError, WebSocketException, asyncio.CancelledError) as exc:
                 logger.exception(
                     "Failed to send state to %s", conn.player.name, exc_info=exc
                 )
@@ -337,7 +339,7 @@ class BangServer:
                 # longer reachable before dropping the connection entirely.
                 try:
                     await conn.websocket.close()
-                except Exception as close_exc:
+                except (OSError, WebSocketException) as close_exc:
                     logger.exception(
                         "Error closing websocket for %s",
                         conn.player.name,

--- a/bang_py/ui_components/card_images.py
+++ b/bang_py/ui_components/card_images.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from pathlib import Path
+from importlib import resources
 from typing import Dict, Tuple
 
 from PySide6 import QtCore, QtGui
@@ -13,7 +13,7 @@ except Exception:  # pragma: no cover - optional dependency
 from ..helpers import RankSuitIconLoader
 
 DEFAULT_SIZE = (60, 90)
-ASSETS_DIR = Path(__file__).resolve().parents[1] / "assets"
+ASSETS_DIR = resources.files("bang_py") / "assets"
 
 _TEMPLATE_FILES = {
     "blue": "template_blue.png",
@@ -53,7 +53,8 @@ class CardImageLoader:
         templates: Dict[str, QtGui.QPixmap] = {}
         for key, fname in _TEMPLATE_FILES.items():
             path = ASSETS_DIR / fname
-            pix = QtGui.QPixmap(str(path))
+            with resources.as_file(path) as file_path:
+                pix = QtGui.QPixmap(str(file_path))
             if pix.isNull():
                 pix = cls._fallback_pixmap(width, height)
             else:

--- a/bang_py/ui_components/game_view.py
+++ b/bang_py/ui_components/game_view.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 import math
-from pathlib import Path
+from importlib import resources
 
 from PySide6 import QtCore, QtGui, QtWidgets
 
 from .card_images import card_image_loader
 
-ASSETS_DIR = Path(__file__).resolve().parents[1] / "assets"
+ASSETS_DIR = resources.files("bang_py") / "assets"
 BULLET_PATH = ASSETS_DIR / "bullet.png"
 
 
@@ -30,7 +30,8 @@ class GameBoard(QtWidgets.QGraphicsView):
         self.card_width = 60
         self.card_height = 90
         self.card_pixmap = self._create_card_pixmap()
-        self.bullet_pixmap = QtGui.QPixmap(str(BULLET_PATH)).scaled(
+        with resources.as_file(BULLET_PATH) as bullet_path:
+            self.bullet_pixmap = QtGui.QPixmap(str(bullet_path)).scaled(
             20,
             10,
             QtCore.Qt.KeepAspectRatio,

--- a/bang_py/ui_components/network_threads.py
+++ b/bang_py/ui_components/network_threads.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+"""Qt threads for running the Bang server and client in the background."""
+
 import asyncio
 import json
 import logging
@@ -78,7 +80,7 @@ class ClientThread(QtCore.QThread):
                                                    self.loop)
             try:
                 fut.result(timeout=1)
-            except Exception as exc:  # noqa: BLE001
+            except (asyncio.TimeoutError, Exception) as exc:  # noqa: BLE001
                 logging.exception("Failed to close websocket: %s", exc)
         if self.loop.is_running():
             self.loop.call_soon_threadsafe(self.loop.stop)


### PR DESCRIPTION
## Summary
- document networking client/server modules
- describe background thread module
- use `importlib.resources` for asset paths
- narrow networking exception handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c23b6e718832385925593d47792bb