### PR TITLE
Add module docstrings for cards

### DIFF
--- a/bang_py/cards/__init__.py
+++ b/bang_py/cards/__init__.py
@@ -1,3 +1,5 @@
+"""Card module exports for Bang! base game and expansions."""
+
 from .card import BaseCard
 from .bang import BangCard
 from .beer import BeerCard

--- a/bang_py/cards/bang.py
+++ b/bang_py/cards/bang.py
@@ -1,3 +1,5 @@
+"""Bang! card from the base game. Basic attack that deals 1 damage unless dodged."""
+
 from __future__ import annotations
 
 from .card import BaseCard

--- a/bang_py/cards/barrel.py
+++ b/bang_py/cards/barrel.py
@@ -1,3 +1,5 @@
+"""Barrel card from the base game. Draw when targeted by Bang!; on Heart, ignore it."""
+
 from __future__ import annotations
 
 from .card import BaseCard

--- a/bang_py/cards/beer.py
+++ b/bang_py/cards/beer.py
@@ -1,3 +1,5 @@
+"""Beer card from the base game. Heals 1 health if allowed by the game rules."""
+
 from __future__ import annotations
 
 from .card import BaseCard

--- a/bang_py/cards/bible.py
+++ b/bang_py/cards/bible.py
@@ -1,3 +1,5 @@
+"""Bible card from the Dodge City expansion. Play as Missed! and then draw one card."""
+
 from __future__ import annotations
 
 from .card import BaseCard

--- a/bang_py/cards/binoculars.py
+++ b/bang_py/cards/binoculars.py
@@ -1,3 +1,5 @@
+"""Binoculars card from the Dodge City expansion. Increases attack range by 1."""
+
 from __future__ import annotations
 
 from .card import BaseCard

--- a/bang_py/cards/brawl.py
+++ b/bang_py/cards/brawl.py
@@ -1,3 +1,5 @@
+"""Brawl card from the Dodge City expansion. Discard a card to make all others discard one."""
+
 from __future__ import annotations
 
 from .card import BaseCard

--- a/bang_py/cards/buffalo_rifle.py
+++ b/bang_py/cards/buffalo_rifle.py
@@ -1,3 +1,5 @@
+"""Buffalo Rifle card from the Dodge City expansion. Bang any player regardless of distance."""
+
 from __future__ import annotations
 
 from .card import BaseCard

--- a/bang_py/cards/can_can.py
+++ b/bang_py/cards/can_can.py
@@ -1,3 +1,5 @@
+"""Can Can card from the Dodge City expansion. Choose a card to discard from any one player."""
+
 from __future__ import annotations
 
 from .card import BaseCard

--- a/bang_py/cards/canteen.py
+++ b/bang_py/cards/canteen.py
@@ -1,3 +1,5 @@
+"""Canteen card from the Dodge City expansion. Heal 1 health."""
+
 from __future__ import annotations
 
 from .card import BaseCard

--- a/bang_py/cards/carbine.py
+++ b/bang_py/cards/carbine.py
@@ -1,3 +1,5 @@
+"""Carbine card from the base game. Gun with range 4."""
+
 from __future__ import annotations
 
 from .card import BaseCard

--- a/bang_py/cards/card.py
+++ b/bang_py/cards/card.py
@@ -1,3 +1,5 @@
+"""Base class and metadata for all Bang! playing cards."""
+
 from __future__ import annotations
 
 from abc import ABC, abstractmethod

--- a/bang_py/cards/cat_balou.py
+++ b/bang_py/cards/cat_balou.py
@@ -1,3 +1,6 @@
+"""Cat Balou card from the base game. Choose a card from the target's hand or in play and discard
+it."""
+
 from __future__ import annotations
 from .card import BaseCard
 from ..player import Player

--- a/bang_py/cards/conestoga.py
+++ b/bang_py/cards/conestoga.py
@@ -1,3 +1,5 @@
+"""Conestoga card from the Dodge City expansion. Steal a card from any player."""
+
 from __future__ import annotations
 
 from .card import BaseCard

--- a/bang_py/cards/derringer.py
+++ b/bang_py/cards/derringer.py
@@ -1,3 +1,5 @@
+"""Derringer card from the Dodge City expansion. Bang at range 1, then draw a card."""
+
 from __future__ import annotations
 
 from .card import BaseCard

