### PR TITLE
Validate player names

### DIFF
--- a/bang_py/network/server.py
+++ b/bang_py/network/server.py
@@ -162,6 +162,13 @@ class BangServer:
 
         await websocket.send("Enter your name:")
         name = await websocket.recv()
+        if not isinstance(name, str):
+            await websocket.send("Invalid name")
+            return
+        name = name.strip()
+        if not name or len(name) > 20 or not name.isprintable():
+            await websocket.send("Invalid name")
+            return
         if len(self.game.players) >= self.max_players:
             await websocket.send("Game full")
             return

--- a/bang_py/ui.py
+++ b/bang_py/ui.py
@@ -46,7 +46,9 @@ class BangUI(QtWidgets.QMainWindow):
         if self.menu_root is not None:
             name = self.menu_root.property("nameText")
             if isinstance(name, str):
-                return name.strip()
+                name = name.strip()
+                if name and len(name) <= 20 and name.isprintable():
+                    return name
         return ""
 
     def _transition_to(self, widget: QtWidgets.QWidget) -> None:
@@ -159,7 +161,9 @@ class BangUI(QtWidgets.QMainWindow):
     ) -> None:
         name = self._get_player_name()
         if not name:
-            QtWidgets.QMessageBox.critical(self, "Error", "Please enter your name")
+            QtWidgets.QMessageBox.critical(
+                self, "Error", "Please enter a valid name"
+            )
             return
         room_code = secrets.token_hex(3)
         self.server_thread = ServerThread(
@@ -182,7 +186,9 @@ class BangUI(QtWidgets.QMainWindow):
     ) -> None:
         name = self._get_player_name()
         if not name:
-            QtWidgets.QMessageBox.critical(self, "Error", "Please enter your name")
+            QtWidgets.QMessageBox.critical(
+                self, "Error", "Please enter a valid name"
+            )
             return
         scheme = "wss" if cafile else "ws"
         uri = f"{scheme}://{addr}:{port}"

--- a/tests/test_name_validation.py
+++ b/tests/test_name_validation.py
@@ -1,0 +1,41 @@
+import asyncio
+import random
+
+import pytest
+from bang_py.network.server import BangServer
+
+websockets = pytest.importorskip("websockets")
+
+
+def test_name_too_long_rejected() -> None:
+    async def run_flow() -> None:
+        random.seed(0)
+        server = BangServer(host="localhost", port=8780, room_code="1234")
+        async with websockets.serve(server.handler, server.host, server.port):
+            async with websockets.connect("ws://localhost:8780") as ws:
+                await ws.recv()
+                await ws.send("1234")
+                await ws.recv()
+                await ws.send("x" * 21)
+                msg = await ws.recv()
+                assert msg == "Invalid name"
+                with pytest.raises(websockets.exceptions.ConnectionClosed):
+                    await ws.recv()
+    asyncio.run(run_flow())
+
+
+def test_name_with_unprintable_rejected() -> None:
+    async def run_flow() -> None:
+        random.seed(0)
+        server = BangServer(host="localhost", port=8781, room_code="1234")
+        async with websockets.serve(server.handler, server.host, server.port):
+            async with websockets.connect("ws://localhost:8781") as ws:
+                await ws.recv()
+                await ws.send("1234")
+                await ws.recv()
+                await ws.send("bad\x00name")
+                msg = await ws.recv()
+                assert msg == "Invalid name"
+                with pytest.raises(websockets.exceptions.ConnectionClosed):
+                    await ws.recv()
+    asyncio.run(run_flow())


### PR DESCRIPTION
## Summary
- Restrict player names to printable characters and 20 characters on the server
- Mirror name validation in the Qt UI and notify users of invalid names
- Add tests for overly long and unprintable player names

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688eabc6f13c832388e68f7b80181cc9