### PR TITLE
Add SSL support for server and clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,22 @@ bang-server
 
 This starts a websocket server on `ws://localhost:8765`.
 
+### Secure connections
+
+Pass `--certfile` and `--keyfile` to start the server with TLS:
+
+```bash
+bang-server --certfile server.pem --keyfile server.key
+```
+
+Use the `wss://` scheme when connecting and provide the CA file if needed:
+
+```bash
+bang-client wss://localhost:8765 --cafile ca.pem
+```
+
+The Qt interface exposes these paths in the host and join dialogs.
+
 ## Connecting a client
 
 ```bash

--- a/bang_py/ui_components/host_join_dialog.py
+++ b/bang_py/ui_components/host_join_dialog.py
@@ -23,15 +23,21 @@ class HostJoinDialog(QtWidgets.QDialog):
         if mode == "host":
             self.port_edit = QtWidgets.QLineEdit("8765")
             self.max_players_edit = QtWidgets.QLineEdit("7")
+            self.cert_edit = QtWidgets.QLineEdit()
+            self.key_edit = QtWidgets.QLineEdit()
             layout.addRow("Host Port:", self.port_edit)
             layout.addRow("Max Players:", self.max_players_edit)
+            layout.addRow("Certificate:", self.cert_edit)
+            layout.addRow("Key File:", self.key_edit)
         else:
             self.addr_edit = QtWidgets.QLineEdit("localhost")
             self.port_edit = QtWidgets.QLineEdit("8765")
             self.code_edit = QtWidgets.QLineEdit()
+            self.cafile_edit = QtWidgets.QLineEdit()
             layout.addRow("Host Address:", self.addr_edit)
             layout.addRow("Port:", self.port_edit)
             layout.addRow("Room Code:", self.code_edit)
+            layout.addRow("CA File:", self.cafile_edit)
 
         buttons = QtWidgets.QDialogButtonBox(
             QtWidgets.QDialogButtonBox.Ok | QtWidgets.QDialogButtonBox.Cancel

--- a/tests/test_network_integration.py
+++ b/tests/test_network_integration.py
@@ -1,8 +1,10 @@
 import asyncio
 import json
+import ssl
 
 import pytest
 from bang_py.network.server import BangServer
+import trustme
 from bang_py.cards.bang import BangCard
 
 websockets = pytest.importorskip("websockets")
@@ -42,5 +44,41 @@ def test_server_client_play_flow() -> None:
                 data = json.loads(await ws2.recv())
                 assert "eliminated" in data["message"]
                 assert not alice.is_alive()
+
+asyncio.run(run_flow())
+
+
+def test_server_client_ssl(tmp_path) -> None:
+    ca = trustme.CA()
+    server_cert = ca.issue_cert("localhost")
+    cert = tmp_path / "cert.pem"
+    key = tmp_path / "key.pem"
+    ca_file = tmp_path / "ca.pem"
+    server_cert.cert_chain_pems[0].write_to_path(cert)
+    server_cert.private_key_pem.write_to_path(key)
+    ca.cert_pem.write_to_path(ca_file)
+
+    server = BangServer(
+        host="localhost",
+        port=8768,
+        room_code="2222",
+        certfile=str(cert),
+        keyfile=str(key),
+    )
+
+    async def run_flow() -> None:
+        ssl_client = ssl.create_default_context(cafile=str(ca_file))
+        async with websockets.serve(
+            server.handler, server.host, server.port, ssl=server.ssl_context
+        ):
+            async with websockets.connect(
+                "wss://localhost:8768", ssl=ssl_client
+            ) as ws:
+                await ws.recv()
+                await ws.send("2222")
+                await ws.recv()
+                await ws.send("Alice")
+                msg = await ws.recv()
+                assert "Joined game" in msg
 
     asyncio.run(run_flow())


### PR DESCRIPTION
## Summary
- add `certfile` and `keyfile` arguments to `BangServer`
- pass SSL context to `websockets.serve`
- update command-line client and server to accept SSL options
- connect with SSL in Qt network threads
- expose certificate fields in host/join dialogs
- document secure connections in README
- test secure websocket connections using `trustme`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f1912fa1c8323ab4af1e410b2c313