--- a/bang_py/cards/duel.py
+++ b/bang_py/cards/duel.py
@@ -1,3 +1,5 @@
+"""Duel card from the base game. Players alternate discarding Bang! cards; loser takes 1 damage."""
+
 from __future__ import annotations
 
 from .card import BaseCard

--- a/bang_py/cards/dynamite.py
+++ b/bang_py/cards/dynamite.py
@@ -1,3 +1,6 @@
+"""Dynamite card from the base game. Passes around; at the start of your turn draw a card, and if it
+is a spade between 2 and 9, Dynamite explodes for 3 damage."""
+
 from __future__ import annotations
 
 from .card import BaseCard

--- a/bang_py/cards/events/__init__.py
+++ b/bang_py/cards/events/__init__.py
@@ -1,3 +1,5 @@
+"""Event card exports for expansions like High Noon and Fistful of Cards."""
+
 from .base import BaseEventCard
 from .abandoned_mine import AbandonedMineEventCard
 from .ambush import AmbushEventCard

--- a/bang_py/cards/events/abandoned_mine.py
+++ b/bang_py/cards/events/abandoned_mine.py
@@ -1,3 +1,6 @@
+"""Abandoned Mine card from the Fistful of Cards expansion. During draw, draw from discard pile if
+possible. Discards go face down on top of the deck."""
+
 from __future__ import annotations
 
 from .base import BaseEventCard

--- a/bang_py/cards/events/ambush.py
+++ b/bang_py/cards/events/ambush.py
@@ -1,3 +1,6 @@
+"""Ambush card from the Fistful of Cards expansion. The distance between any two players is 1. Only
+other cards in play may modify this."""
+
 from __future__ import annotations
 
 from .base import BaseEventCard

--- a/bang_py/cards/events/base.py
+++ b/bang_py/cards/events/base.py
@@ -1,3 +1,5 @@
+"""Base class for event deck cards used by various expansions."""
+
 from __future__ import annotations
 
 from ...player import Player

--- a/bang_py/cards/events/blessing.py
+++ b/bang_py/cards/events/blessing.py
@@ -1,3 +1,5 @@
+"""Blessing card from the High Noon expansion. All cards are Hearts"""
+
 from __future__ import annotations
 
 from .base import BaseEventCard

--- a/bang_py/cards/events/blood_brothers.py
+++ b/bang_py/cards/events/blood_brothers.py
@@ -1,3 +1,6 @@
+"""Blood Brothers card from the Fistful of Cards expansion. At the beginning of his turn, each
+player may choose to lose 1 life (but not their last life) to give 1 life point to any player."""
+
 from __future__ import annotations
 
 from .base import BaseEventCard

--- a/bang_py/cards/events/curse.py
+++ b/bang_py/cards/events/curse.py
@@ -1,3 +1,5 @@
+"""Curse card from the High Noon expansion. All cards are Spades"""
+
 from __future__ import annotations
 
 from .base import BaseEventCard

--- a/bang_py/cards/events/dead_man.py
+++ b/bang_py/cards/events/dead_man.py
@@ -1,3 +1,6 @@
+"""Dead Man card from the Fistful of Cards expansion. During his turn, the player that was
+eliminated first comes back with 2 life and 2 cards."""
+
 from __future__ import annotations
 
 from .base import BaseEventCard

--- a/bang_py/cards/events/fistful_of_cards.py
+++ b/bang_py/cards/events/fistful_of_cards.py
@@ -1,3 +1,6 @@
+"""A Fistful of Cards card from the Fistful of Cards expansion. At the beginning of his turn, each
+player is the target of as many Bangs! as cards in their hand."""
+
 from __future__ import annotations
 
 from .base import BaseEventCard

--- a/bang_py/cards/events/ghost_town.py
+++ b/bang_py/cards/events/ghost_town.py
@@ -1,3 +1,6 @@
+"""Ghost Town card from the High Noon expansion. During their turn, eliminated players come back as
+ghosts with 3 cards and cannot die. At the end of their turn, they are eliminated again."""
+
 from __future__ import annotations
 
 from .base import BaseEventCard

--- a/bang_py/cards/events/gold_rush.py
+++ b/bang_py/cards/events/gold_rush.py
@@ -1,3 +1,6 @@
+"""Gold Rush card from the High Noon expansion. The game proceeds counter-clockwise, but card
+effects still proceed clockwise."""
+
 from __future__ import annotations
 
 from .base import BaseEventCard

