### PR TITLE
Fix Windows CI Python version

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.13-dev'
+          python-version: '3.12'
       - name: Install dependencies
         run: |
           python -m pip install -r requirements.txt


### PR DESCRIPTION
## Summary
- avoid failing Windows builds by using Python 3.12 instead of the dev branch

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687d9537d8b48323bc04ba7ff9374064