### PR TITLE
Add encrypted join token

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ bang-client wss://localhost:8765 --cafile ca.pem
 
 The Qt interface exposes these paths in the host and join dialogs.
 
+### Join tokens
+
+Running ``bang-server --show-token`` prints an encrypted string containing the
+host, port and room code. Start the Qt UI or ``bang-client`` with ``--token`` to
+join automatically.
+
 ## Connecting a client
 
 ```bash

--- a/bang_py/ui_components/host_join_dialog.py
+++ b/bang_py/ui_components/host_join_dialog.py
@@ -12,7 +12,9 @@ needed to start or join a game room.
 class HostJoinDialog(QtWidgets.QDialog):
     """Dialog for hosting or joining a game."""
 
-    def __init__(self, mode: str = "host", parent: QtWidgets.QWidget | None = None) -> None:
+    def __init__(
+        self, mode: str = "host", parent: QtWidgets.QWidget | None = None
+    ) -> None:
         super().__init__(parent)
         self.mode = mode
         self.setWindowTitle("Host Game" if mode == "host" else "Join Game")
@@ -33,7 +35,9 @@ class HostJoinDialog(QtWidgets.QDialog):
             self.addr_edit = QtWidgets.QLineEdit("localhost")
             self.port_edit = QtWidgets.QLineEdit("8765")
             self.code_edit = QtWidgets.QLineEdit()
+            self.token_edit = QtWidgets.QLineEdit()
             self.cafile_edit = QtWidgets.QLineEdit()
+            layout.addRow("Token:", self.token_edit)
             layout.addRow("Host Address:", self.addr_edit)
             layout.addRow("Port:", self.port_edit)
             layout.addRow("Room Code:", self.code_edit)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ requires-python = ">=3.13"
 dependencies = [
     "websockets>=15.0.1",
     "PySide6>=6.9.1",
+    "cryptography>=42.0.5",
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 websockets>=15.0.1
 pyinstaller>=6.14.2
 PySide6>=6.9.1
+cryptography>=42.0.5

--- a/tests/test_join_token.py
+++ b/tests/test_join_token.py
@@ -1,0 +1,23 @@
+import pytest
+
+from bang_py.network.server import (
+    generate_join_token,
+    parse_join_token,
+    DEFAULT_TOKEN_KEY,
+)
+from cryptography.fernet import InvalidToken
+
+
+def test_generate_and_parse_token():
+    token = generate_join_token("host", 1234, "code", DEFAULT_TOKEN_KEY)
+    host, port, code = parse_join_token(token, DEFAULT_TOKEN_KEY)
+    assert host == "host"
+    assert port == 1234
+    assert code == "code"
+
+
+def test_token_invalid_key():
+    token = generate_join_token("host", 1, "c", DEFAULT_TOKEN_KEY)
+    bad_key = b"fh-IQhdbcUCrWTWyQ7WcM5VqCPU-ixXvSawvMkE415Q="
+    with pytest.raises(InvalidToken):
+        parse_join_token(token, bad_key)


### PR DESCRIPTION
## Summary
- support encrypted join tokens for networking
- handle join tokens in Qt join menu and console client
- document token workflow
- add tests for token encoding and decoding
- include cryptography dependency

## Testing
- `pytest -q`
- `pytest tests/test_join_token.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688c33ca846c83239ccdee15a5f8f9ab