### PR TITLE
Install PySide6 in CI

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -17,6 +17,7 @@ jobs:
           sudo apt-get install -y libxcb-cursor0 libxkbcommon-x11-0 libegl1
       - name: Install dependencies
         run: |
+          pip install "PySide6>=6.9.1" --pre
           pip install -r requirements.txt
           pip install -e .
           pip install pytest

--- a/tests/test_card_image_loader.py
+++ b/tests/test_card_image_loader.py
@@ -1,7 +1,7 @@
 import os
 import pytest
 
-pytest.importorskip("PySide6")
+pytest.importorskip("PySide6", reason="PySide6 not installed; skipping GUI tests")
 
 from PySide6 import QtWidgets, QtGui
 

--- a/tests/test_icon_loader.py
+++ b/tests/test_icon_loader.py
@@ -1,7 +1,7 @@
 import os
 import pytest
 
-pytest.importorskip("PySide6")
+pytest.importorskip("PySide6", reason="PySide6 not installed; skipping GUI tests")
 from PySide6 import QtWidgets, QtGui
 from bang_py.helpers import RankSuitIconLoader
 

--- a/tests/test_qt_ui.py
+++ b/tests/test_qt_ui.py
@@ -3,7 +3,7 @@ import json
 
 import pytest
 
-pytest.importorskip("PySide6")
+pytest.importorskip("PySide6", reason="PySide6 not installed; skipping GUI tests")
 
 from PySide6 import QtWidgets, QtCore, QtGui  # noqa: E402
 


### PR DESCRIPTION
## Summary
- install PySide6 in the GitHub Actions workflow
- explain skip reason for GUI-dependent tests when PySide6 is unavailable

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_687fe1f547f08323875e0c828c6eedae