### PR TITLE
Add module docstrings

### DIFF
--- a/bang_py/deck.py
+++ b/bang_py/deck.py
@@ -1,3 +1,5 @@
+"""Define a minimal shuffled deck supporting card draws and additions."""
+
 from __future__ import annotations
 
 from random import shuffle

--- a/bang_py/deck_factory.py
+++ b/bang_py/deck_factory.py
@@ -1,3 +1,5 @@
+"""Create decks with balanced suits and optional expansion cards for Bang!."""
+
 from __future__ import annotations
 
 import random

--- a/bang_py/helpers.py
+++ b/bang_py/helpers.py
@@ -1,3 +1,5 @@
+"""Utility helpers for card checks, ability resolution, and loading rank or suit icons."""
+
 from __future__ import annotations
 
 from .cards.card import BaseCard


### PR DESCRIPTION
## Summary
- Clarify deck module purpose with concise docstring
- Describe deck_factory module's role in building Bang! decks
- Document helpers utilities for card checks and Qt icon loading

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892f162cbc08323af507827d4fa5561