### PR TITLE
Use new websockets client API

### DIFF
--- a/bang_py/network/client.py
+++ b/bang_py/network/client.py
@@ -8,7 +8,7 @@ import ssl
 try:  # Optional websockets import for test environments
     from websockets.asyncio.client import connect
     from websockets.exceptions import WebSocketException
-    import websockets  # re-exported for compatibility
+    import websockets  # re-exported for tests
 except ModuleNotFoundError:  # pragma: no cover - fall back to legacy API
     try:
         import websockets

--- a/bang_py/network/client.py
+++ b/bang_py/network/client.py
@@ -6,9 +6,19 @@ import logging
 import ssl
 
 try:  # Optional websockets import for test environments
-    import websockets
-except ModuleNotFoundError:  # pragma: no cover - handled in main()
-    websockets = None  # type: ignore[assignment]
+    from websockets.asyncio.client import connect
+    from websockets.exceptions import WebSocketException
+    import websockets  # re-exported for compatibility
+except ModuleNotFoundError:  # pragma: no cover - fall back to legacy API
+    try:
+        import websockets
+        from websockets.exceptions import WebSocketException
+
+        connect = websockets.connect
+    except ModuleNotFoundError:  # pragma: no cover - handled in main()
+        connect = None  # type: ignore[assignment]
+        websockets = None  # type: ignore[assignment]
+        WebSocketException = Exception  # type: ignore[assignment]
 
 from .server import parse_join_token
 
