### PR TITLE
Add table and card back images

### DIFF
--- a/bang_py/ui_components/card_images.py
+++ b/bang_py/ui_components/card_images.py
@@ -15,6 +15,12 @@ from ..helpers import RankSuitIconLoader
 DEFAULT_SIZE = (60, 90)
 ASSETS_DIR = resources.files("bang_py") / "assets"
 
+_CARD_BACK_FILES = {
+    "other": "other_card_back.png",
+    "character": "character_card_back.png",
+    "role": "role_card_back.png",
+}
+
 _TEMPLATE_FILES = {
     "blue": "template_blue.png",
     "brown": "template_brown.png",
@@ -33,6 +39,7 @@ class CardImageLoader:
         self.width = width
         self.height = height
         self.templates = self._load_templates(width, height)
+        self.card_backs = self._load_card_backs(width, height)
         self.rank_loader = RankSuitIconLoader()
 
     @staticmethod
@@ -62,8 +69,33 @@ class CardImageLoader:
             templates[key] = pix
         return templates
 
+    @classmethod
+    def _load_card_backs(
+        cls, width: int, height: int
+    ) -> Dict[str, QtGui.QPixmap]:
+        backs: Dict[str, QtGui.QPixmap] = {}
+        for key, fname in _CARD_BACK_FILES.items():
+            path = ASSETS_DIR / fname
+            with resources.as_file(path) as file_path:
+                pix = QtGui.QPixmap(str(file_path))
+            if pix.isNull():
+                pix = cls._fallback_pixmap(width, height)
+            else:
+                pix = pix.scaled(
+                    width,
+                    height,
+                    QtCore.Qt.KeepAspectRatio,
+                    QtCore.Qt.SmoothTransformation,
+                )
+            backs[key] = pix
+        return backs
+
     def get_template(self, name: str) -> QtGui.QPixmap:
         return self.templates.get(name, self._fallback_pixmap(self.width, self.height))
+
+    def get_card_back(self, name: str) -> QtGui.QPixmap:
+        """Return a card back pixmap for ``name``."""
+        return self.card_backs.get(name, self._fallback_pixmap(self.width, self.height))
 
     def compose_card(
         self,

--- a/bang_py/ui_components/game_view.py
+++ b/bang_py/ui_components/game_view.py
@@ -9,6 +9,7 @@ from .card_images import get_loader
 
 ASSETS_DIR = resources.files("bang_py") / "assets"
 BULLET_PATH = ASSETS_DIR / "bullet.png"
+TABLE_PATH = ASSETS_DIR / "table.png"
 
 
 class GameBoard(QtWidgets.QGraphicsView):
@@ -30,6 +31,14 @@ class GameBoard(QtWidgets.QGraphicsView):
         self.card_width = 60
         self.card_height = 90
         self.card_pixmap = self._create_card_pixmap()
+        self.character_pixmap = self._create_card_pixmap(back_type="character")
+        with resources.as_file(TABLE_PATH) as table_path:
+            self.table_pixmap = QtGui.QPixmap(str(table_path)).scaled(
+                self.max_width,
+                self.max_height,
+                QtCore.Qt.KeepAspectRatioByExpanding,
+                QtCore.Qt.SmoothTransformation,
+            )
         with resources.as_file(BULLET_PATH) as bullet_path:
             self.bullet_pixmap = QtGui.QPixmap(str(bullet_path)).scaled(
             20,
@@ -47,27 +56,24 @@ class GameBoard(QtWidgets.QGraphicsView):
         self.fitInView(self._scene.sceneRect(), QtCore.Qt.KeepAspectRatio)
 
     def _create_card_pixmap(
-        self, width: int | None = None, height: int | None = None
+        self,
+        width: int | None = None,
+        height: int | None = None,
+        back_type: str = "other",
     ) -> QtGui.QPixmap:
         w = width or self.card_width
         h = height or self.card_height
         loader = get_loader()
-        return loader.get_template("brown").scaled(
+        return loader.get_card_back(back_type).scaled(
             w, h, QtCore.Qt.KeepAspectRatio, QtCore.Qt.SmoothTransformation
         )
 
     def _draw_board(self) -> None:
         self._scene.clear()
         self._scene.setSceneRect(0, 0, self.max_width, self.max_height)
-        table = self._scene.addEllipse(
-            5,
-            5,
-            self.max_width - 10,
-            self.max_height - 10,
-            QtGui.QPen(),
-            QtGui.QBrush(QtGui.QColor("saddlebrown")),
-        )
+        table = self._scene.addPixmap(self.table_pixmap)
         table.setZValue(-1)
+        table.setPos(0, 0)
         center_x = self.max_width / 2
         draw_x = center_x - self.card_width * 1.5
         draw_y = self.max_height * 0.5
@@ -106,7 +112,7 @@ class GameBoard(QtWidgets.QGraphicsView):
                 ang = math.radians((i - idx) * angle_step + 90)
                 x = center_x + radius * math.cos(ang) - self.card_width / 2
                 y = center_y + radius * math.sin(ang) - self.card_height / 2
-                self._scene.addPixmap(self.card_pixmap).setPos(x, y)
+                self._scene.addPixmap(self.character_pixmap).setPos(x, y)
 
                 bullet_y = y + self.card_height
                 spacing = 2

--- a/tests/test_card_image_loader.py
+++ b/tests/test_card_image_loader.py
@@ -36,3 +36,13 @@ def test_compose_card_returns_pixmap(card_type, kwargs, qt_app):
     pix = loader.compose_card(card_type, **kwargs)
     assert isinstance(pix, QtGui.QPixmap)
     assert not pix.isNull()
+
+
+@pytest.mark.parametrize("name", ["other", "role", "character"])
+def test_get_card_back_returns_pixmap(name, qt_app):
+    from bang_py.ui_components.card_images import CardImageLoader
+
+    loader = CardImageLoader()
+    pix = loader.get_card_back(name)
+    assert isinstance(pix, QtGui.QPixmap)
+    assert not pix.isNull()

--- a/tests/test_qt_ui.py
+++ b/tests/test_qt_ui.py
@@ -93,3 +93,11 @@ def test_gameboard_bullets(qt_app):
     assert "Health: 3" in tooltips
     assert "Health: 2" in tooltips
     board.close()
+
+
+def test_gameboard_table_pixmap(qt_app):
+    from bang_py.ui_components.game_view import GameBoard
+
+    board = GameBoard()
+    assert not board.table_pixmap.isNull()
+    board.close()


### PR DESCRIPTION
## Summary
- display table.png as the board background
- load new card back images for other, character and role decks
- show character card backs for players on the board
- expose `get_card_back` helper and add tests
- test that the board loads the table image

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f0c8cbe50832389db5d5e5dc4db75