### PR TITLE
Overlay ability icons on card images

### DIFF
--- a/bang_py/ui_components/game_view.py
+++ b/bang_py/ui_components/game_view.py
@@ -34,7 +34,7 @@ class CardButton(QtWidgets.QPushButton):
         self.clicked.connect(self._play)
 
         loader = get_loader()
-        pix = loader.compose_card(card_type, rank, suit, card_set)
+        pix = loader.compose_card(card_type, rank, suit, card_set, text)
         if not pix.isNull():
             self.setIcon(QtGui.QIcon(pix))
             self.setIconSize(QtCore.QSize(pix.width(), pix.height()))

--- a/tests/test_card_image_loader.py
+++ b/tests/test_card_image_loader.py
@@ -4,7 +4,7 @@ import pytest
 pytest.importorskip("PySide6", reason="PySide6 not installed; skipping GUI tests")
 
 from PySide6 import QtWidgets, QtGui
-
+from bang_py.ui_components.card_images import CardImageLoader, ACTION_ICON_MAP
 
 @pytest.fixture
 def qt_app():
@@ -46,3 +46,38 @@ def test_get_card_back_returns_pixmap(name, qt_app):
     pix = loader.get_card_back(name)
     assert isinstance(pix, QtGui.QPixmap)
     assert not pix.isNull()
+
+
+@pytest.mark.parametrize("name", ["Bang!", "Draw Card", "Range 3"])
+def test_compose_card_overlays_action_icon(name, qt_app):
+    key = name.lower().replace("!", "").replace(" ", "_")
+    assert key in ACTION_ICON_MAP
+    loader = CardImageLoader()
+    base = loader.compose_card("brown", rank="A", suit="Spades")
+    with_icon = loader.compose_card("brown", rank="A", suit="Spades", name=name)
+    assert with_icon.toImage() != base.toImage()
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "bang",
+        "missed",
+        "any_player",
+        "all_players",
+        "any_reachable_player",
+        "draw_card",
+        "discard_card",
+        "discard_another_card",
+        "gain_life",
+        "range_1",
+        "range_2",
+        "range_3",
+        "range_4",
+        "range_5",
+    ],
+)
+def test_action_icons_loaded(key, qt_app):
+    loader = CardImageLoader()
+    icon = loader.action_icons.get(key)
+    assert icon is not None and not icon.isNull()


### PR DESCRIPTION
## Summary
- extend card/action icon mapping to cover targeting, draw/discard, healing, and range icons
- broaden card image loader tests to verify icon overlays and that every icon asset loads

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890649281548323ae0d25598a1ea8b1