### PR TITLE
refactor: modularize card handlers

### DIFF
--- a/bang_py/card_handlers/basic.py
+++ b/bang_py/card_handlers/basic.py
@@ -1,0 +1,51 @@
+"""Handlers for basic (brown) cards."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ..cards.bang import BangCard
+from ..cards.stagecoach import StagecoachCard
+from ..cards.wells_fargo import WellsFargoCard
+from ..cards.cat_balou import CatBalouCard
+from ..cards.panic import PanicCard
+from ..cards.indians import IndiansCard
+from ..cards.duel import DuelCard
+from ..cards.general_store import GeneralStoreCard
+from ..cards.saloon import SaloonCard
+from ..cards.gatling import GatlingCard
+from ..cards.whisky import WhiskyCard
+from ..cards.beer import BeerCard
+from ..cards.tequila import TequilaCard
+from ..cards.punch import PunchCard
+from ..cards.brawl import BrawlCard
+from ..cards.springfield import SpringfieldCard
+from ..cards.rag_time import RagTimeCard
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from ..game_manager import GameManager
+
+
+def register(game: 'GameManager') -> None:
+    """Register handlers for basic cards on ``game``."""
+    game._card_handlers.update(
+        {
+            BangCard: game._play_bang_card,
+            StagecoachCard: game._handler_self_game,
+            WellsFargoCard: game._handler_self_game,
+            CatBalouCard: game._handler_target_game,
+            PanicCard: game._handler_target_player_game,
+            IndiansCard: game._handler_self_player_game,
+            DuelCard: game._handler_target_player_game,
+            GeneralStoreCard: game._handler_self_player_game,
+            SaloonCard: game._handler_self_player_game,
+            GatlingCard: game._handler_self_player_game,
+            WhiskyCard: game._handler_target_or_self_player_game,
+            BeerCard: game._handler_target_or_self_player_game,
+            TequilaCard: game._handler_target_or_self_player_game,
+            PunchCard: game._handler_target_player,
+            BrawlCard: game._handler_self_player_game,
+            SpringfieldCard: game._handler_target_player_game,
+            RagTimeCard: game._handler_target_player_game,
+        }
+    )

--- a/bang_py/card_handlers/blue.py
+++ b/bang_py/card_handlers/blue.py
@@ -1,0 +1,16 @@
+"""Handlers for blue (equipment) cards.
+
+Currently blue cards require no special handling beyond the default play
+behaviour, so this module registers nothing."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from ..game_manager import GameManager
+
+
+def register(game: 'GameManager') -> None:  # pragma: no cover - simple passthrough
+    """Register handlers for blue cards on ``game`` (currently none)."""
+    return None

--- a/bang_py/card_handlers/event.py
+++ b/bang_py/card_handlers/event.py
@@ -1,0 +1,15 @@
+"""Handlers for event cards."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ..cards.high_noon_card import HighNoonCard
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from ..game_manager import GameManager
+
+
+def register(game: 'GameManager') -> None:
+    """Register handlers for event cards on ``game``."""
+    game._card_handlers.update({HighNoonCard: game._handler_self_player_game})

--- a/bang_py/card_handlers/green.py
+++ b/bang_py/card_handlers/green.py
@@ -1,0 +1,37 @@
+"""Handlers for green (Dodge City) cards."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ..cards.howitzer import HowitzerCard
+from ..cards.pony_express import PonyExpressCard
+from ..cards.knife import KnifeCard
+from ..cards.bible import BibleCard
+from ..cards.canteen import CanteenCard
+from ..cards.conestoga import ConestogaCard
+from ..cards.can_can import CanCanCard
+from ..cards.buffalo_rifle import BuffaloRifleCard
+from ..cards.pepperbox import PepperboxCard
+from ..cards.derringer import DerringerCard
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from ..game_manager import GameManager
+
+
+def register(game: 'GameManager') -> None:
+    """Register handlers for green cards on ``game``."""
+    game._card_handlers.update(
+        {
+            HowitzerCard: game._handler_self_player_game,
+            PonyExpressCard: game._handler_self_player_game,
+            KnifeCard: game._handler_target_player_game,
+            BibleCard: game._handler_target_or_self_player_game,
+            CanteenCard: game._handler_target_or_self_player_game,
+            ConestogaCard: game._handler_target_player_game,
+            CanCanCard: game._handler_target_game,
+            BuffaloRifleCard: game._handler_target_player_game,
+            PepperboxCard: game._handler_target_player_game,
+            DerringerCard: game._handler_target_player_game,
+        }
+    )

--- a/tests/test_handler_registry.py
+++ b/tests/test_handler_registry.py
@@ -1,0 +1,25 @@
+from bang_py.game_manager import GameManager
+from bang_py.deck import Deck
+from bang_py.player import Player
+from bang_py.cards import BangCard
+from bang_py.cards.pony_express import PonyExpressCard
+from bang_py.card_handlers import register_handler_groups
+
+
+def test_register_specific_handler_groups():
+    deck = Deck([BangCard(), BangCard(), BangCard()])
+    gm = GameManager(deck=deck)
+    gm._card_handlers = {}
+    register_handler_groups(gm, ["basic"])
+    p1 = Player("A")
+    gm.add_player(p1)
+    card = PonyExpressCard()
+    p1.hand.append(card)
+    gm.play_card(p1, card)
+    assert len(p1.hand) == 0
+
+    gm._card_handlers = {}
+    p1.hand.append(PonyExpressCard())
+    register_handler_groups(gm, ["basic", "green"])
+    gm.play_card(p1, p1.hand[0])
+    assert len(p1.hand) == 3


### PR DESCRIPTION
## Summary
- split card handlers into basic, green, blue, and event modules
- add registry so GameManager imports only desired handler groups
- cover handler registry with a new test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ea5cf9b8c8323bf3843ad3c517be3