### PR TITLE
Require explicit join token key

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ bang-server
 ```
 
 This starts a websocket server on `ws://localhost:8765`.
-Provide a custom join token key with ``--token-key`` or by passing
-``token_key`` when creating ``BangServer`` in code.
+A join token encryption key is required and may be supplied with
+``--token-key``, by passing ``token_key`` when creating ``BangServer`` or via the
+``BANG_TOKEN_KEY`` environment variable.
 
 ### Secure connections
 
@@ -36,15 +37,16 @@ The Qt interface exposes these paths in the host and join dialogs.
 
 Running ``bang-server --show-token`` prints an encrypted string containing the
 host, port and room code. Start the Qt UI or ``bang-client`` with ``--token`` to
-join automatically. Pass ``--token-key`` with a custom base64 key when starting
-the server and client to override the built-in default:
+join automatically. The server and client must share the same base64 key. You
+can generate one and export it before launching the server:
 
 ```bash
-bang-server --token-key $(openssl rand -base64 32) --show-token
+export BANG_TOKEN_KEY=$(openssl rand -base64 32)
+bang-server --show-token
 ```
 
-The same key must be supplied to ``bang-client`` or ``bang-ui`` via the
-``--token-key`` option so they can decrypt the token.
+Clients can either set ``BANG_TOKEN_KEY`` or pass ``--token-key``/``token_key``
+explicitly so they can decrypt the token.
 
 ## Connecting a client
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,8 @@ import importlib.util
 
 import pytest
 
+from bang_py.network.server import DEFAULT_TOKEN_KEY
+
 
 @pytest.fixture(scope="session", autouse=True)
 def generate_assets():
@@ -16,4 +18,9 @@ def generate_assets():
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     module.main()
+
+
+@pytest.fixture(autouse=True)
+def _set_token_key(monkeypatch):
+    monkeypatch.setenv("BANG_TOKEN_KEY", DEFAULT_TOKEN_KEY.decode())
 

--- a/tests/test_join_token.py
+++ b/tests/test_join_token.py
@@ -21,3 +21,23 @@ def test_token_invalid_key():
     bad_key = b"fh-IQhdbcUCrWTWyQ7WcM5VqCPU-ixXvSawvMkE415Q="
     with pytest.raises(InvalidToken):
         parse_join_token(token, bad_key)
+
+
+def test_token_env_fallback(monkeypatch):
+    monkeypatch.setenv("BANG_TOKEN_KEY", DEFAULT_TOKEN_KEY.decode())
+    token = generate_join_token("host", 2, "abc")
+    host, port, code = parse_join_token(token)
+    assert host == "host"
+    assert port == 2
+    assert code == "abc"
+
+
+def test_missing_key_raises(monkeypatch):
+    monkeypatch.delenv("BANG_TOKEN_KEY", raising=False)
+    with pytest.raises(ValueError):
+        generate_join_token("h", 1, "c")
+    token = generate_join_token("host", 1, "c", DEFAULT_TOKEN_KEY)
+    monkeypatch.delenv("BANG_TOKEN_KEY", raising=False)
+    with pytest.raises(ValueError):
+        parse_join_token(token)
+


### PR DESCRIPTION
## Summary
- require callers to supply a join token key or use the `BANG_TOKEN_KEY` env var
- document generating and exporting the key for server and clients
- test token key handling and set a default key during tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688eb096af688323b8ad0b68cf225b29