### PR TITLE
Factor player name validation into helper

### DIFF
--- a/bang_py/network/server.py
+++ b/bang_py/network/server.py
@@ -95,6 +95,15 @@ def _serialize_players(players: Sequence[Player]) -> list[dict]:
     ]
 
 
+def validate_player_name(name: str) -> bool:
+    """Return ``True`` if ``name`` is a valid player name."""
+
+    if not isinstance(name, str):
+        return False
+    name = name.strip()
+    return bool(name) and len(name) <= 20 and name.isprintable()
+
+
 class BangServer:
     """Run a websocket server for a single Bang game and manage clients."""
 
@@ -171,13 +180,10 @@ class BangServer:
 
         await websocket.send("Enter your name:")
         name = await websocket.recv()
-        if not isinstance(name, str):
+        if not validate_player_name(name):
             await websocket.send("Invalid name")
             return
         name = name.strip()
-        if not name or len(name) > 20 or not name.isprintable():
-            await websocket.send("Invalid name")
-            return
         if len(self.game.players) >= self.max_players:
             await websocket.send("Game full")
             return

--- a/tests/test_name_validation.py
+++ b/tests/test_name_validation.py
@@ -1,45 +1,15 @@
-import asyncio
-import random
-
 import pytest
 
 pytest.importorskip("cryptography")
-from bang_py.network.server import BangServer
+pytest.importorskip("websockets")
 
-websockets = pytest.importorskip("websockets")
-from websockets.asyncio.client import connect
-from websockets.asyncio.server import serve
+from bang_py.network.server import validate_player_name
 
 
 def test_name_too_long_rejected() -> None:
-    async def run_flow() -> None:
-        random.seed(0)
-        server = BangServer(host="localhost", port=8780, room_code="1234")
-        async with serve(server.handler, server.host, server.port):
-            async with connect("ws://localhost:8780") as ws:
-                await ws.recv()
-                await ws.send("1234")
-                await ws.recv()
-                await ws.send("x" * 21)
-                msg = await ws.recv()
-                assert msg == "Invalid name"
-                with pytest.raises(websockets.exceptions.ConnectionClosed):
-                    await ws.recv()
-    asyncio.run(run_flow())
+    assert not validate_player_name("x" * 21)
 
 
 def test_name_with_unprintable_rejected() -> None:
-    async def run_flow() -> None:
-        random.seed(0)
-        server = BangServer(host="localhost", port=8781, room_code="1234")
-        async with serve(server.handler, server.host, server.port):
-            async with connect("ws://localhost:8781") as ws:
-                await ws.recv()
-                await ws.send("1234")
-                await ws.recv()
-                await ws.send("bad\x00name")
-                msg = await ws.recv()
-                assert msg == "Invalid name"
-                with pytest.raises(websockets.exceptions.ConnectionClosed):
-                    await ws.recv()
-    asyncio.run(run_flow())
+    assert not validate_player_name("bad\x00name")
+


### PR DESCRIPTION
## Summary
- add `validate_player_name` helper and use it in the server handler
- simplify name validation tests to call the helper directly without a websocket server

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892cc8098ac83239e2b0ce50cb119ea