### PR TITLE
Refactor GameView to QML

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,10 @@ This networking layer is experimental and only demonstrates joining the game and
 ## Graphical Interface
 
 The original Tkinter UI has been replaced with a Qt interface written for
-PyQt/PySide. It offers smoother graphics using ``QGraphicsView`` and QML
-components. The main window starts maximized and you can press ``F11`` to
-toggle true full-screen mode. The log now appears in a floating dock that can
-be dragged anywhere or docked to the sides of the window. The main menu and
-game board are now rendered from the QML scenes in ``bang_py/qml``.
+PyQt/PySide. The game board, player list and log panel are now layered directly
+inside ``GameBoard.qml`` using QML items. The main window starts maximized and
+you can press ``F11`` to toggle true full-screen mode. Both the main menu and
+the game board are rendered from the QML scenes in ``bang_py/qml``.
 
 Install the Qt requirements first (PySide6 6.9.1 or newer):
 

--- a/bang_py/qml/GameBoard.qml
+++ b/bang_py/qml/GameBoard.qml
@@ -5,6 +5,8 @@ Item {
     id: root
     property string theme: "light"
     property real scale: 1.0
+    property var players: []
+    property alias logText: logArea.text
     width: 800 * scale
     height: 600 * scale
 
@@ -19,5 +21,44 @@ Item {
         text: "Board Prototype"
         color: theme === "dark" ? "white" : "black"
         font.pointSize: 20
+    }
+
+    ListView {
+        id: playerList
+        width: 200 * scale
+        anchors.top: parent.top
+        anchors.bottom: parent.bottom
+        anchors.left: parent.left
+        model: players
+        delegate: Row {
+            spacing: 4
+            Text { text: name }
+            Repeater {
+                model: health
+                delegate: Rectangle {
+                    width: 8 * scale
+                    height: 8 * scale
+                    color: "red"
+                }
+            }
+        }
+    }
+
+    Rectangle {
+        id: logPanel
+        width: parent.width * 0.35
+        height: parent.height * 0.3
+        anchors.right: parent.right
+        anchors.bottom: parent.bottom
+        color: theme === "dark" ? "#000000" : "#ffffff"
+        opacity: 0.7
+
+        TextArea {
+            id: logArea
+            anchors.fill: parent
+            readOnly: true
+            wrapMode: TextArea.WrapAnywhere
+            background: Rectangle { color: "transparent" }
+        }
     }
 }

--- a/tests/test_qt_ui.py
+++ b/tests/test_qt_ui.py
@@ -55,8 +55,9 @@ def test_broadcast_state_updates_ui(qt_app):
         "event": "",
     }
     ui._append_message(json.dumps(state))
-    assert ui.player_list.count() == 2
-    assert ui.board.players == state["players"]
+    root = ui.game_root
+    assert root is not None
+    assert root.property("players") == state["players"]
     assert ui.hand_layout.count() == 2
     ui.close()
 


### PR DESCRIPTION
## Summary
- move player list and log panel into `GameBoard.qml`
- simplify `GameView` so it only loads the QML board
- update `BangUI` to work with the redesigned scene
- adjust tests for the new API
- document the QML board layout

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ff8d500588323b1ad0f6700dd3097