--- a/bang_py/cards/events/handcuffs.py
+++ b/bang_py/cards/events/handcuffs.py
@@ -1,3 +1,6 @@
+"""Handcuffs card from the High Noon expansion. After their draw phase, each player announces a suit
+and can only play that suit for the rest of their turn."""
+
 from __future__ import annotations
 
 from .base import BaseEventCard

--- a/bang_py/cards/events/hangover.py
+++ b/bang_py/cards/events/hangover.py
@@ -1,3 +1,5 @@
+"""Hangover card from the High Noon expansion. All characters lose their abilities."""
+
 from __future__ import annotations
 
 from .base import BaseEventCard

--- a/bang_py/cards/events/hard_liquor.py
+++ b/bang_py/cards/events/hard_liquor.py
@@ -1,3 +1,5 @@
+"""Hard Liquor card from the Fistful of Cards expansion. Skip draw to heal 1"""
+
 from __future__ import annotations
 
 from .base import BaseEventCard

--- a/bang_py/cards/events/high_noon.py
+++ b/bang_py/cards/events/high_noon.py
@@ -1,3 +1,5 @@
+"""High Noon card from the High Noon expansion. Lose 1 life at start of turn"""
+
 from __future__ import annotations
 
 from .base import BaseEventCard

--- a/bang_py/cards/events/lasso.py
+++ b/bang_py/cards/events/lasso.py
@@ -1,3 +1,6 @@
+"""Lasso card from the Fistful of Cards expansion. Cards in play in front of players have no
+effect."""
+
 from __future__ import annotations
 
 from .base import BaseEventCard

--- a/bang_py/cards/events/law_of_the_west.py
+++ b/bang_py/cards/events/law_of_the_west.py
@@ -1,3 +1,6 @@
+"""Law of the West card from the Fistful of Cards expansion. During their draw phase, each player
+must reveal the second card they drew and play it immediately if possible."""
+
 from __future__ import annotations
 
 from .base import BaseEventCard

--- a/bang_py/cards/events/new_identity.py
+++ b/bang_py/cards/events/new_identity.py
@@ -1,3 +1,6 @@
+"""New Identity card from the High Noon expansion. At the start of their turn,
+each player may look at their other face down character card and switch to it with 2 life."""
+
 from __future__ import annotations
 
 from .base import BaseEventCard

--- a/bang_py/cards/events/peyote.py
+++ b/bang_py/cards/events/peyote.py
@@ -1,3 +1,6 @@
+"""Peyote card from the Fistful of Cards expansion. During their draw phase, each player guesses red
+or black. They reveal the top card; if correct they repeat until wrong."""
+
 from __future__ import annotations
 
 from .base import BaseEventCard

--- a/bang_py/cards/events/ranch.py
+++ b/bang_py/cards/events/ranch.py
@@ -1,3 +1,5 @@
+"""Ranch card from the Fistful of Cards expansion. Optional discard and redraw"""
+
 from __future__ import annotations
 
 from .base import BaseEventCard

--- a/bang_py/cards/events/ricochet.py
+++ b/bang_py/cards/events/ricochet.py
@@ -1,3 +1,5 @@
+"""Ricochet card from the Fistful of Cards expansion. Bang! to discard cards in play"""
+
 from __future__ import annotations
 
 from .base import BaseEventCard

--- a/bang_py/cards/events/russian_roulette.py
+++ b/bang_py/cards/events/russian_roulette.py
@@ -1,3 +1,7 @@
+"""Russian Roulette card from the Fistful of Cards expansion. When Russian Roulette enters play,
+starting with the Sheriff each player discards a Missed! The first not to do so loses 2 life
+points."""
+
 from __future__ import annotations
 
 from .base import BaseEventCard

--- a/bang_py/cards/events/shootout.py
+++ b/bang_py/cards/events/shootout.py
@@ -1,3 +1,6 @@
+"""Shootout card from the High Noon expansion. Each player may play a second Bang! card during their
+turn."""
+
 from __future__ import annotations
 
 from .base import BaseEventCard

