### PR TITLE
Fix websocket send task cleanup

### DIFF
--- a/tests/test_server_task_cleanup.py
+++ b/tests/test_server_task_cleanup.py
@@ -1,0 +1,24 @@
+import asyncio
+import pytest
+
+from bang_py.network.server import BangServer
+
+websockets = pytest.importorskip("websockets")
+
+
+def test_disconnect_cleans_tasks(capsys) -> None:
+    async def run_flow() -> None:
+        server = BangServer(host="localhost", port=8789, room_code="3333")
+        async with websockets.serve(server.handler, server.host, server.port):
+            async with websockets.connect("ws://localhost:8789") as ws:
+                await ws.recv()
+                await ws.send("3333")
+                await ws.recv()
+                await ws.send("Alice")
+                await ws.recv()
+                await ws.recv()
+        await asyncio.sleep(0)
+
+    asyncio.run(run_flow())
+    captured = capsys.readouterr()
+    assert "Task was destroyed but it is pending" not in captured.err


### PR DESCRIPTION
## Summary
- manage send tasks in server with explicit cancellation
- store tasks on each websocket connection
- cancel connection tasks when a websocket disconnects
- add regression test ensuring pending tasks are cleaned up

## Testing
- `pytest tests/test_server_task_cleanup.py -q`
- `pytest -q` *(fails to run all tests within time, but partial log shows 15 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_687f2876be7c832382202664d3959815