### PR TITLE
Fix Windows build workflow

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -17,10 +17,11 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.13'
+          python-version: '3.13-dev'
       - name: Install dependencies
         run: |
-          pip install -r requirements.txt
+          python -m pip install -r requirements.txt
+          python -m pip install pyinstaller
       - name: Build executable
         run: |
           pyinstaller bang.spec


### PR DESCRIPTION
## Summary
- use Python `3.13-dev` instead of unsupported `3.13`
- install `pyinstaller` explicitly before building the executable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d8e5cbe408323b7e0f9472b9cb03c