### PR TITLE
Reuse hand card widgets in GameView

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
+.RECIPEPREFIX := >
 .PHONY: build-exe
 
 build-exe:
-	pyinstaller bang.spec
+>mkdir -p build/bang
+>echo "[Paths]\nPrefix=." > build/bang/qt.conf
+>pyinstaller bang.spec


### PR DESCRIPTION
## Summary
- reuse existing CardButton widgets when the hand changes
- create minimal qt.conf before running pyinstaller in `build-exe`

## Testing
- `QT_QPA_PLATFORM=offscreen python - <<'PY' ...` baseline vs optimized CPU usage
- `BANG_AUTO_CLOSE=1 pytest -q -k "not bang_executable"`


------
https://chatgpt.com/codex/tasks/task_e_6890fd4f6ad08323980ca6b81a19b571