### PR TITLE
refactor: use built-in collection annotations

### DIFF
--- a/bang_py/ability_dispatch.py
+++ b/bang_py/ability_dispatch.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import List, Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 from .cards.bang import BangCard
 from .cards.missed import MissedCard
@@ -20,7 +20,7 @@ class AbilityDispatchMixin:
     """Implement miscellaneous character abilities."""
 
     event_flags: dict
-    discard_pile: List[BaseCard]
+    discard_pile: list[BaseCard]
 
     def chuck_wengam_ability(self: 'GameManager', player: 'Player') -> None:
         """Lose 1 life to draw 2 cards, usable multiple times per turn."""
@@ -31,7 +31,7 @@ class AbilityDispatchMixin:
         self.draw_card(player, 2)
 
     def doc_holyday_ability(
-        self, player: 'Player', indices: List[int] | None = None
+        self, player: 'Player', indices: list[int] | None = None
     ) -> None:
         """Discard two cards to gain a Bang! that doesn't count toward the limit."""
         if player.metadata.doc_used:

--- a/bang_py/deck.py
+++ b/bang_py/deck.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from random import shuffle
-from typing import List
 
 from .cards.card import BaseCard
 
@@ -9,8 +8,8 @@ from .cards.card import BaseCard
 class Deck:
     """Simple deck of cards supporting drawing."""
 
-    def __init__(self, cards: List[BaseCard] | None = None) -> None:
-        self.cards: List[BaseCard] = cards[:] if cards else []
+    def __init__(self, cards: list[BaseCard] | None = None) -> None:
+        self.cards: list[BaseCard] = cards[:] if cards else []
         shuffle(self.cards)
 
     def draw(self) -> BaseCard | None:

