### PR TITLE
Cache character images for faster UI loads

### DIFF
--- a/bang_py/ui/components/card_images.py
+++ b/bang_py/ui/components/card_images.py
@@ -21,6 +21,13 @@ CHARACTER_DIR = ASSETS_DIR / "characters"
 AUDIO_DIR = ASSETS_DIR / "audio"
 ICON_DIR = ASSETS_DIR / "icons"
 
+_pixmap_cache: dict[str, QtGui.QPixmap] = {}
+
+
+def clear_pixmap_cache() -> None:
+    """Clear the module level pixmap cache."""
+    _pixmap_cache.clear()
+
 # Mapping of card/ability identifiers to icon filenames.
 ACTION_ICON_MAP = {
     "bang": "bang_icon.webp",
@@ -59,6 +66,10 @@ _TEMPLATE_FILES = {
 def load_character_image(name: str, width: int = 60, height: int = 90) -> QtGui.QPixmap:
     """Return a portrait pixmap for ``name`` or a default image."""
     base = name.lower().replace(" ", "_")
+    cache_key = f"{base}:{width}x{height}"
+    if cache_key in _pixmap_cache:
+        return _pixmap_cache[cache_key]
+
     for ext in (".webp", ".png", ".jpg", ".jpeg"):
         path = CHARACTER_DIR / f"{base}{ext}"
         if path.exists():
@@ -68,6 +79,7 @@ def load_character_image(name: str, width: int = 60, height: int = 90) -> QtGui.
     if not path.exists():
         pix = QtGui.QPixmap(width, height)
         pix.fill(QtGui.QColor("gray"))
+        _pixmap_cache[cache_key] = pix
         return pix
     with resources.as_file(path) as file_path:
         pix = QtGui.QPixmap(str(file_path))
@@ -81,6 +93,7 @@ def load_character_image(name: str, width: int = 60, height: int = 90) -> QtGui.
             QtCore.Qt.KeepAspectRatio,
             QtCore.Qt.SmoothTransformation,
         )
+    _pixmap_cache[cache_key] = pix
     return pix
 
 


### PR DESCRIPTION
## Summary
- cache pixmaps for character portraits and provide a helper to clear the cache
- reuse cached images to avoid repeated disk reads when loading character images

## Testing
- `BANG_AUTO_CLOSE=1 pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892d20421dc8323bfe6ba9e5abb43ce