### PR TITLE
Update testing docs and skip PySide6-dependent tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,20 @@ A GitHub Actions workflow builds this executable for each tagged release and
 automatically attaches `bang.exe` to the release as a downloadable asset. The workflow
 needs the `contents: write` permission (or a PAT) to upload the file.
 
+## Running Tests
+
+Install the Qt bindings before running the test suite. The CI workflow installs
+`PySide6>=6.9.1` first:
+
+```bash
+pip install "PySide6>=6.9.1"
+pip install -r requirements.txt
+pip install -e .
+pytest
+```
+
+Tests that rely on the GUI use `pytest.importorskip("PySide6")` so they are skipped
+automatically when the dependency is missing.
 
 ## Characters
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,8 @@ import pytest
 
 @pytest.fixture(scope="session", autouse=True)
 def generate_assets():
+    if importlib.util.find_spec("PySide6") is None:
+        return
     root = pathlib.Path(__file__).resolve().parents[1]
     script_path = root / "scripts" / "generate_assets.py"
     spec = importlib.util.spec_from_file_location("generate_assets", script_path)

--- a/tests/test_bang_executable.py
+++ b/tests/test_bang_executable.py
@@ -7,11 +7,13 @@ import importlib.util
 
 import pytest
 
+pytest.importorskip(
+    "PySide6", reason="PySide6 not installed; skipping executable test"
+)
+
 pytestmark = pytest.mark.skipif(
-    os.getenv("CI") == "true"
-    or shutil.which("pyinstaller") is None
-    or importlib.util.find_spec("PySide6") is None,
-    reason="Skipping executable test on CI or when dependencies are missing",
+    os.getenv("CI") == "true" or shutil.which("pyinstaller") is None,
+    reason="Skipping executable test on CI or when PyInstaller is missing",
 )
 
 def test_bang_executable_exits(tmp_path):


### PR DESCRIPTION
## Summary
- document PySide6 installation before running `pytest`
- skip asset generation when PySide6 is unavailable
- skip executable test when PySide6 is missing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c38b91a9083239dac001515a7df45