### PR TITLE
Add message size limit and tests

### DIFF
--- a/bang_py/network/server.py
+++ b/bang_py/network/server.py
@@ -29,6 +29,9 @@ from ..cards.general_store import GeneralStoreCard
 
 logger = logging.getLogger(__name__)
 
+# Maximum allowed size for incoming websocket messages
+MAX_MESSAGE_SIZE = 4096
+
 
 @dataclass
 class Connection:
@@ -121,6 +124,9 @@ class BangServer:
 
         try:
             async for message in websocket:
+                if len(message) > MAX_MESSAGE_SIZE:
+                    await websocket.close(code=1009, reason="Message too large")
+                    break
                 await self._process_message(websocket, message)
         finally:
             self.game.remove_player(player)


### PR DESCRIPTION
## Summary
- guard websocket messages in `BangServer` to reject oversized payloads
- add regression tests for oversized or malformed messages

## Testing
- `pytest tests/test_network_messages.py -q`
- `pytest -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_687f1f51c6e8832381daf05f5338dfe0