### PR TITLE
Add mp3 audio support and integrate UI sounds

### DIFF
--- a/bang_py/ui_components/start_menu.py
+++ b/bang_py/ui_components/start_menu.py
@@ -1,10 +1,6 @@
 from __future__ import annotations
 
 from PySide6 import QtCore, QtWidgets
-try:
-    from PySide6 import QtMultimedia  # type: ignore
-except Exception:  # pragma: no cover - optional dependency
-    QtMultimedia = None
 
 from .card_images import load_sound
 
@@ -33,7 +29,7 @@ class StartMenu(QtWidgets.QWidget):
         form.addRow("Name:", self.name_edit)
         layout.addLayout(form)
 
-        self.click_sound = load_sound("ui_click")
+        self.click_sound = load_sound("ui_click", self)
 
         host_btn = QtWidgets.QPushButton("Host Game")
         host_btn.clicked.connect(self._host)

--- a/tests/test_load_sound.py
+++ b/tests/test_load_sound.py
@@ -1,0 +1,21 @@
+import os
+import pytest
+
+pytest.importorskip("PySide6", reason="PySide6 not installed; skipping GUI tests")
+
+from PySide6 import QtWidgets
+from bang_py.ui_components.card_images import load_sound
+
+
+def test_load_sound_mp3():
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    app = QtWidgets.QApplication.instance()
+    created = app is None
+    if created:
+        app = QtWidgets.QApplication([])
+    sound = load_sound("ui_click")
+    if created:
+        app.quit()
+    if sound is None:
+        pytest.skip("QtMultimedia not available")
+    assert hasattr(sound, "play")


### PR DESCRIPTION
## Summary
- support mp3 audio in `load_sound` using `QMediaPlayer`/`QAudioOutput`
- play real sound effects for UI actions in the game view and start menu
- add regression test for mp3 sound loading

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68906dbc28288323b5f1651bc247ed13