### PR TITLE
feat: polish QML buttons and transitions

### DIFF
--- a/bang_py/qml/GameBoard.qml
+++ b/bang_py/qml/GameBoard.qml
@@ -1,6 +1,9 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 
+// Styled buttons reside in this directory
+import "./"
+
 Item {
     id: root
     property string theme: "light"
@@ -11,6 +14,7 @@ Item {
 
     signal drawCard()
     signal discardCard()
+    signal endTurn()
 
     width: 800 * scale
     height: 600 * scale
@@ -53,13 +57,13 @@ Item {
         color: theme === "dark" ? "#555" : "#bbb"
         border.color: "black"
         radius: 4 * scale
-        MouseArea { anchors.fill: parent; onClicked: root.drawCard() }
     }
-    Text {
+    StyledButton {
         text: "Draw"
+        theme: root.theme
         anchors.top: drawPile.bottom
         anchors.horizontalCenter: drawPile.horizontalCenter
-        color: theme === "dark" ? "white" : "black"
+        onClicked: root.drawCard()
     }
 
     Rectangle {
@@ -71,13 +75,13 @@ Item {
         color: theme === "dark" ? "#666" : "#ddd"
         border.color: "black"
         radius: 4 * scale
-        MouseArea { anchors.fill: parent; onClicked: root.discardCard() }
     }
-    Text {
+    StyledButton {
         text: "Discard"
+        theme: root.theme
         anchors.top: discardPile.bottom
         anchors.horizontalCenter: discardPile.horizontalCenter
-        color: theme === "dark" ? "white" : "black"
+        onClicked: root.discardCard()
     }
 
     Repeater {
@@ -148,5 +152,15 @@ Item {
             color: theme === "dark" ? "white" : "black"
             background: Rectangle { color: "transparent" }
         }
+    }
+
+    StyledButton {
+        text: "End Turn"
+        theme: root.theme
+        anchors.right: parent.right
+        anchors.bottom: parent.bottom
+        anchors.rightMargin: 10 * scale
+        anchors.bottomMargin: 10 * scale
+        onClicked: root.endTurn()
     }
 }

--- a/bang_py/qml/MainMenu.qml
+++ b/bang_py/qml/MainMenu.qml
@@ -1,6 +1,9 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 
+// Styled buttons reside in this directory
+import "./"
+
 Rectangle {
     id: root
     property string theme: "light"
@@ -33,16 +36,19 @@ Rectangle {
             }
         }
 
-        Button {
+        StyledButton {
             text: "Host Game"
+            theme: root.theme
             onClicked: root.hostGame()
         }
-        Button {
+        StyledButton {
             text: "Join Game"
+            theme: root.theme
             onClicked: root.joinGame()
         }
-        Button {
+        StyledButton {
             text: "Settings"
+            theme: root.theme
             onClicked: root.settings()
         }
     }

--- a/bang_py/qml/StyledButton.qml
+++ b/bang_py/qml/StyledButton.qml
@@ -1,0 +1,40 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+// A reusable themed button with hover effects and optional icon.
+Button {
+    id: control
+    property string theme: "light"
+    property url iconSource: ""
+    implicitHeight: 40
+    implicitWidth: 120
+    hoverEnabled: true
+
+    contentItem: Row {
+        spacing: icon.visible ? 6 : 0
+        anchors.centerIn: parent
+        Image {
+            id: icon
+            source: control.iconSource
+            visible: source !== ""
+            width: 20
+            height: 20
+            fillMode: Image.PreserveAspectFit
+        }
+        Text {
+            text: control.text
+            color: control.theme === "dark" ? "white" : "black"
+            font.pointSize: 14
+        }
+    }
+
+    background: Rectangle {
+        radius: 4
+        border.color: control.theme === "dark" ? "#888888" : "#8b4513"
+        color: control.down
+               ? (control.theme === "dark" ? "#333333" : "#e39b3a")
+               : control.hovered
+                 ? (control.theme === "dark" ? "#555555" : "#f0b070")
+                 : (control.theme === "dark" ? "#444444" : "#f4a460")
+    }
+}

--- a/bang_py/ui.py
+++ b/bang_py/ui.py
@@ -49,6 +49,21 @@ class BangUI(QtWidgets.QMainWindow):
                 return name.strip()
         return ""
 
+    def _transition_to(self, widget: QtWidgets.QWidget) -> None:
+        """Fade in the given widget on the stacked layout."""
+        if self.stack.indexOf(widget) == -1:
+            self.stack.addWidget(widget)
+        self.stack.setCurrentWidget(widget)
+        effect = QtWidgets.QGraphicsOpacityEffect(widget)
+        widget.setGraphicsEffect(effect)
+        effect.setOpacity(0)
+        anim = QtCore.QPropertyAnimation(effect, b"opacity", self)
+        anim.setDuration(300)
+        anim.setStartValue(0.0)
+        anim.setEndValue(1.0)
+        anim.start(QtCore.QAbstractAnimation.DeleteWhenStopped)
+        self._current_anim = anim
+
     # Menu screens -----------------------------------------------------
     def _build_start_menu(self) -> None:
         qml_dir = Path(__file__).resolve().parent / "qml"
@@ -65,8 +80,7 @@ class BangUI(QtWidgets.QMainWindow):
             root.joinGame.connect(self._join_menu)
             root.settings.connect(self._settings_dialog)
         self.menu_root = root
-        self.stack.addWidget(self.start_menu)
-        self.stack.setCurrentWidget(self.start_menu)
+        self._transition_to(self.start_menu)
 
     def _host_menu(self) -> None:
         dialog = HostJoinDialog("host", self)
@@ -133,8 +147,7 @@ class BangUI(QtWidgets.QMainWindow):
         self.game_view.end_turn_signal.connect(self._end_turn)
         self.hand_layout = self.game_view.hand_layout
         self.game_root = self.game_view.root_obj
-        self.stack.addWidget(self.game_view)
-        self.stack.setCurrentWidget(self.game_view)
+        self._transition_to(self.game_view)
 
     # Networking -------------------------------------------------------
     def _start_host(

--- a/bang_py/ui_components/game_view.py
+++ b/bang_py/ui_components/game_view.py
@@ -73,6 +73,7 @@ class GameView(QtWidgets.QWidget):
             self.root_obj.discardCard.connect(
                 lambda: self.action_signal.emit({"action": "discard"})
             )
+            self.root_obj.endTurn.connect(self.end_turn_signal.emit)
         vbox.addWidget(self.board_qml, 1)
 
         self.update_sound = load_sound("beep")
@@ -80,10 +81,6 @@ class GameView(QtWidgets.QWidget):
         self.hand_widget = QtWidgets.QWidget()
         self.hand_layout = QtWidgets.QHBoxLayout(self.hand_widget)
         vbox.addWidget(self.hand_widget)
-
-        btn_end = QtWidgets.QPushButton("End Turn")
-        btn_end.clicked.connect(self.end_turn_signal.emit)
-        vbox.addWidget(btn_end)
 
     def update_players(self, players: list[dict], self_name: str | None = None) -> None:
         if self.update_sound:


### PR DESCRIPTION
## Summary
- add reusable `StyledButton` with theme-aware colors, hover state and optional icon slot
- use `StyledButton` in menu and game board (adds Draw, Discard and End Turn buttons)
- fade between menu and game view when switching screens

## Testing
- `pytest tests/test_qt_ui.py tests/test_icon_loader.py tests/test_card_image_loader.py`


------
https://chatgpt.com/codex/tasks/task_e_688ea1cec2448323b426a658008d17a4