### PR TITLE
Handle invalid join tokens in UI

### DIFF
--- a/bang_py/ui.py
+++ b/bang_py/ui.py
@@ -19,6 +19,7 @@ from .ui_components import (
 )
 from .theme import get_stylesheet, get_current_theme
 from .network.server import parse_join_token
+from cryptography.fernet import InvalidToken
 
 
 class BangUI(QtWidgets.QMainWindow):
@@ -85,7 +86,11 @@ class BangUI(QtWidgets.QMainWindow):
         if dialog.exec() == QtWidgets.QDialog.Accepted:
             token = dialog.token_edit.text().strip()
             if token:
-                addr, port, code = parse_join_token(token)
+                try:
+                    addr, port, code = parse_join_token(token)
+                except InvalidToken:
+                    QtWidgets.QMessageBox.critical(self, "Error", "Invalid token")
+                    return
             else:
                 addr = dialog.addr_edit.text().strip()
                 code = dialog.code_edit.text().strip()


### PR DESCRIPTION
## Summary
- handle `InvalidToken` in BangUI join dialog
- display error dialog for bad tokens
- test that invalid tokens don't attempt to connect

## Testing
- `pytest tests/test_qt_ui.py::test_join_menu_invalid_token_shows_error -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c44e2e67c83238fa9fab7db16ac59