### PR TITLE
Mark slow tests and document execution

### DIFF
--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,4 +1,9 @@
 # Test Guidelines
 - Set the event deck explicitly or call `random.seed()` in tests to avoid flaky behavior.
-- The `test_bang_executable` test is marked `@pytest.mark.slow` and skipped by default.
-  Run it manually with `pytest -m slow` when PyInstaller is available.
+- The following tests are marked `@pytest.mark.slow` and skipped by default:
+  - `test_bang_executable` verifies the PyInstaller build. Run it with
+    `pytest -m slow tests/test_bang_executable.py` when PyInstaller is available.
+  - `test_full_game_simulation` plays automated games for multiple player counts.
+    Execute it via `pytest -m slow tests/test_full_game_simulation.py`.
+  - `test_network_integration` exercises websocket server/client flow and SSL. Run it
+    with `pytest -m slow tests/test_network_integration.py`.

--- a/tests/test_full_game_simulation.py
+++ b/tests/test_full_game_simulation.py
@@ -1,8 +1,21 @@
 import random
 from typing import List
 
-from bang_py.game_manager import GameManager
-from bang_py.player import Player
+import pytest
+
+from bang_py.cards import (
+    BangCard,
+    BeerCard,
+    StagecoachCard,
+    WellsFargoCard,
+    CatBalouCard,
+    PanicCard,
+    IndiansCard,
+    DuelCard,
+    GeneralStoreCard,
+    SaloonCard,
+    GatlingCard,
+)
 from bang_py.cards.roles import (
     SheriffRoleCard,
     DeputyRoleCard,
@@ -25,19 +38,8 @@ from bang_py.characters.slab_the_killer import SlabTheKiller
 from bang_py.characters.suzy_lafayette import SuzyLafayette
 from bang_py.characters.vulture_sam import VultureSam
 from bang_py.characters.willy_the_kid import WillyTheKid
-from bang_py.cards import (
-    BangCard,
-    BeerCard,
-    StagecoachCard,
-    WellsFargoCard,
-    CatBalouCard,
-    PanicCard,
-    IndiansCard,
-    DuelCard,
-    GeneralStoreCard,
-    SaloonCard,
-    GatlingCard,
-)
+from bang_py.game_manager import GameManager
+from bang_py.player import Player
 
 CHAR_CLASSES = [
     BartCassidy,
@@ -191,7 +193,8 @@ def simulate_game(num_players: int) -> str:
     return result[0]
 
 
-def test_full_game_simulation() -> None:
-    for n in range(4, 8):
-        outcome = simulate_game(n)
-        assert "win" in outcome
+@pytest.mark.slow
+@pytest.mark.parametrize("num_players", range(4, 8))
+def test_full_game_simulation(num_players: int) -> None:
+    outcome = simulate_game(num_players)
+    assert "win" in outcome

--- a/tests/test_network_integration.py
+++ b/tests/test_network_integration.py
@@ -5,15 +5,17 @@ import ssl
 import pytest
 
 pytest.importorskip("cryptography")
+pytest.importorskip("trustme")
+pytest.importorskip("websockets")
 
-from bang_py.network.server import BangServer
-from bang_py.cards.bang import BangCard
-
-trustme = pytest.importorskip("trustme")
-
-websockets = pytest.importorskip("websockets")
+import trustme
 from websockets.asyncio.client import connect
 from websockets.asyncio.server import serve
+
+from bang_py.cards.bang import BangCard
+from bang_py.network.server import BangServer
+
+pytestmark = pytest.mark.slow
 
 
 def test_server_client_play_flow() -> None:


### PR DESCRIPTION
## Summary
- Parameterize and mark the full game simulation test as slow so it runs only when explicitly requested.
- Simplify network integration test imports and tag the module as a slow test suite.
- Document available slow tests and how to invoke them.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689272b9ac588323af2cb48621435311