### PR TITLE
Add character module docstrings

### DIFF
--- a/bang_py/characters/__init__.py
+++ b/bang_py/characters/__init__.py
@@ -1,3 +1,4 @@
+"""Character classes from the core, Dodge City, and Bullet expansions."""
 from .base import BaseCharacter
 from .apache_kid import ApacheKid
 from .bart_cassidy import BartCassidy

--- a/bang_py/characters/apache_kid.py
+++ b/bang_py/characters/apache_kid.py
@@ -1,3 +1,4 @@
+"""Diamonds cannot affect you. Dodge City expansion."""
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/bang_py/characters/bart_cassidy.py
+++ b/bang_py/characters/bart_cassidy.py
@@ -1,3 +1,4 @@
+"""Draw a card whenever you lose a life point. Core set."""
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/bang_py/characters/base.py
+++ b/bang_py/characters/base.py
@@ -1,3 +1,4 @@
+"""Abstract base class for Bang characters."""
 from __future__ import annotations
 
 from abc import ABC, abstractmethod

--- a/bang_py/characters/belle_star.py
+++ b/bang_py/characters/belle_star.py
@@ -1,3 +1,4 @@
+"""Ignore other players' equipment on your turn. Dodge City expansion."""
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/bang_py/characters/bill_noface.py
+++ b/bang_py/characters/bill_noface.py
@@ -1,3 +1,4 @@
+"""Draw one plus your wounds during phase 1. Dodge City expansion."""
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/bang_py/characters/black_jack.py
+++ b/bang_py/characters/black_jack.py
@@ -1,3 +1,4 @@
+"""Reveal your second draw; if red, draw an extra card. Core set."""
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/bang_py/characters/calamity_janet.py
+++ b/bang_py/characters/calamity_janet.py
@@ -1,3 +1,4 @@
+"""Play Bang! as Missed! and vice versa. Core set."""
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/bang_py/characters/chuck_wengam.py
+++ b/bang_py/characters/chuck_wengam.py
@@ -1,3 +1,4 @@
+"""Lose 1 life to draw 2 cards during your turn. Dodge City expansion."""
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/bang_py/characters/claus_the_saint.py
+++ b/bang_py/characters/claus_the_saint.py
@@ -1,3 +1,4 @@
+"""Draw for all, keep two, gift the rest. Bullet expansion exclusive."""
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/bang_py/characters/doc_holyday.py
+++ b/bang_py/characters/doc_holyday.py
@@ -1,3 +1,4 @@
+"""Discard 2 cards for a free Bang once per turn. Dodge City expansion."""
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/bang_py/characters/el_gringo.py
+++ b/bang_py/characters/el_gringo.py
@@ -1,3 +1,4 @@
+"""Steal a card from your attacker when wounded. Core set."""
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/bang_py/characters/elena_fuente.py
+++ b/bang_py/characters/elena_fuente.py
@@ -1,3 +1,4 @@
+"""Any hand card may be played as Missed!. Dodge City expansion."""
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/bang_py/characters/greg_digger.py
+++ b/bang_py/characters/greg_digger.py
@@ -1,3 +1,4 @@
+"""Gain 2 life when another player dies. Dodge City expansion."""
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/bang_py/characters/herb_hunter.py
+++ b/bang_py/characters/herb_hunter.py
@@ -1,3 +1,4 @@
+"""Draw two cards when someone else is eliminated. Dodge City expansion."""
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/bang_py/characters/jesse_jones.py
+++ b/bang_py/characters/jesse_jones.py
@@ -1,3 +1,4 @@
+"""Steal a card instead of drawing the first. Core set."""
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/bang_py/characters/johnny_kisch.py
+++ b/bang_py/characters/johnny_kisch.py
@@ -1,3 +1,4 @@
+"""Play a card and discard all copies in play. Bullet expansion exclusive."""
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/bang_py/characters/jose_delgado.py
+++ b/bang_py/characters/jose_delgado.py
@@ -1,3 +1,4 @@
+"""Discard a blue card to draw two more. Dodge City expansion."""
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/bang_py/characters/jourdonnais.py
+++ b/bang_py/characters/jourdonnais.py
@@ -1,3 +1,4 @@
+"""Always count as having a Barrel. Core set."""
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/bang_py/characters/kit_carlson.py
+++ b/bang_py/characters/kit_carlson.py
@@ -1,3 +1,4 @@
+"""View top 3 cards; keep 2 and return 1 to the deck. Core set."""
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/bang_py/characters/lucky_duke.py
+++ b/bang_py/characters/lucky_duke.py
@@ -1,3 +1,4 @@
+"""Draw! twice and choose the result you prefer. Core set."""
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/bang_py/characters/molly_stark.py
+++ b/bang_py/characters/molly_stark.py
@@ -1,3 +1,4 @@
+"""Draw when playing or discarding out of turn, including Duels. Dodge City expansion."""
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/bang_py/characters/pat_brennan.py
+++ b/bang_py/characters/pat_brennan.py
@@ -1,3 +1,4 @@
+"""Draw a card from play instead of the deck. Dodge City expansion."""
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/bang_py/characters/paul_regret.py
+++ b/bang_py/characters/paul_regret.py
@@ -1,3 +1,4 @@
+"""Opponents see you at distance +1. Core set."""
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/bang_py/characters/pedro_ramirez.py
+++ b/bang_py/characters/pedro_ramirez.py
@@ -1,3 +1,4 @@
+"""May draw the top discard instead of from the deck. Core set."""
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/bang_py/characters/pixie_pete.py
+++ b/bang_py/characters/pixie_pete.py
@@ -1,3 +1,4 @@
+"""Draw three cards during phase 1. Dodge City expansion."""
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/bang_py/characters/rose_doolan.py
+++ b/bang_py/characters/rose_doolan.py
@@ -1,3 +1,4 @@
+"""See all others at distance -1. Core set."""
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/bang_py/characters/sean_mallory.py
+++ b/bang_py/characters/sean_mallory.py
@@ -1,3 +1,4 @@
+"""Hand limit increases to 10 cards. Dodge City expansion."""
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/bang_py/characters/sid_ketchum.py
+++ b/bang_py/characters/sid_ketchum.py
@@ -1,3 +1,4 @@
+"""Discard two cards to heal one life. Core set."""
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/bang_py/characters/slab_the_killer.py
+++ b/bang_py/characters/slab_the_killer.py
@@ -1,3 +1,4 @@
+"""Your Bang! requires two Missed! to avoid. Core set."""
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/bang_py/characters/suzy_lafayette.py
+++ b/bang_py/characters/suzy_lafayette.py
@@ -1,3 +1,4 @@
+"""Draw a card when you empty your hand. Core set."""
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/bang_py/characters/tequila_joe.py
+++ b/bang_py/characters/tequila_joe.py
@@ -1,3 +1,4 @@
+"""Beer heals you by 2 instead of 1. Dodge City expansion."""
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/bang_py/characters/uncle_will.py
+++ b/bang_py/characters/uncle_will.py
@@ -1,3 +1,4 @@
+"""Once per turn, any card becomes a General Store. Bullet expansion exclusive."""
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/bang_py/characters/vera_custer.py
+++ b/bang_py/characters/vera_custer.py
@@ -1,3 +1,4 @@
+"""Copy another living character's ability each turn. Dodge City expansion."""
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/bang_py/characters/vulture_sam.py
+++ b/bang_py/characters/vulture_sam.py
@@ -1,3 +1,4 @@
+"""Claim all cards from eliminated players. Core set."""
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/bang_py/characters/willy_the_kid.py
+++ b/bang_py/characters/willy_the_kid.py
@@ -1,3 +1,4 @@
+"""Play any number of Bang! cards each turn. Core set."""
 from __future__ import annotations
 
 from typing import TYPE_CHECKING


### PR DESCRIPTION
## Summary
- add concise module docstrings to every character module
- mention associated expansion in each docstring

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6892d0113b3083238bef863ef7c0603f