### PR TITLE
Skip server tests when cryptography is missing

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -18,6 +18,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install "PySide6>=6.9.1" --pre
+          pip install cryptography
           pip install -r requirements.txt
           pip install -e .
           pip install pytest

--- a/README.md
+++ b/README.md
@@ -161,17 +161,19 @@ needs the `contents: write` permission (or a PAT) to upload the file.
 ## Running Tests
 
 Install the Qt bindings before running the test suite. The CI workflow installs
-`PySide6>=6.9.1` first:
+`PySide6>=6.9.1` first along with `cryptography` for the network tests:
 
 ```bash
 pip install "PySide6>=6.9.1"
+pip install cryptography
 pip install -r requirements.txt
 pip install -e .
 pytest
 ```
 
 Tests that rely on the GUI use `pytest.importorskip("PySide6")` so they are skipped
-automatically when the dependency is missing.
+automatically when the dependency is missing. Networking tests behave the same
+way if `cryptography` is not installed.
 
 ## Characters
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,8 @@ import importlib.util
 
 import pytest
 
+pytest.importorskip("cryptography")
+
 from bang_py.network.server import DEFAULT_TOKEN_KEY
 
 


### PR DESCRIPTION
## Summary
- Skip server fixtures when the `cryptography` dependency is not available
- Install `cryptography` during CI runs
- Document how to install `cryptography` for local test runs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68911cb61f2c8323b52b8a70d62ef171