### PR TITLE
Use deque for event decks

### DIFF
--- a/bang_py/events/event_decks.py
+++ b/bang_py/events/event_decks.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from collections import deque
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
@@ -189,9 +190,9 @@ class EventCard:
             self.apply(game)
 
 
-def create_high_noon_deck() -> list[BaseEventCard]:
+def create_high_noon_deck() -> deque[BaseEventCard]:
     """Return a simple High Noon event deck."""
-    return [
+    return deque([
         BlessingEventCard(),
         CurseEventCard(),
         GhostTownEventCard(),
@@ -207,12 +208,12 @@ def create_high_noon_deck() -> list[BaseEventCard]:
         TrainArrivalEventCard(),
         HandcuffsEventCard(),
         NewIdentityEventCard(),
-    ]
+    ])
 
 
-def create_fistful_deck() -> list[BaseEventCard]:
+def create_fistful_deck() -> deque[BaseEventCard]:
     """Return a simple Fistful of Cards event deck."""
-    return [
+    return deque([
         AbandonedMineEventCard(),
         AmbushEventCard(),
         BloodBrothersEventCard(),
@@ -228,4 +229,4 @@ def create_fistful_deck() -> list[BaseEventCard]:
         TheJudgeEventCard(),
         VendettaEventCard(),
         FistfulOfCardsEventCard(),
-    ]
+    ])

--- a/bang_py/events/event_logic.py
+++ b/bang_py/events/event_logic.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import List, Optional, TYPE_CHECKING
 import random
+from collections import deque
 
 from .event_decks import EventCard, create_high_noon_deck, create_fistful_deck
 from ..cards.roles import SheriffRoleCard
@@ -16,7 +17,7 @@ if TYPE_CHECKING:
 class EventLogicMixin:
     """Mixin providing event deck helpers for :class:`GameManager`."""
 
-    event_deck: List[EventCard] | None
+    event_deck: deque[EventCard] | None
     current_event: EventCard | None
     event_flags: dict
     expansions: List[str]
@@ -31,7 +32,7 @@ class EventLogicMixin:
         """Draw and apply the next event card."""
         if not self.event_deck:
             return
-        self.current_event = self.event_deck.pop(0)
+        self.current_event = self.event_deck.popleft()
         self.event_flags.clear()
         self.current_event.apply(self)
 
@@ -42,28 +43,34 @@ class EventLogicMixin:
         elif "fistful_of_cards" in self.expansions:
             self.event_deck = self._prepare_fistful_deck()
         elif self.event_deck:
-            random.shuffle(self.event_deck)
+            deck_list = list(self.event_deck)
+            random.shuffle(deck_list)
+            self.event_deck = deque(deck_list)
 
-    def _prepare_high_noon_deck(self: 'GameManager') -> List[EventCard] | None:
+    def _prepare_high_noon_deck(self: 'GameManager') -> deque[EventCard] | None:
         """Create and shuffle the High Noon event deck."""
         deck = create_high_noon_deck()
         if deck:
-            final = next((c for c in deck if c.name == "High Noon"), None)
+            deck_list = list(deck)
+            final = next((c for c in deck_list if c.name == "High Noon"), None)
             if final:
-                deck.remove(final)
-                random.shuffle(deck)
-                deck.append(final)
+                deck_list.remove(final)
+                random.shuffle(deck_list)
+                deck_list.append(final)
+            deck = deque(deck_list)
         return deck
 
-    def _prepare_fistful_deck(self: 'GameManager') -> List[EventCard] | None:
+    def _prepare_fistful_deck(self: 'GameManager') -> deque[EventCard] | None:
         """Create and shuffle the Fistful of Cards event deck."""
         deck = create_fistful_deck()
         if deck:
-            final = next((c for c in deck if c.name == "A Fistful of Cards"), None)
+            deck_list = list(deck)
+            final = next((c for c in deck_list if c.name == "A Fistful of Cards"), None)
             if final:
-                deck.remove(final)
-                random.shuffle(deck)
-                deck.append(final)
+                deck_list.remove(final)
+                random.shuffle(deck_list)
+                deck_list.append(final)
+            deck = deque(deck_list)
         return deck
 
     def _apply_event_start_effects(self: 'GameManager', player: Player) -> Player | None:

--- a/bang_py/game_manager.py
+++ b/bang_py/game_manager.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from typing import Callable, Sequence
+from collections import deque
 
 from .deck import Deck
 from .cards.card import BaseCard
