### PR TITLE
Use native collection types

### DIFF
--- a/bang_py/event_decks.py
+++ b/bang_py/event_decks.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Callable, List, TYPE_CHECKING
+from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 from .cards.events import (
     BaseEventCard,
@@ -188,7 +189,7 @@ class EventCard:
             self.apply(game)
 
 
-def create_high_noon_deck() -> List[BaseEventCard]:
+def create_high_noon_deck() -> list[BaseEventCard]:
     """Return a simple High Noon event deck."""
     return [
         BlessingEventCard(),
@@ -209,7 +210,7 @@ def create_high_noon_deck() -> List[BaseEventCard]:
     ]
 
 
-def create_fistful_deck() -> List[BaseEventCard]:
+def create_fistful_deck() -> list[BaseEventCard]:
     """Return a simple Fistful of Cards event deck."""
     return [
         AbandonedMineEventCard(),

--- a/bang_py/turn_phases/turn_flow.py
+++ b/bang_py/turn_phases/turn_flow.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import List, Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 from ..characters.jesse_jones import JesseJones
 from ..characters.jose_delgado import JoseDelgado
@@ -18,13 +18,13 @@ if TYPE_CHECKING:  # pragma: no cover - imported for type checking
 class TurnFlowMixin:
     """Manage turn progression for :class:`GameManager`."""
 
-    _players: List['Player']
-    turn_order: List[int]
+    _players: list['Player']
+    turn_order: list[int]
     current_turn: int
     phase: str
-    draw_phase_listeners: List
-    play_phase_listeners: List
-    turn_started_listeners: List
+    draw_phase_listeners: list
+    play_phase_listeners: list
+    turn_started_listeners: list
     discard_pile: list
     deck: object
     event_flags: dict
@@ -103,7 +103,7 @@ class TurnFlowMixin:
             return True
         return False
 
-    def _begin_turn(self: 'GameManager', *, blood_target: Optional['Player'] = None) -> None:
+    def _begin_turn(self: 'GameManager', *, blood_target: 'Player' | None = None) -> None:
         if not self.turn_order:
             return
         self.current_turn %= len(self.turn_order)
@@ -122,7 +122,7 @@ class TurnFlowMixin:
 
     def _run_start_turn_checks(
         self: 'GameManager', player: 'Player'
-    ) -> Optional['Player']:
+    ) -> 'Player' | None:
         """Apply start-of-turn effects returning the acting player or ``None``."""
         player = self._apply_event_start_effects(player)
         if not player:

--- a/bang_py/ui_components/card_images.py
+++ b/bang_py/ui_components/card_images.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from importlib import resources
-from typing import Dict
 
 from PySide6 import QtCore, QtGui, QtWidgets
 try:
@@ -153,8 +152,8 @@ class CardImageLoader:
     @classmethod
     def _load_templates(
         cls, width: int, height: int
-    ) -> Dict[str, QtGui.QPixmap]:
-        templates: Dict[str, QtGui.QPixmap] = {}
+    ) -> dict[str, QtGui.QPixmap]:
+        templates: dict[str, QtGui.QPixmap] = {}
         for key, fname in _TEMPLATE_FILES.items():
             path = ASSETS_DIR / fname
             with resources.as_file(path) as file_path:
@@ -169,8 +168,8 @@ class CardImageLoader:
     @classmethod
     def _load_card_backs(
         cls, width: int, height: int
-    ) -> Dict[str, QtGui.QPixmap]:
-        backs: Dict[str, QtGui.QPixmap] = {}
+    ) -> dict[str, QtGui.QPixmap]:
+        backs: dict[str, QtGui.QPixmap] = {}
         for key, fname in _CARD_BACK_FILES.items():
             path = ASSETS_DIR / fname
             with resources.as_file(path) as file_path:
@@ -188,8 +187,8 @@ class CardImageLoader:
         return backs
 
     @classmethod
-    def _load_action_icons(cls) -> Dict[str, QtGui.QPixmap]:
-        icons: Dict[str, QtGui.QPixmap] = {}
+    def _load_action_icons(cls) -> dict[str, QtGui.QPixmap]:
+        icons: dict[str, QtGui.QPixmap] = {}
         for key, fname in ACTION_ICON_MAP.items():
             path = ICON_DIR / fname
             with resources.as_file(path) as file_path:


### PR DESCRIPTION
## Summary
- use built-in generics and `| None` in turn flow, card image utilities, and event decks
- drop obsolete `typing` imports

## Testing
- `pyright bang_py/turn_phases/turn_flow.py bang_py/ui_components/card_images.py bang_py/event_decks.py` (fails: 32 errors)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892649522688323aa85f353ce6bd5c4