@@ -47,7 +57,7 @@ async def main(
     Incoming messages are parsed as JSON when possible and printed to the
     console along with the list of players.
     """
-    if websockets is None:
+    if connect is None:
         logging.error("websockets package is required for networking")
         return
 
@@ -63,7 +73,7 @@ async def main(
         if cafile:
             ssl_ctx.load_verify_locations(cafile)
 
-    async with websockets.connect(uri, ssl=ssl_ctx) as websocket:
+    async with connect(uri, ssl=ssl_ctx) as websocket:
         prompt = await websocket.recv()
         logging.info(prompt)
         await websocket.send(room_code)

--- a/bang_py/network/client.py
+++ b/bang_py/network/client.py
@@ -9,7 +9,7 @@ try:  # Optional websockets import for test environments
     from websockets.asyncio.client import connect
     from websockets.exceptions import WebSocketException
     import websockets  # re-exported for tests
-except ModuleNotFoundError:  # pragma: no cover - fall back to legacy API
+except (ModuleNotFoundError, ImportError):  # pragma: no cover - fall back to legacy API
     try:
         import websockets
         from websockets.exceptions import WebSocketException

--- a/bang_py/ui_components/network_threads.py
+++ b/bang_py/ui_components/network_threads.py
@@ -16,11 +16,12 @@ try:  # Optional websockets import for test environments
     from websockets.exceptions import WebSocketException
 except ModuleNotFoundError:  # pragma: no cover - fall back to legacy API
     try:
-        import websockets
+        from websockets import connect
         from websockets.exceptions import WebSocketException
-        from websockets.legacy.client import WebSocketClientProtocol
-
-        connect = websockets.connect
+        try:
+            from websockets.legacy.client import WebSocketClientProtocol
+        except ModuleNotFoundError:  # pragma: no cover - older versions
+            from websockets.client import WebSocketClientProtocol  # type: ignore[no-redef]
     except ModuleNotFoundError:  # pragma: no cover - handled in _run()
         connect = None  # type: ignore[assignment]
         WebSocketClientProtocol = Any  # type: ignore[assignment]

--- a/bang_py/ui_components/network_threads.py
+++ b/bang_py/ui_components/network_threads.py
@@ -14,10 +14,17 @@ from PySide6 import QtCore
 try:  # Optional websockets import for test environments
     from websockets.asyncio.client import connect, WebSocketClientProtocol
     from websockets.exceptions import WebSocketException
-except ModuleNotFoundError:  # pragma: no cover - handled in _run()
-    connect = None  # type: ignore[assignment]
-    WebSocketClientProtocol = Any  # type: ignore[assignment]
-    WebSocketException = Exception  # type: ignore[assignment]
+except ModuleNotFoundError:  # pragma: no cover - fall back to legacy API
+    try:
+        import websockets
+        from websockets.exceptions import WebSocketException
+        from websockets.legacy.client import WebSocketClientProtocol
+
+        connect = websockets.connect
+    except ModuleNotFoundError:  # pragma: no cover - handled in _run()
+        connect = None  # type: ignore[assignment]
+        WebSocketClientProtocol = Any  # type: ignore[assignment]
+        WebSocketException = Exception  # type: ignore[assignment]
 
 from ..network.server import BangServer
 

--- a/tests/test_name_validation.py
+++ b/tests/test_name_validation.py
@@ -7,14 +7,20 @@ pytest.importorskip("cryptography")
 from bang_py.network.server import BangServer
 
 websockets = pytest.importorskip("websockets")
+try:  # Prefer the modern asyncio API
+    from websockets.asyncio.client import connect
+    from websockets.asyncio.server import serve
+except ModuleNotFoundError:  # pragma: no cover - older websockets versions
+    connect = websockets.connect  # type: ignore[attr-defined]
+    serve = websockets.serve  # type: ignore[attr-defined]
 
 
 def test_name_too_long_rejected() -> None:
     async def run_flow() -> None:
         random.seed(0)
         server = BangServer(host="localhost", port=8780, room_code="1234")
-        async with websockets.serve(server.handler, server.host, server.port):
-            async with websockets.connect("ws://localhost:8780") as ws:
+        async with serve(server.handler, server.host, server.port):
+            async with connect("ws://localhost:8780") as ws:
                 await ws.recv()
                 await ws.send("1234")
                 await ws.recv()
@@ -30,8 +36,8 @@ def test_name_with_unprintable_rejected() -> None:
     async def run_flow() -> None:
         random.seed(0)
         server = BangServer(host="localhost", port=8781, room_code="1234")
-        async with websockets.serve(server.handler, server.host, server.port):
-            async with websockets.connect("ws://localhost:8781") as ws:
+        async with serve(server.handler, server.host, server.port):
+            async with connect("ws://localhost:8781") as ws:
                 await ws.recv()
                 await ws.send("1234")
                 await ws.recv()

--- a/tests/test_network_integration.py
+++ b/tests/test_network_integration.py
@@ -12,14 +12,19 @@ from bang_py.cards.bang import BangCard
 trustme = pytest.importorskip("trustme")
 
 websockets = pytest.importorskip("websockets")
+try:  # Prefer the modern asyncio API
+    from websockets.asyncio.client import connect
+    from websockets.asyncio.server import serve
+except ModuleNotFoundError:  # pragma: no cover - older websockets versions
+    connect = websockets.connect  # type: ignore[attr-defined]
+    serve = websockets.serve  # type: ignore[attr-defined]
 
 
 def test_server_client_play_flow() -> None:
     async def run_flow() -> None:
         server = BangServer(host="localhost", port=8767, room_code="1111")
-        async with websockets.serve(server.handler, server.host, server.port):
-            async with websockets.connect("ws://localhost:8767") as ws1, \
-                       websockets.connect("ws://localhost:8767") as ws2:
+        async with serve(server.handler, server.host, server.port):
+            async with connect("ws://localhost:8767") as ws1, connect("ws://localhost:8767") as ws2:
                 # Alice join
                 await ws1.recv()
                 await ws1.send("1111")
@@ -72,10 +77,10 @@ def test_server_client_ssl(tmp_path) -> None:
 
     async def run_flow() -> None:
         ssl_client = ssl.create_default_context(cafile=str(ca_file))
-        async with websockets.serve(
+        async with serve(
             server.handler, server.host, server.port, ssl=server.ssl_context
         ):
-            async with websockets.connect(
+            async with connect(
                 "wss://localhost:8768", ssl=ssl_client
             ) as ws:
                 await ws.recv()

--- a/tests/test_network_integration.py
+++ b/tests/test_network_integration.py
@@ -54,7 +54,7 @@ def test_server_client_play_flow() -> None:
                 assert "eliminated" in data["message"]
                 assert not alice.is_alive()
 
-asyncio.run(run_flow())
+    asyncio.run(run_flow())
 
 
 def test_server_client_ssl(tmp_path) -> None:

--- a/tests/test_network_messages.py
+++ b/tests/test_network_messages.py
@@ -8,15 +8,19 @@ pytest.importorskip("cryptography")
 from bang_py.network.server import BangServer, MAX_MESSAGE_SIZE
 
 websockets = pytest.importorskip("websockets")
+try:  # Prefer the modern asyncio API
+    from websockets.asyncio.client import connect
+    from websockets.asyncio.server import serve
+except ModuleNotFoundError:  # pragma: no cover - older websockets versions
+    connect = websockets.connect  # type: ignore[attr-defined]
+    serve = websockets.serve  # type: ignore[attr-defined]
 
 
 def test_oversized_message_closes_connection() -> None:
     async def run_flow() -> None:
         server = BangServer(host="localhost", port=8770, room_code="z999")
-        async with websockets.serve(
-            server.handler, server.host, server.port, max_size=MAX_MESSAGE_SIZE
-        ):
-            async with websockets.connect("ws://localhost:8770") as ws:
+        async with serve(server.handler, server.host, server.port, max_size=MAX_MESSAGE_SIZE):
+            async with connect("ws://localhost:8770") as ws:
                 await ws.recv()
                 await ws.send("z999")
                 await ws.recv()
@@ -36,8 +40,8 @@ def test_oversized_message_closes_connection() -> None:
 def test_malformed_message_ignored() -> None:
     async def run_flow() -> None:
         server = BangServer(host="localhost", port=8771, room_code="z998")
-        async with websockets.serve(server.handler, server.host, server.port):
-            async with websockets.connect("ws://localhost:8771") as ws:
+        async with serve(server.handler, server.host, server.port):
+            async with connect("ws://localhost:8771") as ws:
                 await ws.recv()
                 await ws.send("z998")
                 await ws.recv()
@@ -55,8 +59,8 @@ def test_malformed_message_ignored() -> None:
 def test_invalid_payload_rejected() -> None:
     async def run_flow() -> None:
         server = BangServer(host="localhost", port=8772, room_code="z997")
-        async with websockets.serve(server.handler, server.host, server.port):
-            async with websockets.connect("ws://localhost:8772") as ws:
+        async with serve(server.handler, server.host, server.port):
+            async with connect("ws://localhost:8772") as ws:
                 await ws.recv()
                 await ws.send("z997")
                 await ws.recv()

--- a/tests/test_network_messages.py
+++ b/tests/test_network_messages.py
@@ -26,7 +26,10 @@ def test_oversized_message_closes_connection() -> None:
                 await ws.send("x" * (MAX_MESSAGE_SIZE + 1))
                 with pytest.raises(websockets.exceptions.ConnectionClosed) as exc:
                     await ws.recv()
-                assert exc.value.rcvd.code == 1009
+                if hasattr(exc.value, "rcvd"):
+                    assert exc.value.rcvd.code == 1009
+                else:  # pragma: no cover - older websockets versions
+                    assert exc.value.code == 1009
     asyncio.run(run_flow())
 
 

--- a/tests/test_network_messages.py
+++ b/tests/test_network_messages.py
@@ -26,7 +26,7 @@ def test_oversized_message_closes_connection() -> None:
                 await ws.send("x" * (MAX_MESSAGE_SIZE + 1))
                 with pytest.raises(websockets.exceptions.ConnectionClosed) as exc:
                     await ws.recv()
-                assert exc.value.code == 1009
+                assert exc.value.rcvd.code == 1009
     asyncio.run(run_flow())
 
 

--- a/tests/test_server_task_cleanup.py
+++ b/tests/test_server_task_cleanup.py
@@ -6,13 +6,19 @@ pytest.importorskip("cryptography")
 from bang_py.network.server import BangServer
 
 websockets = pytest.importorskip("websockets")
+try:  # Prefer the modern asyncio API
+    from websockets.asyncio.client import connect
+    from websockets.asyncio.server import serve
+except ModuleNotFoundError:  # pragma: no cover - older websockets versions
+    connect = websockets.connect  # type: ignore[attr-defined]
+    serve = websockets.serve  # type: ignore[attr-defined]
 
 
 def test_disconnect_cleans_tasks(capsys) -> None:
     async def run_flow() -> None:
         server = BangServer(host="localhost", port=8789, room_code="3333")
-        async with websockets.serve(server.handler, server.host, server.port):
-            async with websockets.connect("ws://localhost:8789") as ws:
+        async with serve(server.handler, server.host, server.port):
+            async with connect("ws://localhost:8789") as ws:
                 await ws.recv()
                 await ws.send("3333")
                 await ws.recv()


### PR DESCRIPTION
## Summary
- switch `ClientThread` to `websockets.asyncio.client.connect`
- fix test to avoid deprecated `ConnectionClosed.code`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6891a9a6627083238dc09909b3192a93