@@ -36,7 +37,7 @@ class GameManager(
     discard_pile: list[BaseCard] = field(default_factory=list)
     current_turn: int = 0
     turn_order: list[int] = field(default_factory=list)
-    event_deck: list[EventCard] | None = None
+    event_deck: deque[EventCard] | None = None
     current_event: EventCard | None = None
     event_flags: dict = field(default_factory=dict)
     first_eliminated: Player | None = None

--- a/tests/test_bullet_event_cards.py
+++ b/tests/test_bullet_event_cards.py
@@ -1,3 +1,5 @@
+from collections import deque
+
 from bang_py.game_manager import GameManager
 from bang_py.player import Player
 from bang_py.cards.roles import SheriffRoleCard, OutlawRoleCard
@@ -21,7 +23,7 @@ def test_handcuffs_restricts_suit():
     outlaw = Player("O", role=OutlawRoleCard())
     gm.add_player(sheriff)
     gm.add_player(outlaw)
-    gm.event_deck = [HandcuffsEventCard()]
+    gm.event_deck = deque([HandcuffsEventCard()])
     gm.turn_order = [0, 1]
     gm.current_turn = 0
     gm.draw_event_card()
@@ -39,7 +41,7 @@ def test_new_identity_event_redraw():
     p = Player("P", role=SheriffRoleCard())
     gm.add_player(p)
     p.hand = [BangCard(), BangCard()]
-    gm.event_deck = [NewIdentityEventCard()]
+    gm.event_deck = deque([NewIdentityEventCard()])
     gm.draw_event_card()
     assert len(p.hand) == 2
 
@@ -53,7 +55,7 @@ def test_lasso_event_ignores_equipment():
     gm.add_player(b)
     MustangCard().play(b)
     assert a.distance_to(b) > 1
-    gm.event_deck = [LassoEventCard()]
+    gm.event_deck = deque([LassoEventCard()])
     gm.draw_event_card()
     assert a.distance_to(b) == 1
 
@@ -64,7 +66,7 @@ def test_sniper_event_allows_special_bang():
     t = Player("T")
     gm.add_player(p)
     gm.add_player(t)
-    gm.event_deck = [SniperEventCard()]
+    gm.event_deck = deque([SniperEventCard()])
     gm.draw_event_card()
     p.hand.extend([BangCard(), BangCard()])
     gm.play_card(p, p.hand[0], t)
@@ -80,7 +82,7 @@ def test_sniper_event_double_bang_damage():
     gm.add_player(attacker)
     gm.add_player(target)
     attacker.hand.extend([BangCard(), BangCard()])
-    gm.event_deck = [SniperEventCard()]
+    gm.event_deck = deque([SniperEventCard()])
     gm.draw_event_card()
     attacker.metadata.use_sniper = True
     gm.play_card(attacker, attacker.hand[0], target)
@@ -96,7 +98,7 @@ def test_russian_roulette_players_discard_missed():
     gm.add_player(s)
     gm.add_player(o)
     o.hand.append(MissedCard())
-    gm.event_deck = [RussianRouletteEventCard()]
+    gm.event_deck = deque([RussianRouletteEventCard()])
     gm.draw_event_card()
     assert s.health == s.max_health - 2
     assert o.health == o.max_health

--- a/tests/test_event_deck_effects.py
+++ b/tests/test_event_deck_effects.py
@@ -1,3 +1,5 @@
+from collections import deque
+
 from bang_py.events.event_decks import (
     EventCard,
     _thirst,
@@ -47,7 +49,7 @@ from bang_py.deck import Deck
 
 def test_thirst_event_draw_one():
     gm = GameManager()
-    gm.event_deck = [EventCard("Thirst", _thirst, "")]
+    gm.event_deck = deque([EventCard("Thirst", _thirst, "")])
     p = Player("Sheriff", role=SheriffRoleCard())
     gm.add_player(p)
     gm.draw_event_card()
@@ -61,7 +63,7 @@ def test_fistful_event_bangs_by_hand():
     p = Player("Sheriff", role=SheriffRoleCard())
     gm.add_player(p)
     p.hand = [BangCard(), BangCard()]
-    gm.event_deck = [EventCard("A Fistful of Cards", _fistful, "")]
+    gm.event_deck = deque([EventCard("A Fistful of Cards", _fistful, "")])
     gm.turn_order = [0]
     gm.current_turn = 0
     gm._begin_turn()
@@ -79,7 +81,7 @@ def test_sermon_event_blocks_bang():
     outlaw = Player("Outlaw")
     gm.add_player(sheriff)
     gm.add_player(outlaw)
-    gm.event_deck = [EventCard("The Sermon", _enable_no_bang, "")]
+    gm.event_deck = deque([EventCard("The Sermon", _enable_no_bang, "")])
     gm.draw_event_card()
     sheriff.hand.append(BangCard())
     gm.play_card(sheriff, sheriff.hand[0], outlaw)
@@ -94,7 +96,7 @@ def test_hangover_disables_abilities():
     p = Player("Sheriff", role=SheriffRoleCard(), character=JesseJones())
     gm.add_player(p)
     assert has_ability(p, JesseJones)
-    gm.event_deck = [EventCard("Hangover", _hangover, "")]
+    gm.event_deck = deque([EventCard("Hangover", _hangover, "")])
     gm.draw_event_card()
     assert not has_ability(p, JesseJones)
 
@@ -103,7 +105,7 @@ def test_judge_prevents_beer_play():
     gm = GameManager()
     sheriff = Player("Sheriff", role=SheriffRoleCard())
     gm.add_player(sheriff)
-    gm.event_deck = [EventCard("The Judge", _judge, "")]
+    gm.event_deck = deque([EventCard("The Judge", _judge, "")])
     gm.draw_event_card()
     sheriff.health -= 1
     sheriff.hand.append(BeerCard())
@@ -119,7 +121,7 @@ def test_ghost_town_revives_players():
     gm.add_player(sheriff)
     gm.add_player(outlaw)
     outlaw.take_damage(outlaw.health)
-    gm.event_deck = [EventCard("Ghost Town", _ghost_town, "")]
+    gm.event_deck = deque([EventCard("Ghost Town", _ghost_town, "")])
     gm.turn_order = [0, 1]
     gm.current_turn = 0
     gm._begin_turn()  # sheriff first turn
@@ -137,10 +139,10 @@ def test_ghost_town_players_disappear_next_event():
     gm.add_player(sheriff)
     gm.add_player(outlaw)
     outlaw.take_damage(outlaw.health)
-    gm.event_deck = [
+    gm.event_deck = deque([
         EventCard("Ghost Town", _ghost_town, ""),
         EventCard("Thirst", _thirst, ""),
-    ]
+    ])
     gm.turn_order = [0, 1]
     gm.current_turn = 0
     gm._begin_turn()  # sheriff first turn
@@ -158,7 +160,7 @@ def test_blessing_overrides_suit():
     gm = GameManager(deck=deck)
     p = Player("Sheriff", role=SheriffRoleCard())
     gm.add_player(p)
-    gm.event_deck = [EventCard("Blessing", _blessing, "")]
+    gm.event_deck = deque([EventCard("Blessing", _blessing, "")])
     gm.draw_event_card()
     gm.draw_phase(p)
     assert all(c.suit == "Hearts" for c in p.hand)
@@ -174,7 +176,7 @@ def test_gold_rush_reverses_turn_order():
     gm.add_player(p3)
     gm.turn_order = [0, 1, 2]
     gm.current_turn = 0
-    gm.event_deck = [EventCard("Gold Rush", _gold_rush, "")]
+    gm.event_deck = deque([EventCard("Gold Rush", _gold_rush, "")])
     gm.draw_event_card()
     gm.end_turn()
     assert gm.players[gm.turn_order[gm.current_turn]] is p3
@@ -186,7 +188,7 @@ def test_vendetta_outlaw_range_bonus():
     target = Player("T")
     gm.add_player(outlaw)
     gm.add_player(target)
-    gm.event_deck = [EventCard("Vendetta", _vendetta, "")]
+    gm.event_deck = deque([EventCard("Vendetta", _vendetta, "")])
     gm.draw_event_card()
     assert outlaw.attack_range == 2
 
@@ -197,7 +199,7 @@ def test_sermon_blocks_bang_real():
     outlaw = Player("Outlaw")
     gm.add_player(sheriff)
     gm.add_player(outlaw)
-    gm.event_deck = [EventCard("The Sermon", _sermon, "")]
+    gm.event_deck = deque([EventCard("The Sermon", _sermon, "")])
     gm.draw_event_card()
     sheriff.hand.append(BangCard())
     gm.play_card(sheriff, sheriff.hand[0], outlaw)
@@ -213,7 +215,7 @@ def test_ricochet_discards_equipment():
     gm.add_player(target)
     BarrelCard().play(target)
     shooter.hand.append(BangCard())
-    gm.event_deck = [EventCard("Ricochet", _ricochet, "")]
+    gm.event_deck = deque([EventCard("Ricochet", _ricochet, "")])
     gm.draw_event_card()
     assert gm.ricochet_shoot(shooter, target, "Barrel")
     assert "Barrel" not in target.equipment
@@ -228,7 +230,7 @@ def test_ricochet_can_be_missed():
     BarrelCard().play(target)
     target.hand.append(MissedCard())
     shooter.hand.append(BangCard())
-    gm.event_deck = [EventCard("Ricochet", _ricochet, "")]
+    gm.event_deck = deque([EventCard("Ricochet", _ricochet, "")])
     gm.draw_event_card()
     assert not gm.ricochet_shoot(shooter, target, "Barrel")
     assert "Barrel" in target.equipment
@@ -241,7 +243,7 @@ def test_ambush_sets_distance_one():
     p2 = Player("B")
     gm.add_player(p1)
     gm.add_player(p2)
-    gm.event_deck = [EventCard("Ambush", _ambush_event, "")]
+    gm.event_deck = deque([EventCard("Ambush", _ambush_event, "")])
     gm.draw_event_card()
     assert p1.distance_to(p2) == 1
 
@@ -252,7 +254,7 @@ def test_ranch_discard_and_redraw():
     gm = GameManager(deck=deck)
     p1 = Player("A")
     gm.add_player(p1)
-    gm.event_deck = [EventCard("Ranch", _ranch, "")]
+    gm.event_deck = deque([EventCard("Ranch", _ranch, "")])
     gm.draw_event_card()
     p1.hand = [BangCard(), MissedCard()]
     gm.draw_phase(p1, ranch_discards=[2, 3])
@@ -263,7 +265,7 @@ def test_high_noon_start_damage():
     gm = GameManager()
     p = Player("Sheriff", role=SheriffRoleCard())
     gm.add_player(p)
-    gm.event_deck = [EventCard("High Noon", _high_noon, "")]
+    gm.event_deck = deque([EventCard("High Noon", _high_noon, "")])
     gm.turn_order = [0]
     gm.current_turn = 0
     gm.draw_event_card()
@@ -278,7 +280,7 @@ def test_blood_brothers_transfer_during_turn():
     gm.add_player(p1)
     gm.add_player(p2)
     p2.health -= 1
-    gm.event_deck = [EventCard("Blood Brothers", _blood_brothers, "")]
+    gm.event_deck = deque([EventCard("Blood Brothers", _blood_brothers, "")])
     gm.turn_order = [0]
     gm.current_turn = 0
     gm.draw_event_card()
@@ -352,7 +354,7 @@ def test_peyote_extra_draw():
     gm = GameManager(deck=deck)
     p = Player("Sheriff", role=SheriffRoleCard())
     gm.add_player(p)
-    gm.event_deck = [EventCard("Peyote", _peyote, "")]
+    gm.event_deck = deque([EventCard("Peyote", _peyote, "")])
     gm.draw_event_card()
     gm.draw_phase(p, peyote_guesses=["red", "black", "red"])
     assert len(p.hand) == 3
@@ -364,7 +366,7 @@ def test_abandoned_mine_uses_discard_pile_and_deck_top():
     p1 = Player("A")
     gm.add_player(p1)
     gm.discard_pile.append(BangCard())
-    gm.event_deck = [EventCard("Abandoned Mine", _abandoned_mine, "")]
+    gm.event_deck = deque([EventCard("Abandoned Mine", _abandoned_mine, "")])
     gm.draw_event_card()
     p1.health = 1
     gm.draw_phase(p1)
@@ -384,7 +386,7 @@ def test_daltons_discards_equipment():
     gm.add_player(p2)
     MustangCard().play(p1)
     MustangCard().play(p2)
-    gm.event_deck = [TheDaltonsEventCard()]
+    gm.event_deck = deque([TheDaltonsEventCard()])
     gm.draw_event_card()
     assert not p1.equipment
     assert not p2.equipment
@@ -398,7 +400,7 @@ def test_doctor_heals_lowest():
     gm.add_player(p2)
     p1.health -= 2
     p2.health -= 1
-    gm.event_deck = [TheDoctorEventCard()]
+    gm.event_deck = deque([TheDoctorEventCard()])
     gm.draw_event_card()
     assert p1.health == p1.max_health - 1
     assert p2.health == p2.max_health - 1
@@ -408,7 +410,7 @@ def test_reverend_blocks_beer():
     gm = GameManager()
     p = Player("Sheriff", role=SheriffRoleCard())
     gm.add_player(p)
-    gm.event_deck = [TheReverendEventCard()]
+    gm.event_deck = deque([TheReverendEventCard()])
     gm.draw_event_card()
     p.health -= 1
     p.hand.append(BeerCard())
@@ -420,7 +422,7 @@ def test_train_arrival_draw_three():
     gm = GameManager()
     p = Player("Sheriff", role=SheriffRoleCard())
     gm.add_player(p)
-    gm.event_deck = [TrainArrivalEventCard()]
+    gm.event_deck = deque([TrainArrivalEventCard()])
     gm.draw_event_card()
     gm.draw_phase(p)
     assert len(p.hand) == 3
@@ -430,7 +432,7 @@ def test_hard_liquor_skip_draw_to_heal():
     gm = GameManager()
     p = Player("Sheriff", role=SheriffRoleCard())
     gm.add_player(p)
-    gm.event_deck = [EventCard("Hard Liquor", _hard_liquor, "")]
+    gm.event_deck = deque([EventCard("Hard Liquor", _hard_liquor, "")])
     gm.draw_event_card()
     p.health -= 1
     gm.draw_phase(p, skip_heal=True)
@@ -444,7 +446,7 @@ def test_law_of_west_plays_second_card():
     gm = GameManager(deck=deck)
     p = Player("Sheriff", role=SheriffRoleCard())
     gm.add_player(p)
-    gm.event_deck = [EventCard("Law of the West", _law_of_the_west, "")]
+    gm.event_deck = deque([EventCard("Law of the West", _law_of_the_west, "")])
     gm.draw_event_card()
     gm.draw_phase(p)
     assert len(p.hand) == 1
@@ -456,7 +458,7 @@ def test_shootout_allows_multiple_bangs():
     p2 = Player("Outlaw")
     gm.add_player(p1)
     gm.add_player(p2)
-    gm.event_deck = [EventCard("Shootout", _shootout, "")]
+    gm.event_deck = deque([EventCard("Shootout", _shootout, "")])
     gm.draw_event_card()
     p1.hand.extend([BangCard(), BangCard()])
     gm.play_card(p1, p1.hand[0], p2)
@@ -472,7 +474,7 @@ def test_handcuffs_limits_suit_played():
     p2 = Player("Outlaw")
     gm.add_player(p1)
     gm.add_player(p2)
-    gm.event_deck = [HandcuffsEventCard()]
+    gm.event_deck = deque([HandcuffsEventCard()])
     gm.turn_order = [0, 1]
     gm.current_turn = 0
     gm.draw_event_card()
@@ -504,7 +506,7 @@ def test_event_sequence_progresses_each_sheriff_turn():
     outlaw = Player("Outlaw")
     gm.add_player(sheriff)
     gm.add_player(outlaw)
-    gm.event_deck = [e1, e2]
+    gm.event_deck = deque([e1, e2])
     gm.start_game(deal_roles=False)
     assert gm.current_event is None
     gm.end_turn()  # sheriff end -> outlaw turn
@@ -525,7 +527,7 @@ def test_dead_man_revives_first_eliminated():
     gm.start_game(deal_roles=False)
     outlaw.take_damage(outlaw.health)
     gm.on_player_damaged(outlaw)
-    gm.event_deck = [DeadManEventCard()]
+    gm.event_deck = deque([DeadManEventCard()])
     gm.draw_event_card()
     gm.end_turn()  # sheriff end -> outlaw turn and revive
     assert outlaw.health == 2
@@ -538,7 +540,7 @@ def test_blood_brothers_life_transfer():
     target = Player("B")
     gm.add_player(donor)
     gm.add_player(target)
-    gm.event_deck = [BloodBrothersEventCard()]
+    gm.event_deck = deque([BloodBrothersEventCard()])
     gm.draw_event_card()
     target.take_damage(1)
     assert gm.blood_brothers_transfer(donor, target)
@@ -551,7 +553,7 @@ def test_curse_overrides_to_spades():
     gm = GameManager(deck=deck)
     p = Player("Sheriff", role=SheriffRoleCard())
     gm.add_player(p)
-    gm.event_deck = [CurseEventCard()]
+    gm.event_deck = deque([CurseEventCard()])
     gm.draw_event_card()
     gm.draw_phase(p)
     assert p.hand[0].suit == "Spades"
@@ -565,7 +567,7 @@ def test_no_draw_skips_draw_phase():
     gm = GameManager()
     p = Player("Sheriff", role=SheriffRoleCard())
     gm.add_player(p)
-    gm.event_deck = [EventCard("Skip", _no_draw, "")]
+    gm.event_deck = deque([EventCard("Skip", _no_draw, "")])
     gm.draw_event_card()
     gm.draw_phase(p)
     assert not p.hand


### PR DESCRIPTION
## Summary
- switch event deck structures to `deque` and shuffle accordingly
- construct High Noon and Fistful decks as `deque` instances
- adjust tests for new event deck type

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6892e4c9212c8323a3115a0888ba90d5