### PR TITLE
Mark executable test as slow

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,3 +32,9 @@ bang-ui = "bang_py.ui:main"
     "assets/*.md",
     "qml/*.qml",
 ]
+
+[tool.pytest.ini_options]
+addopts = "-m 'not slow'"
+markers = [
+    "slow: marks tests that are slow and require manual invocation",
+]

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,2 +1,4 @@
 # Test Guidelines
 - Set the event deck explicitly or call `random.seed()` in tests to avoid flaky behavior.
+- The `test_bang_executable` test is marked `@pytest.mark.slow` and skipped by default.
+  Run it manually with `pytest -m slow` when PyInstaller is available.

--- a/tests/test_bang_executable.py
+++ b/tests/test_bang_executable.py
@@ -11,10 +11,13 @@ pytest.importorskip(
     "PySide6", reason="PySide6 not installed; skipping executable test"
 )
 
-pytestmark = pytest.mark.skipif(
-    os.getenv("CI") == "true" or shutil.which("pyinstaller") is None,
-    reason="Skipping executable test on CI or when PyInstaller is missing",
-)
+pytestmark = [
+    pytest.mark.skipif(
+        os.getenv("CI") == "true" or shutil.which("pyinstaller") is None,
+        reason="Skipping executable test on CI or when PyInstaller is missing",
+    ),
+    pytest.mark.slow,
+]
 
 def test_bang_executable_exits(tmp_path):
     try:


### PR DESCRIPTION
## Summary
- mark the PyInstaller executable test with `pytest.mark.slow`
- skip `slow` tests by default through pytest configuration
- document how to run the executable test manually

## Testing
- `pytest`
- `pytest -m slow --collect-only`


------
https://chatgpt.com/codex/tasks/task_e_6891a039b91c8323a692ec44d968deae