### PR TITLE
refactor: centralize Qt app fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import os
 import pathlib
 import importlib.util
 
@@ -37,4 +38,23 @@ def generate_assets() -> None:
 def _set_token_key(monkeypatch: pytest.MonkeyPatch) -> None:
     if DEFAULT_TOKEN_KEY is not None:
         monkeypatch.setenv("BANG_TOKEN_KEY", DEFAULT_TOKEN_KEY.decode())
+
+
+@pytest.fixture
+def qt_app() -> "QtWidgets.QApplication":
+    """Create a ``QApplication`` instance for Qt tests."""
+    pytest.importorskip("PySide6")
+    pytest.importorskip("PySide6.QtWidgets")
+    from PySide6 import QtWidgets
+
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    os.environ.setdefault("BANG_AUTO_CLOSE", "1")
+
+    app = QtWidgets.QApplication.instance()
+    created = app is None
+    if created:
+        app = QtWidgets.QApplication([])
+    yield app
+    if created:
+        app.quit()
 

--- a/tests/test_card_image_loader.py
+++ b/tests/test_card_image_loader.py
@@ -1,4 +1,3 @@
-import os
 import pytest
 
 pytest.importorskip(
@@ -15,19 +14,8 @@ pytest.importorskip(
     exc_type=ImportError,
 )
 
-from PySide6 import QtWidgets, QtGui
+from PySide6 import QtGui
 from bang_py.ui.components.card_images import CardImageLoader, ACTION_ICON_MAP
-
-@pytest.fixture
-def qt_app():
-    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
-    app = QtWidgets.QApplication.instance()
-    created = app is None
-    if created:
-        app = QtWidgets.QApplication([])
-    yield app
-    if created:
-        app.quit()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_icon_loader.py
+++ b/tests/test_icon_loader.py
@@ -1,4 +1,3 @@
-import os
 import pytest
 
 pytest.importorskip(
@@ -14,20 +13,8 @@ pytest.importorskip(
     reason="QtGui unavailable; skipping GUI tests",
     exc_type=ImportError,
 )
-from PySide6 import QtWidgets, QtGui
+from PySide6 import QtGui
 from bang_py.helpers import RankSuitIconLoader
-
-
-@pytest.fixture
-def qt_app():
-    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
-    app = QtWidgets.QApplication.instance()
-    created = app is None
-    if created:
-        app = QtWidgets.QApplication([])
-    yield app
-    if created:
-        app.quit()
 
 
 def test_loader_returns_pixmap(qt_app):

--- a/tests/test_qt_ui.py
+++ b/tests/test_qt_ui.py
@@ -1,4 +1,3 @@
-import os
 import json
 
 import pytest
@@ -22,20 +21,7 @@ pytest.importorskip(
     exc_type=ImportError,
 )
 
-from PySide6 import QtWidgets, QtCore  # noqa: E402
-
-
-@pytest.fixture
-def qt_app():
-    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
-    os.environ.setdefault("BANG_AUTO_CLOSE", "1")
-    app = QtWidgets.QApplication.instance()
-    created = app is None
-    if created:
-        app = QtWidgets.QApplication([])
-    yield app
-    if created:
-        app.quit()
+from PySide6 import QtWidgets  # noqa: E402
 
 
 def test_bang_ui_creation(qt_app):


### PR DESCRIPTION
## Summary
- add shared `qt_app` fixture in `tests/conftest.py`
- drop duplicate `qt_app` fixtures from UI test modules
- update UI tests to rely on shared fixture

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892f63f2c1883239d66ff4cdf435754