### PR TITLE
Delay card image loader until after QApplication

### DIFF
--- a/bang_py/ui_components/card_images.py
+++ b/bang_py/ui_components/card_images.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 from importlib import resources
-from typing import Dict, Tuple
+from typing import Dict
 
-from PySide6 import QtCore, QtGui
+from PySide6 import QtCore, QtGui, QtWidgets
 
 try:
     from PySide6 import QtSvg  # type: ignore
@@ -106,5 +106,21 @@ class CardImageLoader:
                 return "brown"
 
 
-card_image_loader = CardImageLoader(*DEFAULT_SIZE)
+_card_image_loader: CardImageLoader | None = None
+
+
+def get_loader() -> CardImageLoader:
+    """Return a cached :class:`CardImageLoader` instance.
+
+    The loader is created lazily after a ``QApplication`` exists to avoid
+    issues with Qt objects being instantiated before the application.
+    """
+
+    if QtWidgets.QApplication.instance() is None:
+        raise RuntimeError("QApplication must be instantiated before using CardImageLoader")
+
+    global _card_image_loader
+    if _card_image_loader is None:
+        _card_image_loader = CardImageLoader(*DEFAULT_SIZE)
+    return _card_image_loader
 

--- a/bang_py/ui_components/game_view.py
+++ b/bang_py/ui_components/game_view.py
@@ -5,7 +5,7 @@ from importlib import resources
 
 from PySide6 import QtCore, QtGui, QtWidgets
 
-from .card_images import card_image_loader
+from .card_images import get_loader
 
 ASSETS_DIR = resources.files("bang_py") / "assets"
 BULLET_PATH = ASSETS_DIR / "bullet.png"
@@ -51,7 +51,8 @@ class GameBoard(QtWidgets.QGraphicsView):
     ) -> QtGui.QPixmap:
         w = width or self.card_width
         h = height or self.card_height
-        return card_image_loader.get_template("brown").scaled(
+        loader = get_loader()
+        return loader.get_template("brown").scaled(
             w, h, QtCore.Qt.KeepAspectRatio, QtCore.Qt.SmoothTransformation
         )
 
@@ -148,7 +149,8 @@ class CardButton(QtWidgets.QPushButton):
         self.customContextMenuRequested.connect(self._context_menu)
         self.clicked.connect(self._play)
 
-        pix = card_image_loader.compose_card(card_type, rank, suit, card_set)
+        loader = get_loader()
+        pix = loader.compose_card(card_type, rank, suit, card_set)
         if not pix.isNull():
             self.setIcon(QtGui.QIcon(pix))
             self.setIconSize(QtCore.QSize(pix.width(), pix.height()))


### PR DESCRIPTION
## Summary
- lazy-init the card image loader only after a QApplication exists
- switch `game_view` to use `get_loader()` when creating card images

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d97e4a1708323ae84b137119583fe