### PR TITLE
refactor: drop websockets legacy API

### DIFF
--- a/bang_py/__init__.py
+++ b/bang_py/__init__.py
@@ -28,6 +28,7 @@ from .characters.suzy_lafayette import SuzyLafayette
 from .characters.vulture_sam import VultureSam
 from .characters.willy_the_kid import WillyTheKid
 from .helpers import RankSuitIconLoader
+from .network.server import BangServer
 
 __all__ = [
     "GameManager",
@@ -57,10 +58,5 @@ __all__ = [
     "WillyTheKid",
     "create_standard_deck",
     "RankSuitIconLoader",
+    "BangServer",
 ]
-try:
-    from .network.server import BangServer
-except Exception:  # Server requires optional websockets dependency
-    BangServer = None
-else:
-    __all__.append("BangServer")

--- a/bang_py/network/client.py
+++ b/bang_py/network/client.py
@@ -5,20 +5,8 @@ import json
 import logging
 import ssl
 
-try:  # Optional websockets import for test environments
-    from websockets.asyncio.client import connect
-    from websockets.exceptions import WebSocketException
-    import websockets  # re-exported for tests
-except (ModuleNotFoundError, ImportError):  # pragma: no cover - fall back to legacy API
-    try:
-        import websockets
-        from websockets.exceptions import WebSocketException
-
-        connect = websockets.connect
-    except ModuleNotFoundError:  # pragma: no cover - handled in main()
-        connect = None  # type: ignore[assignment]
-        websockets = None  # type: ignore[assignment]
-        WebSocketException = Exception  # type: ignore[assignment]
+from websockets.asyncio.client import connect
+from websockets.exceptions import WebSocketException
 
 from .server import parse_join_token
 
@@ -57,9 +45,6 @@ async def main(
     Incoming messages are parsed as JSON when possible and printed to the
     console along with the list of players.
     """
-    if connect is None:
-        logging.error("websockets package is required for networking")
-        return
 
     if token:
         host, port, room_code = parse_join_token(

--- a/bang_py/network/server.py
+++ b/bang_py/network/server.py
@@ -11,13 +11,8 @@ import logging
 
 from cryptography.fernet import Fernet
 
-try:  # Optional websockets import for test environments
-    from websockets.asyncio.server import serve, ServerConnection
-    from websockets.exceptions import WebSocketException
-except ModuleNotFoundError:  # pragma: no cover - handled in start()
-    serve = None  # type: ignore[assignment]
-    ServerConnection = Any  # type: ignore[assignment]
-    WebSocketException = Exception  # type: ignore[assignment]
+from websockets.asyncio.server import serve, ServerConnection
+from websockets.exceptions import WebSocketException
 
 from ..game_manager import GameManager
 from ..player import Player
@@ -659,8 +654,6 @@ class BangServer:
 
     async def start(self) -> None:
         """Start the websocket server and run until cancelled."""
-        if serve is None:
-            raise RuntimeError("websockets package is required to run the server")
         async with serve(
             self.handler,
             self.host,

--- a/tests/test_name_validation.py
+++ b/tests/test_name_validation.py
@@ -7,12 +7,8 @@ pytest.importorskip("cryptography")
 from bang_py.network.server import BangServer
 
 websockets = pytest.importorskip("websockets")
-try:  # Prefer the modern asyncio API
-    from websockets.asyncio.client import connect
-    from websockets.asyncio.server import serve
-except ModuleNotFoundError:  # pragma: no cover - older websockets versions
-    connect = websockets.connect  # type: ignore[attr-defined]
-    serve = websockets.serve  # type: ignore[attr-defined]
+from websockets.asyncio.client import connect
+from websockets.asyncio.server import serve
 
 
 def test_name_too_long_rejected() -> None:

--- a/tests/test_network_client.py
+++ b/tests/test_network_client.py
@@ -1,19 +1,8 @@
-import builtins
 import importlib
-import sys
+
+from websockets.asyncio.client import connect as async_connect
 
 
-def test_client_import_without_websockets(monkeypatch):
-    """Client module should import even if websockets is missing."""
-    original_import = builtins.__import__
-
-    def fake_import(name, *args, **kwargs):
-        if name == "websockets":
-            raise ModuleNotFoundError
-        return original_import(name, *args, **kwargs)
-
-    monkeypatch.setattr(builtins, "__import__", fake_import)
-    sys.modules.pop("bang_py.network.client", None)
-
+def test_client_uses_asyncio_connect() -> None:
     module = importlib.import_module("bang_py.network.client")
-    assert module.websockets is None
+    assert module.connect is async_connect

--- a/tests/test_network_integration.py
+++ b/tests/test_network_integration.py
@@ -12,12 +12,8 @@ from bang_py.cards.bang import BangCard
 trustme = pytest.importorskip("trustme")
 
 websockets = pytest.importorskip("websockets")
-try:  # Prefer the modern asyncio API
-    from websockets.asyncio.client import connect
-    from websockets.asyncio.server import serve
-except ModuleNotFoundError:  # pragma: no cover - older websockets versions
-    connect = websockets.connect  # type: ignore[attr-defined]
-    serve = websockets.serve  # type: ignore[attr-defined]
+from websockets.asyncio.client import connect
+from websockets.asyncio.server import serve
 
 
 def test_server_client_play_flow() -> None:

--- a/tests/test_network_messages.py
+++ b/tests/test_network_messages.py
@@ -8,12 +8,8 @@ pytest.importorskip("cryptography")
 from bang_py.network.server import BangServer, MAX_MESSAGE_SIZE
 
 websockets = pytest.importorskip("websockets")
-try:  # Prefer the modern asyncio API
-    from websockets.asyncio.client import connect
-    from websockets.asyncio.server import serve
-except ModuleNotFoundError:  # pragma: no cover - older websockets versions
-    connect = websockets.connect  # type: ignore[attr-defined]
-    serve = websockets.serve  # type: ignore[attr-defined]
+from websockets.asyncio.client import connect
+from websockets.asyncio.server import serve
 
 
 def test_oversized_message_closes_connection() -> None:
@@ -30,10 +26,7 @@ def test_oversized_message_closes_connection() -> None:
                 await ws.send("x" * (MAX_MESSAGE_SIZE + 1))
                 with pytest.raises(websockets.exceptions.ConnectionClosed) as exc:
                     await ws.recv()
-                if hasattr(exc.value, "rcvd"):
-                    assert exc.value.rcvd.code == 1009
-                else:  # pragma: no cover - older websockets versions
-                    assert exc.value.code == 1009
+                assert exc.value.rcvd.code == 1009
     asyncio.run(run_flow())
 
 

--- a/tests/test_server_task_cleanup.py
+++ b/tests/test_server_task_cleanup.py
@@ -6,12 +6,8 @@ pytest.importorskip("cryptography")
 from bang_py.network.server import BangServer
 
 websockets = pytest.importorskip("websockets")
-try:  # Prefer the modern asyncio API
-    from websockets.asyncio.client import connect
-    from websockets.asyncio.server import serve
-except ModuleNotFoundError:  # pragma: no cover - older websockets versions
-    connect = websockets.connect  # type: ignore[attr-defined]
-    serve = websockets.serve  # type: ignore[attr-defined]
+from websockets.asyncio.client import connect
+from websockets.asyncio.server import serve
 
 
 def test_disconnect_cleans_tasks(capsys) -> None:


### PR DESCRIPTION
## Summary
- rely on websockets>=15's asyncio API across server, client, and Qt network threads
- export `BangServer` unconditionally
- modernize networking tests to import from `websockets.asyncio`

## Testing
- `BANG_AUTO_CLOSE=1 pytest`

------
https://chatgpt.com/codex/tasks/task_e_68926256ddf48323998622338c25ee7f