### PR TITLE
Add caching for composed card pixmaps

### DIFF
--- a/tests/test_card_image_loader.py
+++ b/tests/test_card_image_loader.py
@@ -93,3 +93,26 @@ def test_action_icons_loaded(key, qt_app):
     loader = CardImageLoader()
     icon = loader.action_icons.get(key)
     assert icon is not None and not icon.isNull()
+
+
+def test_compose_card_uses_cache(qt_app):
+    loader = CardImageLoader()
+    first = loader.compose_card("brown", rank="A", suit="Spades")
+    second = loader.compose_card("brown", rank="A", suit="Spades")
+    assert first is second
+
+
+def test_clear_cache_invalidates(qt_app):
+    loader = CardImageLoader()
+    first = loader.compose_card("brown", rank="A", suit="Spades")
+    loader.clear_cache()
+    second = loader.compose_card("brown", rank="A", suit="Spades")
+    assert first is not second
+
+
+def test_reload_assets_clears_cache(qt_app):
+    loader = CardImageLoader()
+    first = loader.compose_card("brown", rank="A", suit="Spades")
+    loader.reload_assets()
+    second = loader.compose_card("brown", rank="A", suit="Spades")
+    assert first is not second


### PR DESCRIPTION
## Summary
- cache composed card pixmaps in `CardImageLoader` keyed by card parameters
- expose `clear_cache` and `reload_assets` to invalidate cached pixmaps when templates or assets change
- test cache reuse and invalidation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892a8c6273c8323a56d97228ad8cca6