--- a/bang_py/cards/events/sniper.py
+++ b/bang_py/cards/events/sniper.py
@@ -1,3 +1,7 @@
+"""Sniper card from the Fistful of Cards expansion. During their turn, each player may discard 2
+Bang! cards together against a player. It counts as 1 Bang!, but can only be countered by 2
+Missed!"""
+
 from __future__ import annotations
 
 from .base import BaseEventCard

--- a/bang_py/cards/events/the_daltons.py
+++ b/bang_py/cards/events/the_daltons.py
@@ -1,3 +1,6 @@
+"""The Daltons card from the High Noon expansion. When The Daltons enters play, each player that has
+any blue cards in front of them must choose one to discard."""
+
 from __future__ import annotations
 
 from .base import BaseEventCard

--- a/bang_py/cards/events/the_doctor.py
+++ b/bang_py/cards/events/the_doctor.py
@@ -1,3 +1,6 @@
+"""The Doctor card from the High Noon expansion. When The Doctor enters play, the player(s) still in
+the game with the fewest life points regain 1 life point."""
+
 from __future__ import annotations
 
 from .base import BaseEventCard

--- a/bang_py/cards/events/the_judge.py
+++ b/bang_py/cards/events/the_judge.py
@@ -1,3 +1,6 @@
+"""The Judge card from the Fistful of Cards expansion. Players cannot play cards in front of
+themselves or others."""
+
 from __future__ import annotations
 
 from .base import BaseEventCard

--- a/bang_py/cards/events/the_reverend.py
+++ b/bang_py/cards/events/the_reverend.py
@@ -1,3 +1,5 @@
+"""The Reverend card from the High Noon expansion. Beer cannot be played"""
+
 from __future__ import annotations
 
 from .base import BaseEventCard

--- a/bang_py/cards/events/the_sermon.py
+++ b/bang_py/cards/events/the_sermon.py
@@ -1,3 +1,5 @@
+"""The Sermon card from the High Noon expansion. Bang! cannot be played"""
+
 from __future__ import annotations
 
 from .base import BaseEventCard

--- a/bang_py/cards/events/thirst.py
+++ b/bang_py/cards/events/thirst.py
@@ -1,3 +1,5 @@
+"""Thirst card from the High Noon expansion. Players draw only one card"""
+
 from __future__ import annotations
 
 from .base import BaseEventCard

--- a/bang_py/cards/events/train_arrival.py
+++ b/bang_py/cards/events/train_arrival.py
@@ -1,3 +1,6 @@
+"""Train Arrival card from the High Noon expansion. During their draw phase, each player draws an
+additional card."""
+
 from __future__ import annotations
 
 from .base import BaseEventCard

--- a/bang_py/cards/events/vendetta.py
+++ b/bang_py/cards/events/vendetta.py
@@ -1,3 +1,6 @@
+"""Vendetta card from the Fistful of Cards expansion. At the end of their turn, each player draws!
+On a heart, they may play another turn. They cannot benefit again."""
+
 from __future__ import annotations
 
 from .base import BaseEventCard

--- a/bang_py/cards/gatling.py
+++ b/bang_py/cards/gatling.py
@@ -1,3 +1,5 @@
+"""Gatling card from the base game. Bang every other player once."""
+
 from __future__ import annotations
 
 from .card import BaseCard

--- a/bang_py/cards/general_store.py
+++ b/bang_py/cards/general_store.py
@@ -1,3 +1,6 @@
+"""General Store card from the base game. Reveal cards for all players to choose one in turn
+order."""
+
 from __future__ import annotations
 
 from .card import BaseCard

--- a/bang_py/cards/hideout.py
+++ b/bang_py/cards/hideout.py
@@ -1,3 +1,5 @@
+"""Hideout card from the Dodge City expansion. Opponents see you at +1 distance."""
+
 from __future__ import annotations
 
 from .card import BaseCard

--- a/bang_py/cards/high_noon_card.py
+++ b/bang_py/cards/high_noon_card.py
@@ -1,3 +1,5 @@
+"""High Noon card from the High Noon expansion. Event: everyone draws one card."""
+
 from __future__ import annotations
 
 from .card import BaseCard

--- a/bang_py/cards/howitzer.py
+++ b/bang_py/cards/howitzer.py
@@ -1,3 +1,5 @@
+"""Howitzer card from the Dodge City expansion. Bang all opponents ignoring distance."""
+
 from __future__ import annotations
 
 from .card import BaseCard

