### PR TITLE
feat(ui): migrate game board to QML

### DIFF
--- a/bang_py/qml/GameBoard.qml
+++ b/bang_py/qml/GameBoard.qml
@@ -6,42 +6,129 @@ Item {
     property string theme: "light"
     property real scale: 1.0
     property var players: []
+    property string selfName: ""
     property alias logText: logArea.text
+
+    signal drawCard()
+    signal discardCard()
+
     width: 800 * scale
     height: 600 * scale
+    property real cardW: 60 * scale
+    property real cardH: 90 * scale
 
     Rectangle {
-        id: table
         anchors.fill: parent
         color: theme === "dark" ? "#004000" : "#006400"
     }
 
-    Text {
+    Canvas {
+        id: star
+        width: 30 * scale
+        height: 30 * scale
         anchors.centerIn: parent
-        text: "Board Prototype"
-        color: theme === "dark" ? "white" : "black"
-        font.pointSize: 20
+        onPaint: {
+            var ctx = getContext("2d")
+            ctx.fillStyle = "gold"
+            ctx.beginPath()
+            for (var i = 0; i < 5; i++) {
+                var ang = -Math.PI / 2 + i * 2 * Math.PI / 5
+                ctx.lineTo(width / 2 + width / 2 * Math.cos(ang),
+                           height / 2 + width / 2 * Math.sin(ang))
+                ang += Math.PI / 5
+                ctx.lineTo(width / 2 + width / 4 * Math.cos(ang),
+                           height / 2 + width / 4 * Math.sin(ang))
+            }
+            ctx.closePath()
+            ctx.fill()
+        }
     }
 
-    ListView {
-        id: playerList
-        width: 200 * scale
-        anchors.top: parent.top
-        anchors.bottom: parent.bottom
-        anchors.left: parent.left
-        model: players
-        delegate: Row {
-            spacing: 4
-            Text { text: name }
-            Repeater {
-                model: health
-                delegate: Rectangle {
-                    width: 8 * scale
-                    height: 8 * scale
-                    color: "red"
+    Rectangle {
+        id: drawPile
+        width: cardW
+        height: cardH
+        anchors.centerIn: parent
+        anchors.horizontalCenterOffset: -cardW
+        color: theme === "dark" ? "#555" : "#bbb"
+        border.color: "black"
+        radius: 4 * scale
+        MouseArea { anchors.fill: parent; onClicked: root.drawCard() }
+    }
+    Text {
+        text: "Draw"
+        anchors.top: drawPile.bottom
+        anchors.horizontalCenter: drawPile.horizontalCenter
+        color: theme === "dark" ? "white" : "black"
+    }
+
+    Rectangle {
+        id: discardPile
+        width: cardW
+        height: cardH
+        anchors.centerIn: parent
+        anchors.horizontalCenterOffset: cardW
+        color: theme === "dark" ? "#666" : "#ddd"
+        border.color: "black"
+        radius: 4 * scale
+        MouseArea { anchors.fill: parent; onClicked: root.discardCard() }
+    }
+    Text {
+        text: "Discard"
+        anchors.top: discardPile.bottom
+        anchors.horizontalCenter: discardPile.horizontalCenter
+        color: theme === "dark" ? "white" : "black"
+    }
+
+    Repeater {
+        model: players.length
+        delegate: Item {
+            property var pl: players[index]
+            width: cardW
+            height: cardH
+            property real angleStep: 360 / players.length
+            property real ang: (index - root.selfIndex) * angleStep + 90
+            property real rad: ang * Math.PI / 180
+            property real radius: Math.min(root.width, root.height) * 0.35
+            x: root.width / 2 + radius * Math.cos(rad) - width / 2
+            y: root.height / 2 + radius * Math.sin(rad) - height / 2
+
+            Rectangle {
+                anchors.fill: parent
+                color: theme === "dark" ? "#333" : "#ddd"
+                border.color: "black"
+                radius: 4 * scale
+            }
+            Row {
+                id: bullets
+                spacing: 2 * scale
+                anchors.top: parent.bottom
+                anchors.horizontalCenter: parent.horizontalCenter
+                Repeater {
+                    model: pl.health
+                    delegate: Rectangle {
+                        width: 8 * scale
+                        height: 8 * scale
+                        color: "red"
+                        radius: 2 * scale
+                    }
                 }
             }
+            Text {
+                text: pl.name
+                anchors.top: bullets.bottom
+                anchors.horizontalCenter: parent.horizontalCenter
+                color: theme === "dark" ? "white" : "black"
+                font.pixelSize: 12 * scale
+            }
         }
+    }
+    property int selfIndex: {
+        for (var i = 0; i < players.length; i++) {
+            if (players[i].name === selfName)
+                return i
+        }
+        return 0
     }
 
     Rectangle {
@@ -52,12 +139,13 @@ Item {
         anchors.bottom: parent.bottom
         color: theme === "dark" ? "#000000" : "#ffffff"
         opacity: 0.7
-
+        border.color: theme === "dark" ? "#444" : "#222"
         TextArea {
             id: logArea
             anchors.fill: parent
             readOnly: true
             wrapMode: TextArea.WrapAnywhere
+            color: theme === "dark" ? "white" : "black"
             background: Rectangle { color: "transparent" }
         }
     }

--- a/bang_py/ui_components/__init__.py
+++ b/bang_py/ui_components/__init__.py
@@ -2,14 +2,13 @@
 
 from .start_menu import StartMenu
 from .host_join_dialog import HostJoinDialog
-from .game_view import GameView, GameBoard, CardButton
+from .game_view import GameView, CardButton
 from .network_threads import ServerThread, ClientThread
 
 __all__ = [
     "StartMenu",
     "HostJoinDialog",
     "GameView",
-    "GameBoard",
     "CardButton",
     "ServerThread",
     "ClientThread",

--- a/bang_py/ui_components/game_view.py
+++ b/bang_py/ui_components/game_view.py
@@ -1,140 +1,10 @@
 from __future__ import annotations
 
-import math
 from importlib import resources
 
 from PySide6 import QtCore, QtGui, QtWidgets, QtQuickWidgets
 
-from .card_images import get_loader, load_character_image, load_sound
-
-ASSETS_DIR = resources.files("bang_py") / "assets"
-BULLET_PATH = ASSETS_DIR / "bullet.png"
-TABLE_PATH = ASSETS_DIR / "table.png"
-
-
-class GameBoard(QtWidgets.QGraphicsView):
-    """Simple board rendering using QGraphicsView."""
-
-    def __init__(self, parent: QtWidgets.QWidget | None = None) -> None:
-        super().__init__(parent)
-        self.setRenderHint(QtGui.QPainter.Antialiasing)
-        self._scene = QtWidgets.QGraphicsScene(self)
-        self.setScene(self._scene)
-        screen = QtGui.QGuiApplication.primaryScreen()
-        if screen is not None:
-            geom = screen.availableGeometry()
-            self.max_width = geom.width()
-            self.max_height = geom.height()
-        else:
-            self.max_width = 800
-            self.max_height = 600
-        self.card_width = 60
-        self.card_height = 90
-        self.card_pixmap = self._create_card_pixmap()
-        with resources.as_file(TABLE_PATH) as table_path:
-            self.table_pixmap = QtGui.QPixmap(str(table_path)).scaled(
-                self.max_width,
-                self.max_height,
-                QtCore.Qt.KeepAspectRatioByExpanding,
-                QtCore.Qt.SmoothTransformation,
-            )
-        with resources.as_file(BULLET_PATH) as bullet_path:
-            self.bullet_pixmap = QtGui.QPixmap(str(bullet_path)).scaled(
-            20,
-            10,
-            QtCore.Qt.KeepAspectRatio,
-            QtCore.Qt.SmoothTransformation,
-        )
-        self.players: list[dict] = []
-        self.self_name: str | None = None
-        self._draw_board()
-
-    def resizeEvent(self, event: QtGui.QResizeEvent) -> None:  # noqa: D401
-        """Handle widget resize and scale contents."""
-        super().resizeEvent(event)
-        self.fitInView(self._scene.sceneRect(), QtCore.Qt.KeepAspectRatio)
-
-    def _create_card_pixmap(
-        self,
-        width: int | None = None,
-        height: int | None = None,
-        back_type: str = "other",
-    ) -> QtGui.QPixmap:
-        w = width or self.card_width
-        h = height or self.card_height
-        loader = get_loader()
-        return loader.get_card_back(back_type).scaled(
-            w, h, QtCore.Qt.KeepAspectRatio, QtCore.Qt.SmoothTransformation
-        )
-
-    def _draw_board(self) -> None:
-        self._scene.clear()
-        self._scene.setSceneRect(0, 0, self.max_width, self.max_height)
-        table = self._scene.addPixmap(self.table_pixmap)
-        table.setZValue(-1)
-        table.setPos(0, 0)
-        center_x = self.max_width / 2
-        draw_x = center_x - self.card_width * 1.5
-        draw_y = self.max_height * 0.5
-        discard_x = center_x + self.card_width * 0.5
-        self._scene.addPixmap(self.card_pixmap).setPos(draw_x, draw_y)
-        self._scene.addText("Draw").setPos(draw_x, draw_y + self.card_height)
-        self._scene.addPixmap(self.card_pixmap).setPos(discard_x, draw_y)
-        self._scene.addText("Discard").setPos(
-            discard_x, draw_y + self.card_height
-        )
-
-        # Star emblem at the center of the table
-        star = QtGui.QPolygonF()
-        outer = 15
-        inner = 6
-        for i in range(10):
-            angle = math.radians(i * 36 - 90)
-            r = outer if i % 2 == 0 else inner
-            star.append(QtCore.QPointF(r * math.cos(angle), r * math.sin(angle)))
-        item = self._scene.addPolygon(
-            star,
-            QtGui.QPen(QtGui.QColor("gold")),
-            QtGui.QBrush(QtGui.QColor("gold")),
-        )
-        item.setPos(center_x, self.max_height / 2)
-
-        if self.players:
-            angle_step = 360 / len(self.players)
-            center_y = self.max_height / 2
-            radius = min(self.max_width, self.max_height) * 0.35
-            idx = next(
-                (i for i, pl in enumerate(self.players) if pl["name"] == self.self_name),
-                0,
-            )
-            for i, pl in enumerate(self.players):
-                ang = math.radians((i - idx) * angle_step + 90)
-                x = center_x + radius * math.cos(ang) - self.card_width / 2
-                y = center_y + radius * math.sin(ang) - self.card_height / 2
-                portrait = load_character_image(
-                    pl.get("character", ""), self.card_width, self.card_height
-                )
-                self._scene.addPixmap(portrait).setPos(x, y)
-
-                bullet_y = y + self.card_height
-                spacing = 2
-                health = int(pl.get("health", 0))
-                bullet_w = self.bullet_pixmap.width()
-                row_w = health * bullet_w + max(0, health - 1) * spacing
-                start_x = x + (self.card_width - row_w) / 2
-                for b in range(health):
-                    item = self._scene.addPixmap(self.bullet_pixmap)
-                    item.setPos(start_x + b * (bullet_w + spacing), bullet_y)
-
-                name_item = self._scene.addText(pl["name"])
-                name_item.setPos(x, bullet_y + self.bullet_pixmap.height() + 2)
-                name_item.setToolTip(f"Health: {health}")
-
-    def update_players(self, players: list[dict], self_name: str | None = None) -> None:
-        """Redraw the board to show ``players`` with ``self_name`` at the bottom."""
-        self.players = players
-        self.self_name = self_name
-        self._draw_board()
+from .card_images import get_loader, load_sound
 
 
 class CardButton(QtWidgets.QPushButton):
@@ -197,6 +67,12 @@ class GameView(QtWidgets.QWidget):
         if self.root_obj is not None:
             self.root_obj.setProperty("theme", theme)
             self.root_obj.setProperty("scale", 1.0)
+            self.root_obj.drawCard.connect(
+                lambda: self.action_signal.emit({"action": "draw"})
+            )
+            self.root_obj.discardCard.connect(
+                lambda: self.action_signal.emit({"action": "discard"})
+            )
         vbox.addWidget(self.board_qml, 1)
 
         self.update_sound = load_sound("beep")
@@ -204,10 +80,6 @@ class GameView(QtWidgets.QWidget):
         self.hand_widget = QtWidgets.QWidget()
         self.hand_layout = QtWidgets.QHBoxLayout(self.hand_widget)
         vbox.addWidget(self.hand_widget)
-
-        btn_draw = QtWidgets.QPushButton("Draw")
-        btn_draw.clicked.connect(lambda: self.action_signal.emit({"action": "draw"}))
-        vbox.addWidget(btn_draw)
 
         btn_end = QtWidgets.QPushButton("End Turn")
         btn_end.clicked.connect(self.end_turn_signal.emit)
@@ -218,6 +90,8 @@ class GameView(QtWidgets.QWidget):
             self.update_sound.play()
         if self.root_obj is not None:
             self.root_obj.setProperty("players", players)
+            if self_name is not None:
+                self.root_obj.setProperty("selfName", self_name)
 
     def update_hand(self, cards: list[object]) -> None:
         while self.hand_layout.count():


### PR DESCRIPTION
## Summary
- Render card table, players, and log panel entirely in QML with draw/discard signals
- Load QML board in `GameView` via `QQuickWidget` and forward board signals to Python
- Remove legacy `GameBoard` view and adjust tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e9eb6c2b08323b2c47762a1ef446f