### PR TITLE
Add validation for player name

### DIFF
--- a/bang_py/ui/qml/MainMenu.qml
+++ b/bang_py/ui/qml/MainMenu.qml
@@ -28,12 +28,19 @@ Rectangle {
 
         TextField {
             id: nameField
-            placeholderText: "Name"
+            placeholderText: "Name (max 20 chars)"
             width: 200 * scale
             color: theme === "dark" ? "white" : "black"
             background: Rectangle {
                 color: theme === "dark" ? "#3c3c3c" : "#fff8dc"
             }
+            validator: RegExpValidator { regExp: /^[\x20-\x7E]{1,20}$/ }
+        }
+
+        Label {
+            text: "Use up to 20 printable characters"
+            color: "red"
+            visible: nameField.text !== "" && !nameField.acceptableInput
         }
 
         StyledButton {


### PR DESCRIPTION
## Summary
- Restrict main menu name input to 1-20 printable characters using a `RegExpValidator` and updated placeholder text.
- Show a red error label when the name violates the validator rules.

## Testing
- `BANG_AUTO_CLOSE=1 pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892ce1cd8dc8323b4e47adaa5a316d9