### PR TITLE
Mark network message tests as slow

### DIFF
--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -7,3 +7,5 @@
     Execute it via `pytest -m slow tests/test_full_game_simulation.py`.
   - `test_network_integration` exercises websocket server/client flow and SSL. Run it
     with `pytest -m slow tests/test_network_integration.py`.
+  - `test_network_messages` checks server handling of malformed or oversized messages.
+    Execute it with `pytest -m slow tests/test_network_messages.py`.

--- a/tests/test_network_messages.py
+++ b/tests/test_network_messages.py
@@ -3,6 +3,8 @@ import json
 
 import pytest
 
+pytestmark = pytest.mark.slow
+
 pytest.importorskip("cryptography")
 
 from bang_py.network.server import BangServer, MAX_MESSAGE_SIZE


### PR DESCRIPTION
## Summary
- mark `test_network_messages` module as slow since it opens websocket connections
- document slow test in tests/AGENTS guidelines

## Testing
- `pytest`
- `pytest -m slow tests/test_network_messages.py`


------
https://chatgpt.com/codex/tasks/task_e_6892efc3e8c883239e23974140bea89a