### PR TITLE
Set Python 3.13-dev in CI

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.13'
+          python-version: '3.13-dev'
       - name: Install system packages
         run: |
           sudo apt-get update

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.12'
+          python-version: '3.13-dev'
       - name: Install dependencies
         run: |
           python -m pip install -r requirements.txt


### PR DESCRIPTION
## Summary
- switch both CI workflows to use Python 3.13-dev

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d848479e08323a98fd1c10bb58a5b