### PR TITLE
Add theme support and QML prototypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ PyQt/PySide. It offers smoother graphics using ``QGraphicsView`` and a flexible
 layout. The main window starts maximized and you can press ``F11`` to toggle
 true full-screen mode. The log now appears in a floating dock that can be
 dragged anywhere or docked to the sides of the window.
+Experimental QML scenes for the menu and board are available under
+``bang_py/qml``.
 
 Install the Qt requirements first (PySide6 6.9.1 or newer):
 
@@ -62,6 +64,9 @@ bang-ui
 
 Set `BANG_AUTO_CLOSE=1` to automatically close the window. This is mainly useful
 for automated tests.
+
+Set `BANG_THEME=dark` to enable a dark interface or choose the theme from the
+**Settings** dialog at runtime.
 
 Enter your name and choose **Host Game** or **Join Game**. Hosting launches a
 local server and shows a room code to share with friends. The host screen lets

--- a/bang_py/qml/GameBoard.qml
+++ b/bang_py/qml/GameBoard.qml
@@ -1,0 +1,20 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+Item {
+    width: 800
+    height: 600
+
+    Rectangle {
+        id: table
+        anchors.fill: parent
+        color: "#006400"
+    }
+
+    Text {
+        anchors.centerIn: parent
+        text: "Board Prototype"
+        color: "white"
+        font.pointSize: 20
+    }
+}

--- a/bang_py/qml/MainMenu.qml
+++ b/bang_py/qml/MainMenu.qml
@@ -1,0 +1,23 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+Rectangle {
+    width: 400
+    height: 300
+    color: "#333333"
+
+    Column {
+        anchors.centerIn: parent
+        spacing: 10
+
+        Text {
+            text: "Bang!"
+            font.pointSize: 24
+            color: "white"
+        }
+
+        Button { text: "Host Game" }
+        Button { text: "Join Game" }
+        Button { text: "Settings" }
+    }
+}

--- a/bang_py/theme.py
+++ b/bang_py/theme.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+"""Utility functions for styling the Qt interface."""
+
+import os
+
+DEFAULT_THEME = "light"
+
+
+def get_current_theme() -> str:
+    """Return the theme specified by ``BANG_THEME`` or the default."""
+    return os.getenv("BANG_THEME", DEFAULT_THEME)
+
+
+def get_stylesheet(theme: str) -> str:
+    """Return a Qt stylesheet string for the requested theme."""
+    if theme == "dark":
+        return (
+            """
+            QWidget {
+                background-color: #2b2b2b;
+                color: #dddddd;
+                font-family: "Segoe UI";
+                font-size: 16px;
+            }
+            QPushButton {
+                background-color: #444444;
+                border: 2px solid #888888;
+                min-width: 80px;
+                max-width: 150px;
+            }
+            QLineEdit {
+                background-color: #3c3c3c;
+                color: #ffffff;
+            }
+            """
+        )
+    return (
+        """
+        QWidget {
+            background-color: #deb887;
+            color: #000000;
+            font-family: "Segoe UI";
+            font-size: 16px;
+        }
+        QPushButton {
+            background-color: #f4a460;
+            border: 2px solid #8b4513;
+            min-width: 80px;
+            max-width: 150px;
+        }
+        QLineEdit {
+            background-color: #fff8dc;
+            color: #000000;
+        }
+        """
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,4 +24,5 @@ bang-ui = "bang_py.ui:main"
 "bang_py" = [
     "assets/*.png",
     "assets/*.svg",
+    "qml/*.qml",
 ]

--- a/tests/test_qt_ui.py
+++ b/tests/test_qt_ui.py
@@ -101,3 +101,12 @@ def test_gameboard_table_pixmap(qt_app):
     board = GameBoard()
     assert not board.table_pixmap.isNull()
     board.close()
+
+
+def test_dark_theme_from_env(qt_app, monkeypatch):
+    monkeypatch.setenv("BANG_THEME", "dark")
+    from bang_py.ui import BangUI
+
+    ui = BangUI()
+    assert "#2b2b2b" in ui.styleSheet()
+    ui.close()


### PR DESCRIPTION
## Summary
- introduce `theme.py` with light and dark styles
- add a settings dialog and theme handling in the Qt UI
- embed prototype QML scenes for the menu and board
- include QML files in packaging and document new theme option
- test that the UI respects the `BANG_THEME` environment variable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f2ecf3cf483238b613d938ffcbf0c