### PR TITLE
Guard asset generation fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,12 +10,20 @@ except Exception:
 
 
 @pytest.fixture(scope="session", autouse=True)
-def generate_assets():
+def generate_assets() -> None:
+    """Generate placeholder assets only when required files are missing."""
+    root = pathlib.Path(__file__).resolve().parents[1]
+    assets = root / "bang_py" / "assets"
+    char_dir = assets / "characters"
+    audio_dir = assets / "audio"
+    char_files = list(char_dir.glob("*.webp"))
+    audio_files = list(audio_dir.glob("*.mp3")) + list(audio_dir.glob("*.ogg"))
+    if char_files and audio_files:
+        return
     try:
         from PySide6 import QtCore, QtGui, QtWidgets  # noqa: F401
     except Exception:
         return
-    root = pathlib.Path(__file__).resolve().parents[1]
     script_path = root / "scripts" / "generate_assets.py"
     spec = importlib.util.spec_from_file_location("generate_assets", script_path)
     if spec is None or spec.loader is None:
@@ -26,7 +34,7 @@ def generate_assets():
 
 
 @pytest.fixture(autouse=True)
-def _set_token_key(monkeypatch):
+def _set_token_key(monkeypatch: pytest.MonkeyPatch) -> None:
     if DEFAULT_TOKEN_KEY is not None:
         monkeypatch.setenv("BANG_TOKEN_KEY", DEFAULT_TOKEN_KEY.decode())
 


### PR DESCRIPTION
## Summary
- Avoid regenerating assets when committed files exist, falling back to script only when required images or audio are missing

## Testing
- `CI=true pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891323f655c83238c249a742eb5acf8