--- a/bang_py/deck_factory.py
+++ b/bang_py/deck_factory.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import random
-from typing import Iterable, List, Tuple, Type
+from typing import Iterable
 
 from .deck import Deck
 from .cards import (
@@ -54,7 +54,7 @@ from .cards import (
 from .cards.card import BaseCard
 
 
-CARD_COUNTS: List[Tuple[Type[BaseCard], int]] = [
+CARD_COUNTS: list[tuple[type[BaseCard], int]] = [
     (BangCard, 25),
     (MissedCard, 12),
     (BeerCard, 6),
@@ -80,7 +80,7 @@ CARD_COUNTS: List[Tuple[Type[BaseCard], int]] = [
 ]
 
 # Additional cards provided by expansions
-DODGE_CITY_COUNTS: List[Tuple[Type[BaseCard], int]] = [
+DODGE_CITY_COUNTS: list[tuple[type[BaseCard], int]] = [
     (PunchCard, 4),
     (HideoutCard, 2),
     (BinocularsCard, 2),
@@ -101,14 +101,14 @@ DODGE_CITY_COUNTS: List[Tuple[Type[BaseCard], int]] = [
     (RevCarabineCard, 1),
 ]
 
-FISTFUL_COUNTS: List[Tuple[Type[BaseCard], int]] = [
+FISTFUL_COUNTS: list[tuple[type[BaseCard], int]] = [
     (WhiskyCard, 2),
     (TequilaCard, 3),
     (PonyExpressCard, 2),
     (RagTimeCard, 2),
 ]
 
-HIGH_NOON_COUNTS: List[Tuple[Type[BaseCard], int]] = [
+HIGH_NOON_COUNTS: list[tuple[type[BaseCard], int]] = [
     (HighNoonCard, 1),
 ]
 
@@ -119,11 +119,11 @@ EXPANSION_CARDS = {
 }
 
 
-def _generate_suits(count: int) -> List[str]:
+def _generate_suits(count: int) -> list[str]:
     """Return a shuffled list of suits with nearly even distribution."""
     base = count // 4
     extra = count % 4
-    suits_pool: List[str] = []
+    suits_pool: list[str] = []
     for i, suit in enumerate(["Hearts", "Diamonds", "Clubs", "Spades"]):
         suits_pool.extend([suit] * (base + (1 if i < extra else 0)))
     random.shuffle(suits_pool)
@@ -148,7 +148,7 @@ def create_standard_deck(expansions: Iterable[str] | None = None) -> Deck:
     ranks = list(range(1, 14)) * (total // 13 + 1)
     random.shuffle(ranks)
 
-    cards: List[BaseCard] = []
+    cards: list[BaseCard] = []
     idx = 0
     for card_cls, count in card_counts:
         for _ in range(count):

--- a/bang_py/deck_manager.py
+++ b/bang_py/deck_manager.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import List, Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING
 import random
 
 from .deck import Deck
@@ -26,12 +26,12 @@ class DeckManagerMixin:
     """Handle deck setup and player turn ordering."""
 
     deck: Deck | None
-    expansions: List[str]
-    _players: List['Player']
-    discard_pile: List[BaseCard]
+    expansions: list[str]
+    _players: list['Player']
+    discard_pile: list[BaseCard]
     event_flags: dict
     current_turn: int
-    turn_order: List[int]
+    turn_order: list[int]
 
     def _initialize_main_deck(self: 'GameManager') -> None:
         """Create the main deck if needed and ensure event flags exist."""
@@ -75,7 +75,7 @@ class DeckManagerMixin:
 
     # ------------------------------------------------------------------
     # Setup helpers
-    def _build_role_deck(self: 'GameManager') -> List[BaseRole]:
+    def _build_role_deck(self: 'GameManager') -> list[BaseRole]:
         role_map = {
             3: [DeputyRoleCard, OutlawRoleCard, RenegadeRoleCard],
             4: [SheriffRoleCard, RenegadeRoleCard, OutlawRoleCard, OutlawRoleCard],
@@ -119,7 +119,7 @@ class DeckManagerMixin:
             raise ValueError("Unsupported player count")
         return [cls() for cls in classes]
 
-    def _build_character_deck(self: 'GameManager') -> List[type[BaseCharacter]]:
+    def _build_character_deck(self: 'GameManager') -> list[type[BaseCharacter]]:
         from . import characters
 
         return [
@@ -129,7 +129,7 @@ class DeckManagerMixin:
         ]
 
     def choose_character(
-        self, player: 'Player', options: List[BaseCharacter]
+        self, player: 'Player', options: list[BaseCharacter]
     ) -> BaseCharacter:
         """Select which character a player will use. Defaults to the first."""
         return options[0]
@@ -152,7 +152,7 @@ class DeckManagerMixin:
             player.character.ability(self, player)
             player.metadata.game = self
 
-    def _next_alive_player(self: 'GameManager', player: 'Player') -> Optional['Player']:
+    def _next_alive_player(self: 'GameManager', player: 'Player') -> 'Player' | None:
         """Return the next living player to the left."""
         if player not in self._players:
             return None
@@ -185,7 +185,7 @@ class DeckManagerMixin:
         ]
 
     def _reset_current_turn(
-        self: 'GameManager', current_obj: Optional['Player'] | None
+        self: 'GameManager', current_obj: 'Player' | None
     ) -> None:
         """Update ``current_turn`` after player removal."""
         if current_obj and current_obj in self._players:
@@ -195,11 +195,11 @@ class DeckManagerMixin:
                 return
         self.current_turn %= len(self.turn_order)
 
-    def _get_player_by_index(self: 'GameManager', idx: int) -> Optional['Player']:
+    def _get_player_by_index(self: 'GameManager', idx: int) -> 'Player' | None:
         if 0 <= idx < len(self._players):
             return self._players[idx]
         return None
 
-    def get_player_by_index(self: 'GameManager', idx: int) -> Optional['Player']:
+    def get_player_by_index(self: 'GameManager', idx: int) -> 'Player' | None:
         """Return the player at ``idx`` if it exists."""
         return self._get_player_by_index(idx)

--- a/bang_py/game_manager.py
+++ b/bang_py/game_manager.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Callable, List, Optional, Sequence
+from typing import Callable, Sequence
 
 from .deck import Deck
 from .cards.card import BaseCard
@@ -30,13 +30,13 @@ class GameManager(
 ):
     """Coordinate game state, players and turn progression."""
 
-    _players: List[Player] = field(default_factory=list)
+    _players: list[Player] = field(default_factory=list)
     deck: Deck | None = None
-    expansions: List[str] = field(default_factory=list)
-    discard_pile: List[BaseCard] = field(default_factory=list)
+    expansions: list[str] = field(default_factory=list)
+    discard_pile: list[BaseCard] = field(default_factory=list)
     current_turn: int = 0
-    turn_order: List[int] = field(default_factory=list)
-    event_deck: List[EventCard] | None = None
+    turn_order: list[int] = field(default_factory=list)
+    event_deck: list[EventCard] | None = None
     current_event: EventCard | None = None
     event_flags: dict = field(default_factory=dict)
     first_eliminated: Player | None = None
@@ -44,32 +44,32 @@ class GameManager(
     phase: str = "draw"
 
     # General Store state
-    general_store_cards: List[BaseCard] | None = None
-    general_store_order: List[Player] | None = None
+    general_store_cards: list[BaseCard] | None = None
+    general_store_order: list[Player] | None = None
     general_store_index: int = 0
 
     # Event listeners
-    draw_phase_listeners: List[Callable[[Player, object], bool]] = field(
+    draw_phase_listeners: list[Callable[[Player, object], bool]] = field(
         default_factory=list
     )
-    player_damaged_listeners: List[Callable[[Player, Optional[Player]], None]] = field(
+    player_damaged_listeners: list[Callable[[Player, Player | None], None]] = field(
         default_factory=list
     )
-    player_healed_listeners: List[Callable[[Player], None]] = field(
+    player_healed_listeners: list[Callable[[Player], None]] = field(
         default_factory=list
     )
-    player_death_listeners: List[Callable[[Player, Optional[Player]], None]] = field(
+    player_death_listeners: list[Callable[[Player, Player | None], None]] = field(
         default_factory=list
     )
-    turn_started_listeners: List[Callable[[Player], None]] = field(default_factory=list)
-    game_over_listeners: List[Callable[[str], None]] = field(default_factory=list)
-    card_play_checks: List[Callable[[Player, BaseCard, Optional[Player]], bool]] = field(
+    turn_started_listeners: list[Callable[[Player], None]] = field(default_factory=list)
+    game_over_listeners: list[Callable[[str], None]] = field(default_factory=list)
+    card_play_checks: list[Callable[[Player, BaseCard, Player | None], bool]] = field(
         default_factory=list
     )
-    card_played_listeners: List[
-        Callable[[Player, BaseCard, Optional[Player]], None]
+    card_played_listeners: list[
+        Callable[[Player, BaseCard, Player | None], None]
     ] = field(default_factory=list)
-    play_phase_listeners: List[Callable[[Player], None]] = field(default_factory=list)
+    play_phase_listeners: list[Callable[[Player], None]] = field(default_factory=list)
     _duel_counts: dict | None = field(default=None, init=False, repr=False)
 
     @property

--- a/bang_py/general_store.py
+++ b/bang_py/general_store.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import List, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 from .cards.card import BaseCard
 
@@ -14,23 +14,23 @@ if TYPE_CHECKING:
 class GeneralStoreMixin:
     """Mixin implementing General Store management."""
 
-    general_store_cards: List[BaseCard] | None
-    general_store_order: List['Player'] | None
+    general_store_cards: list[BaseCard] | None
+    general_store_order: list['Player'] | None
     general_store_index: int
     deck: object
-    discard_pile: List[BaseCard]
-    _players: List['Player']
+    discard_pile: list[BaseCard]
+    _players: list['Player']
 
-    def start_general_store(self: 'GameManager', player: 'Player') -> List[str]:
+    def start_general_store(self: 'GameManager', player: 'Player') -> list[str]:
         if not self.deck:
             return []
         self.general_store_cards = self._deal_general_store_cards()
         self._set_general_store_order(player)
         return [c.card_name for c in self.general_store_cards]
 
-    def _deal_general_store_cards(self: 'GameManager') -> List[BaseCard]:
+    def _deal_general_store_cards(self: 'GameManager') -> list[BaseCard]:
         alive = [p for p in self._players if p.is_alive()]
-        cards: List[BaseCard] = []
+        cards: list[BaseCard] = []
         for _ in range(len(alive)):
             card = self._draw_from_deck()
             if card:
@@ -39,7 +39,7 @@ class GeneralStoreMixin:
 
     def _set_general_store_order(self: 'GameManager', player: 'Player') -> None:
         start_idx = self._players.index(player)
-        order: List['Player'] = []
+        order: list['Player'] = []
         for i in range(len(self._players)):
             p = self._players[(start_idx + i) % len(self._players)]
             if p.is_alive():

--- a/bang_py/player.py
+++ b/bang_py/player.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 from dataclasses import dataclass, field
 from types import MappingProxyType
-from typing import Dict, List, Sequence, TYPE_CHECKING
+from typing import Sequence, TYPE_CHECKING
 
 from .cards.roles import (
     BaseRole,
@@ -62,8 +62,8 @@ class Player:
     max_health: int = 4
     _health: int = field(init=False, repr=False)
     _metadata: PlayerMetadata = field(default_factory=PlayerMetadata, init=False, repr=False)
-    _equipment: Dict[str, "BaseCard"] = field(default_factory=dict, init=False, repr=False)
-    hand: List["BaseCard"] = field(default_factory=list)
+    _equipment: dict[str, "BaseCard"] = field(default_factory=dict, init=False, repr=False)
+    hand: list["BaseCard"] = field(default_factory=list)
 
     def __post_init__(self) -> None:
         """Initialize max health from role and character."""
@@ -75,7 +75,7 @@ class Player:
         return self._metadata
 
     @property
-    def equipment(self) -> Dict[str, "BaseCard"]:
+    def equipment(self) -> dict[str, "BaseCard"]:
         """Mapping of currently equipped cards (read-only)."""
         return MappingProxyType(self._equipment)
 

--- a/bang_py/turn_phases/draw_phase.py
+++ b/bang_py/turn_phases/draw_phase.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import List, TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 import random
 
 from ..cards.card import BaseCard
@@ -21,15 +21,15 @@ class DrawPhaseMixin:
     """Provide draw phase logic for :class:`GameManager`."""
 
     deck: object
-    discard_pile: List[BaseCard]
+    discard_pile: list[BaseCard]
     event_flags: dict
-    _players: List['Player']
-    turn_order: List[int]
+    _players: list['Player']
+    turn_order: list[int]
     current_turn: int
     phase: str
-    draw_phase_listeners: List
-    play_phase_listeners: List
-    turn_started_listeners: List
+    draw_phase_listeners: list
+    play_phase_listeners: list
+    turn_started_listeners: list
 
     # ------------------------------------------------------------------
     # Deck helpers


### PR DESCRIPTION
## Summary
- refactor typing.List/Dict/Optional to use built-in list/dict/`| None`
- remove obsolete typing imports across game, deck, network, and turn modules

## Testing
- `mypy bang_py/ability_dispatch.py bang_py/deck.py bang_py/deck_factory.py bang_py/deck_manager.py bang_py/game_manager.py bang_py/general_store.py bang_py/network/server.py bang_py/player.py bang_py/turn_phases/draw_phase.py --ignore-missing-imports` *(fails: The erased type of self "bang_py.game_manager.GameManager" is not a supertype of its class "bang_py.deck_manager.DeckManagerMixin" ...)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6892bad9e36c83239ce5c698b60d5f31