--- a/bang_py/cards/indians.py
+++ b/bang_py/cards/indians.py
@@ -1,3 +1,5 @@
+"""Indians! card from the base game. Others discard Bang! or suffer 1 damage."""
+
 from __future__ import annotations
 
 from .card import BaseCard

--- a/bang_py/cards/iron_plate.py
+++ b/bang_py/cards/iron_plate.py
@@ -1,3 +1,5 @@
+"""Iron Plate card from the Dodge City expansion. Counts as a Missed!"""
+
 from __future__ import annotations
 
 from .missed import MissedCard

--- a/bang_py/cards/jail.py
+++ b/bang_py/cards/jail.py
@@ -1,3 +1,5 @@
+"""Jail card from the base game. Skip your turn unless you draw a Heart."""
+
 from __future__ import annotations
 
 from .card import BaseCard

--- a/bang_py/cards/knife.py
+++ b/bang_py/cards/knife.py
@@ -1,3 +1,5 @@
+"""Knife card from the Dodge City expansion. Attack at distance 1 that can be dodged."""
+
 from __future__ import annotations
 
 from .card import BaseCard

--- a/bang_py/cards/missed.py
+++ b/bang_py/cards/missed.py
@@ -1,3 +1,5 @@
+"""Missed! card from the base game. Negates one Bang! targeting you."""
+
 from __future__ import annotations
 
 from .card import BaseCard

--- a/bang_py/cards/mustang.py
+++ b/bang_py/cards/mustang.py
@@ -1,3 +1,5 @@
+"""Mustang card from the base game. Opponents see you at 1 greater distance."""
+
 from __future__ import annotations
 
 from .card import BaseCard

--- a/bang_py/cards/panic.py
+++ b/bang_py/cards/panic.py
@@ -1,3 +1,6 @@
+"""Panic! card from the base game. Range 1: choose a card from the target's hand or in play and take
+it."""
+
 from __future__ import annotations
 from .card import BaseCard
 from ..player import Player

--- a/bang_py/cards/pepperbox.py
+++ b/bang_py/cards/pepperbox.py
@@ -1,3 +1,5 @@
+"""Pepperbox card from the Dodge City expansion. Acts as a normal Bang!"""
+
 from __future__ import annotations
 
 from .card import BaseCard

--- a/bang_py/cards/pony_express.py
+++ b/bang_py/cards/pony_express.py
@@ -1,3 +1,5 @@
+"""Pony Express card from the Fistful of Cards expansion. Draw three cards."""
+
 from __future__ import annotations
 
 from .card import BaseCard

--- a/bang_py/cards/punch.py
+++ b/bang_py/cards/punch.py
@@ -1,3 +1,5 @@
+"""Punch card from the Dodge City expansion. Deal 1 damage if the target is within distance 1."""
+
 from __future__ import annotations
 
 from .card import BaseCard

--- a/bang_py/cards/rag_time.py
+++ b/bang_py/cards/rag_time.py
@@ -1,3 +1,6 @@
+"""Rag Time card from the Fistful of Cards expansion. Discard another card to take a card from any
+player."""
+
 from __future__ import annotations
 
 from .card import BaseCard

--- a/bang_py/cards/remington.py
+++ b/bang_py/cards/remington.py
@@ -1,3 +1,5 @@
+"""Remington card from the base game. Gun with range 3."""
+
 from __future__ import annotations
 
 from .card import BaseCard

--- a/bang_py/cards/rev_carabine.py
+++ b/bang_py/cards/rev_carabine.py
@@ -1,3 +1,5 @@
+"""Rev. Carabine card from the Dodge City expansion. Gun with range 4."""
+
 from __future__ import annotations
 
 from .card import BaseCard

--- a/bang_py/cards/roles/__init__.py
+++ b/bang_py/cards/roles/__init__.py
@@ -1,3 +1,5 @@
+"""Role card exports defining player objectives."""
+
 from .base import BaseRole
 from .sheriff import SheriffRoleCard
 from .deputy import DeputyRoleCard

--- a/bang_py/cards/roles/base.py
+++ b/bang_py/cards/roles/base.py
@@ -1,3 +1,5 @@
+"""Base class for role cards defining victory conditions in the base game."""
+
 from __future__ import annotations
 
 from abc import ABC, abstractmethod

