### PR TITLE
Organize event modules into package

### DIFF
--- a/bang_py/events/__init__.py
+++ b/bang_py/events/__init__.py
@@ -1,0 +1,7 @@
+"""Event deck implementations and logic for optional expansions.
+
+This package contains helpers for constructing event decks, applying their
+effects during gameplay, and notifying game components of event-driven
+changes. It centralizes all event-related utilities used by the Bang game
+manager.
+"""

--- a/bang_py/events/event_decks.py
+++ b/bang_py/events/event_decks.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
-from .cards.events import (
+from ..cards.events import (
     BaseEventCard,
     AbandonedMineEventCard,
     AmbushEventCard,
@@ -39,10 +39,10 @@ from .cards.events import (
     HandcuffsEventCard,
     NewIdentityEventCard,
 )
-from .player import Player
+from ..player import Player
 
 if TYPE_CHECKING:
-    from .game_manager import GameManager
+    from ..game_manager import GameManager
 
 
 def _peyote(game: GameManager) -> None:

--- a/bang_py/events/event_hooks.py
+++ b/bang_py/events/event_hooks.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 from typing import List, Optional, TYPE_CHECKING
 
-from .cards.roles import SheriffRoleCard
-from .cards.card import BaseCard
+from ..cards.roles import SheriffRoleCard
+from ..cards.card import BaseCard
 
 if TYPE_CHECKING:  # pragma: no cover - imported for type checking
-    from .player import Player
-    from .game_manager import GameManager
+    from ..player import Player
+    from ..game_manager import GameManager
 
 
 class EventHooksMixin:

--- a/bang_py/events/event_logic.py
+++ b/bang_py/events/event_logic.py
@@ -6,11 +6,11 @@ from typing import List, Optional, TYPE_CHECKING
 import random
 
 from .event_decks import EventCard, create_high_noon_deck, create_fistful_deck
-from .cards.roles import SheriffRoleCard
-from .player import Player
+from ..cards.roles import SheriffRoleCard
+from ..player import Player
 
 if TYPE_CHECKING:
-    from .game_manager import GameManager
+    from ..game_manager import GameManager
 
 
 class EventLogicMixin:

--- a/bang_py/game_manager.py
+++ b/bang_py/game_manager.py
@@ -8,14 +8,14 @@ from typing import Callable, List, Optional, Sequence
 from .deck import Deck
 from .cards.card import BaseCard
 from .player import Player
-from .event_decks import EventCard
-from .event_logic import EventLogicMixin
+from .events.event_decks import EventCard
+from .events.event_logic import EventLogicMixin
 from .card_handlers import CardHandlersMixin
 from .general_store import GeneralStoreMixin
 from .turn_phases import TurnPhasesMixin
 from .deck_manager import DeckManagerMixin
 from .ability_dispatch import AbilityDispatchMixin
-from .event_hooks import EventHooksMixin
+from .events.event_hooks import EventHooksMixin
 
 
 @dataclass

--- a/tests/test_bullet_event_cards.py
+++ b/tests/test_bullet_event_cards.py
@@ -1,7 +1,7 @@
 from bang_py.game_manager import GameManager
 from bang_py.player import Player
 from bang_py.cards.roles import SheriffRoleCard, OutlawRoleCard
-from bang_py.event_decks import create_high_noon_deck, create_fistful_deck
+from bang_py.events.event_decks import create_high_noon_deck, create_fistful_deck
 from bang_py.cards.events import (
     HandcuffsEventCard,
     NewIdentityEventCard,

--- a/tests/test_event_deck_effects.py
+++ b/tests/test_event_deck_effects.py
@@ -1,4 +1,4 @@
-from bang_py.event_decks import (
+from bang_py.events.event_decks import (
     EventCard,
     _thirst,
     _fistful,


### PR DESCRIPTION
## Summary
- Move event deck files into new `bang_py.events` package
- Update imports to reference `bang_py.events.*`
- Document event utilities package

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689277acd920832390bb2773055cd405