### PR TITLE
Limit server payload size and test

### DIFF
--- a/bang_py/network/server.py
+++ b/bang_py/network/server.py
@@ -666,6 +666,7 @@ class BangServer:
             self.host,
             self.port,
             ssl=self.ssl_context,
+            max_size=MAX_MESSAGE_SIZE,
         ):
             logger.info(
                 "Server started on %s:%s (code: %s)",


### PR DESCRIPTION
## Summary
- Enforce websocket frame size limits in server.start to reject huge payloads earlier
- Test that oversized messages close the connection with code 1009

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68910f3b22308323b68ab68dd6b6e67d