--- a/bang_py/cards/roles/deputy.py
+++ b/bang_py/cards/roles/deputy.py
@@ -1,3 +1,5 @@
+"""Deputy role from the base game; wins with the Sheriff when all enemies are gone."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/bang_py/cards/roles/outlaw.py
+++ b/bang_py/cards/roles/outlaw.py
@@ -1,3 +1,5 @@
+"""Outlaw role from the base game; wins by eliminating the Sheriff."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/bang_py/cards/roles/renegade.py
+++ b/bang_py/cards/roles/renegade.py
@@ -1,3 +1,5 @@
+"""Renegade role from the base game; aims to be last alive after the Sheriff falls."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/bang_py/cards/roles/sheriff.py
+++ b/bang_py/cards/roles/sheriff.py
@@ -1,3 +1,5 @@
+"""Sheriff role from the base game; wins by eliminating all Outlaws and the Renegade."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/bang_py/cards/saloon.py
+++ b/bang_py/cards/saloon.py
@@ -1,3 +1,5 @@
+"""Saloon card from the base game. All players heal 1 health."""
+
 from __future__ import annotations
 
 from .card import BaseCard

--- a/bang_py/cards/schofield.py
+++ b/bang_py/cards/schofield.py
@@ -1,3 +1,5 @@
+"""Schofield card from the base game. Gun with range 2."""
+
 from __future__ import annotations
 
 from .card import BaseCard

--- a/bang_py/cards/scope.py
+++ b/bang_py/cards/scope.py
@@ -1,3 +1,5 @@
+"""Scope card from the base game. Increases your attack range by 1."""
+
 from __future__ import annotations
 
 from .card import BaseCard

--- a/bang_py/cards/sombrero.py
+++ b/bang_py/cards/sombrero.py
@@ -1,3 +1,5 @@
+"""Sombrero card from the Dodge City expansion. Counts as a Missed!"""
+
 from __future__ import annotations
 
 from .missed import MissedCard

--- a/bang_py/cards/springfield.py
+++ b/bang_py/cards/springfield.py
@@ -1,3 +1,5 @@
+"""Springfield card from the Dodge City expansion. Discard another card to Bang! any player."""
+
 from __future__ import annotations
 
 from .card import BaseCard

--- a/bang_py/cards/stagecoach.py
+++ b/bang_py/cards/stagecoach.py
@@ -1,3 +1,5 @@
+"""Stagecoach card from the base game. Draw two cards."""
+
 from __future__ import annotations
 
 from .card import BaseCard

--- a/bang_py/cards/ten_gallon_hat.py
+++ b/bang_py/cards/ten_gallon_hat.py
@@ -1,3 +1,5 @@
+"""Ten Gallon Hat card from the Dodge City expansion. Counts as a Missed!"""
+
 from __future__ import annotations
 
 from .missed import MissedCard

--- a/bang_py/cards/tequila.py
+++ b/bang_py/cards/tequila.py
@@ -1,3 +1,6 @@
+"""Tequila card from the Fistful of Cards expansion. Discard another card with Tequila to heal 1
+health."""
+
 from __future__ import annotations
 
 from .card import BaseCard

--- a/bang_py/cards/volcanic.py
+++ b/bang_py/cards/volcanic.py
@@ -1,3 +1,5 @@
+"""Volcanic card from the base game. Gun with range 1. Allows unlimited Bang! cards per turn."""
+
 from __future__ import annotations
 
 from .card import BaseCard

--- a/bang_py/cards/wells_fargo.py
+++ b/bang_py/cards/wells_fargo.py
@@ -1,3 +1,5 @@
+"""Wells Fargo card from the base game. Draw three cards."""
+
 from __future__ import annotations
 
 from .card import BaseCard

--- a/bang_py/cards/whisky.py
+++ b/bang_py/cards/whisky.py
@@ -1,3 +1,6 @@
+"""Whisky card from the Fistful of Cards expansion. Discard another card with Whisky to heal 2
+health."""
+
 from __future__ import annotations
 
 from .card import BaseCard

--- a/bang_py/cards/winchester.py
+++ b/bang_py/cards/winchester.py
@@ -1,3 +1,5 @@
+"""Winchester card from the base game. Gun with range 5."""
+
 from __future__ import annotations
 
 from .card import BaseCard


### PR DESCRIPTION
## Summary
- add module docstrings for all card modules
- reference relevant expansions in each docstring

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68926952a5148323ab562770c5d451d6