### PR TITLE
Use PyInstaller directly in Windows workflow

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -23,7 +23,7 @@ jobs:
           pip install -r requirements.txt
       - name: Build executable
         run: |
-          make build-exe
+          pyinstaller bang.spec
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- tweak `windows-build.yml` to run `pyinstaller bang.spec` directly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d8698be3c832396a527dc3b3dc3da