### PR TITLE
refactor: use deque for deck

### DIFF
--- a/bang_py/characters/kit_carlson.py
+++ b/bang_py/characters/kit_carlson.py
@@ -32,7 +32,7 @@ class KitCarlson(BaseCharacter):
                 if c is None:
                     continue
                 if i == back_index:
-                    gm.deck.cards.insert(0, c)
+                    gm.deck.cards.appendleft(c)
                 else:
                     player.hand.append(c)
             return True

--- a/bang_py/deck.py
+++ b/bang_py/deck.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from random import shuffle
+from collections import deque
 
 from .cards.card import BaseCard
 
@@ -11,17 +12,18 @@ class Deck:
     """Simple deck of cards supporting drawing."""
 
     def __init__(self, cards: list[BaseCard] | None = None) -> None:
-        self.cards: list[BaseCard] = cards[:] if cards else []
-        shuffle(self.cards)
+        card_list = cards[:] if cards else []
+        shuffle(card_list)
+        self.cards: deque[BaseCard] = deque(card_list)
 
     def draw(self) -> BaseCard | None:
         """Draw a card from the deck if available."""
         if self.cards:
-            return self.cards.pop()
+            return self.cards.popleft()
         return None
 
     def add(self, card: BaseCard) -> None:
-        self.cards.insert(0, card)
+        self.cards.append(card)
 
     def __len__(self) -> int:
         return len(self.cards)

--- a/bang_py/turn_phases/discard_phase.py
+++ b/bang_py/turn_phases/discard_phase.py
@@ -36,6 +36,6 @@ class DiscardPhaseMixin:
         while len(player.hand) > limit:
             card = player.hand.pop()
             if self.event_flags.get("abandoned_mine"):
-                self.deck.cards.insert(0, card)
+                self.deck.cards.appendleft(card)
             else:
                 self._pass_left_or_discard(player, card)

--- a/bang_py/turn_phases/draw_phase.py
+++ b/bang_py/turn_phases/draw_phase.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 import random
+from collections import deque
 
 from ..cards.card import BaseCard
 from ..characters.jesse_jones import JesseJones
@@ -39,7 +40,9 @@ class DrawPhaseMixin:
         if card is None and self.discard_pile:
             self.deck.cards.extend(self.discard_pile)
             self.discard_pile.clear()
-            random.shuffle(self.deck.cards)
+            cards = list(self.deck.cards)
+            random.shuffle(cards)
+            self.deck.cards = deque(cards)
             card = self.deck.draw()
         return card
 

--- a/tests/test_additional_cards.py
+++ b/tests/test_additional_cards.py
@@ -14,6 +14,7 @@ from bang_py.cards import (
     BeerCard,
     BangCard,
 )
+from collections import deque
 
 
 def test_stagecoach_draws_two_cards():
@@ -99,7 +100,7 @@ def test_general_store_gives_each_player_card():
 def test_general_store_selection_order():
     deck = Deck([])
     c1, c2, c3 = BangCard(), BeerCard(), GatlingCard()
-    deck.cards = [c1, c2, c3]
+    deck.cards = deque([c3, c2, c1])
     gm = GameManager(deck=deck)
     p1 = Player("A")
     p2 = Player("B")
@@ -116,7 +117,7 @@ def test_general_store_selection_order():
 def test_general_store_allows_player_choice():
     deck = Deck([])
     c1, c2, c3 = BangCard(), BeerCard(), GatlingCard()
-    deck.cards = [c1, c2, c3]
+    deck.cards = deque([c3, c2, c1])
     gm = GameManager(deck=deck)
     p1 = Player("A")
     p2 = Player("B")

--- a/tests/test_bullet_event_cards.py
+++ b/tests/test_bullet_event_cards.py
@@ -13,11 +13,12 @@ from bang_py.cards.events import (
 )
 from bang_py.cards import BangCard, MissedCard
 from bang_py.deck import Deck
+from collections import deque
 
 
 def test_handcuffs_restricts_suit():
     deck = Deck([])
-    deck.cards = [BangCard(suit="Hearts"), BangCard(suit="Spades")]
+    deck.cards = deque([BangCard(suit="Hearts"), BangCard(suit="Spades")])
     gm = GameManager(deck=deck)
     sheriff = Player("S", role=SheriffRoleCard())
     outlaw = Player("O", role=OutlawRoleCard())

--- a/tests/test_cards.py
+++ b/tests/test_cards.py
@@ -73,7 +73,7 @@ def test_barrel_dodges_bang_on_heart():
     target = Player("Target")
     BarrelCard().play(target)
     deck = create_standard_deck()
-    deck.cards.append(BeerCard(suit="Hearts"))
+    deck.cards.appendleft(BeerCard(suit="Hearts"))
     BangCard().play(target, deck)
     assert target.health == target.max_health
     assert target.metadata.dodged is True
@@ -83,7 +83,7 @@ def test_barrel_fails_on_non_heart():
     target = Player("Target")
     BarrelCard().play(target)
     deck = create_standard_deck()
-    deck.cards.append(BeerCard(suit="Clubs"))
+    deck.cards.appendleft(BeerCard(suit="Clubs"))
     BangCard().play(target, deck)
     assert target.health == target.max_health - 1
 
@@ -93,7 +93,7 @@ def test_jail_skip_turn():
     jail = JailCard()
     jail.play(player)
     deck = create_standard_deck()
-    deck.cards.append(BangCard(suit="Clubs"))
+    deck.cards.appendleft(BangCard(suit="Clubs"))
     skipped = jail.check_turn(player, deck)
     assert skipped is True
     assert "Jail" not in player.equipment
@@ -104,7 +104,7 @@ def test_jail_freed_on_heart():
     jail = JailCard()
     jail.play(player)
     deck = create_standard_deck()
-    deck.cards.append(BangCard(suit="Hearts"))
+    deck.cards.appendleft(BangCard(suit="Hearts"))
     skipped = jail.check_turn(player, deck)
     assert skipped is False
     assert "Jail" not in player.equipment
@@ -116,7 +116,7 @@ def test_dynamite_explodes():
     dyn = DynamiteCard()
     dyn.play(p1)
     deck = create_standard_deck()
-    deck.cards.append(BangCard(suit="Spades", rank=5))
+    deck.cards.appendleft(BangCard(suit="Spades", rank=5))
     exploded = dyn.check_dynamite(p1, p2, deck)
     assert exploded is True
     assert p1.health == p1.max_health - 3
@@ -129,7 +129,7 @@ def test_dynamite_passes():
     dyn = DynamiteCard()
     dyn.play(p1)
     deck = create_standard_deck()
-    deck.cards.append(BangCard(suit="Hearts", rank=1))
+    deck.cards.appendleft(BangCard(suit="Hearts", rank=1))
     exploded = dyn.check_dynamite(p1, p2, deck)
     assert exploded is False
     assert "Dynamite" not in p1.equipment

--- a/tests/test_characters.py
+++ b/tests/test_characters.py
@@ -77,7 +77,7 @@ def test_character_ability_registered():
 
 def test_bart_cassidy_draw_on_damage():
     deck = create_standard_deck()
-    deck.cards.append(BangCard())
+    deck.cards.appendleft(BangCard())
     gm = GameManager(deck=deck)
     p1 = Player("Bart", character=BartCassidy())
     p2 = Player("Shooter")
@@ -90,11 +90,13 @@ def test_bart_cassidy_draw_on_damage():
 
 def test_black_jack_extra_draw():
     deck = create_standard_deck()
-    deck.cards.extend([
-        BeerCard(suit="Clubs"),
-        BeerCard(suit="Diamonds"),
-        BeerCard(suit="Spades"),
-    ])
+    deck.cards.extendleft(
+        [
+            BeerCard(suit="Clubs"),
+            BeerCard(suit="Diamonds"),
+            BeerCard(suit="Spades"),
+        ]
+    )
     gm = GameManager(deck=deck)
     p = Player("BJ", character=BlackJack())
     gm.add_player(p)
@@ -142,7 +144,7 @@ def test_el_gringo_steals_on_damage():
 
 def test_jesse_jones_draws_from_opponent():
     deck = create_standard_deck()
-    deck.cards.append(BangCard())
+    deck.cards.appendleft(BangCard())
     gm = GameManager(deck=deck)
     jj = Player("JJ", character=JesseJones())
     other = Player("Other")
@@ -156,7 +158,7 @@ def test_jesse_jones_draws_from_opponent():
 
 def test_jesse_jones_selects_card_index():
     deck = create_standard_deck()
-    deck.cards.append(BangCard())
+    deck.cards.appendleft(BangCard())
     gm = GameManager(deck=deck)
     jj = Player("JJ", character=JesseJones())
     other = Player("Other")
@@ -171,7 +173,7 @@ def test_jesse_jones_selects_card_index():
 
 def test_jourdonnais_has_virtual_barrel():
     deck = create_standard_deck()
-    deck.cards.append(BeerCard(suit="Hearts"))
+    deck.cards.appendleft(BeerCard(suit="Hearts"))
     target = Player("Jour", character=Jourdonnais())
     BangCard().play(target, deck)
     assert target.metadata.dodged is True
@@ -179,7 +181,7 @@ def test_jourdonnais_has_virtual_barrel():
 
 def test_kit_carlson_draw_three_keep_two():
     deck = create_standard_deck()
-    deck.cards.extend([BangCard(), BeerCard(), MissedCard()])
+    deck.cards.extendleft([BangCard(), BeerCard(), MissedCard()])
     gm = GameManager(deck=deck)
     kit = Player("Kit", character=KitCarlson())
     gm.add_player(kit)
@@ -190,7 +192,7 @@ def test_kit_carlson_draw_three_keep_two():
 
 def test_lucky_duke_draw_two_on_jail():
     deck = create_standard_deck()
-    deck.cards.extend([BangCard(suit="Clubs"), BangCard(suit="Hearts")])
+    deck.cards.extendleft([BangCard(suit="Clubs"), BangCard(suit="Hearts")])
     gm = GameManager(deck=deck)
     player = Player("Lucky", character=LuckyDuke())
     gm.add_player(player)
@@ -214,7 +216,7 @@ def test_barrel_draw_card_discarded():
 
 def test_pedro_ramirez_takes_from_discard():
     deck = create_standard_deck()
-    deck.cards.append(BangCard())
+    deck.cards.appendleft(BangCard())
     gm = GameManager(deck=deck)
     gm.discard_pile.append(MissedCard())
     pedro = Player("Pedro", character=PedroRamirez())
@@ -225,7 +227,7 @@ def test_pedro_ramirez_takes_from_discard():
 
 def test_pedro_ramirez_draws_from_deck_when_chosen():
     deck = create_standard_deck()
-    deck.cards.extend([BangCard(), BeerCard()])
+    deck.cards.extendleft([BangCard(), BeerCard()])
     gm = GameManager(deck=deck)
     gm.discard_pile.append(MissedCard())
     pedro = Player("Pedro", character=PedroRamirez())
@@ -264,7 +266,7 @@ def test_sid_ketchum_discard_two_to_heal():
 
 def test_suzy_lafayette_draws_when_empty():
     deck = create_standard_deck()
-    deck.cards.append(BangCard())
+    deck.cards.appendleft(BangCard())
     gm = GameManager(deck=deck)
     suzy = Player("Suzy", character=SuzyLafayette())
     target = Player("Target")

--- a/tests/test_draw_discard_equipment.py
+++ b/tests/test_draw_discard_equipment.py
@@ -7,11 +7,12 @@ from bang_py.cards.mustang import MustangCard
 from bang_py.cards.iron_plate import IronPlateCard
 from bang_py.characters.black_jack import BlackJack
 from bang_py.characters.sid_ketchum import SidKetchum
+from collections import deque
 
 
 def test_draw_phase_black_jack_extra_card():
     deck = Deck([])
-    deck.cards = [BangCard(), BangCard(suit="Hearts"), BangCard()]
+    deck.cards = deque([BangCard(), BangCard(suit="Hearts"), BangCard()])
     gm = GameManager(deck=deck)
     p = Player("BJ", character=BlackJack())
     gm.add_player(p)

--- a/tests/test_event_deck_effects.py
+++ b/tests/test_event_deck_effects.py
@@ -250,7 +250,7 @@ def test_ambush_sets_distance_one():
 
 def test_ranch_discard_and_redraw():
     deck = Deck([])
-    deck.cards = [BangCard(), BangCard(), BangCard(), BangCard()]
+    deck.cards = deque([BangCard(), BangCard(), BangCard(), BangCard()])
     gm = GameManager(deck=deck)
     p1 = Player("A")
     gm.add_player(p1)
@@ -346,11 +346,13 @@ def test_event_deck_order_fistful():
 
 def test_peyote_extra_draw():
     deck = Deck([])
-    deck.cards = [
-        BangCard(suit="Hearts"),
-        BangCard(suit="Clubs"),
-        BangCard(suit="Diamonds"),
-    ]
+    deck.cards = deque(
+        [
+            BangCard(suit="Diamonds"),
+            BangCard(suit="Clubs"),
+            BangCard(suit="Hearts"),
+        ]
+    )
     gm = GameManager(deck=deck)
     p = Player("Sheriff", role=SheriffRoleCard())
     gm.add_player(p)
@@ -442,7 +444,7 @@ def test_hard_liquor_skip_draw_to_heal():
 
 def test_law_of_west_plays_second_card():
     deck = Deck([])
-    deck.cards = [BeerCard(), BeerCard()]
+    deck.cards = deque([BeerCard(), BeerCard()])
     gm = GameManager(deck=deck)
     p = Player("Sheriff", role=SheriffRoleCard())
     gm.add_player(p)
@@ -468,7 +470,7 @@ def test_shootout_allows_multiple_bangs():
 
 def test_handcuffs_limits_suit_played():
     deck = Deck([])
-    deck.cards = [BangCard(suit="Hearts"), BeerCard(suit="Spades")]
+    deck.cards = deque([BangCard(suit="Hearts"), BeerCard(suit="Spades")])
     gm = GameManager(deck=deck)
     p1 = Player("Sheriff", role=SheriffRoleCard())
     p2 = Player("Outlaw")

--- a/tests/test_expansions.py
+++ b/tests/test_expansions.py
@@ -79,7 +79,7 @@ def test_high_noon_draws_card_for_all():
     p2 = Player("B")
     gm.add_player(p1)
     gm.add_player(p2)
-    gm.deck.cards.extend([PunchCard(), PunchCard()])
+    gm.deck.cards.extendleft([PunchCard(), PunchCard()])
     card = HighNoonCard()
     p1.hand.append(card)
     gm.play_card(p1, card, p1)

--- a/tests/test_gamemanager.py
+++ b/tests/test_gamemanager.py
@@ -6,7 +6,7 @@ from bang_py.cards.bang import BangCard
 
 def test_drawing_and_playing() -> None:
     deck = create_standard_deck()
-    deck.cards.extend([BangCard(), BangCard()])
+    deck.cards.extendleft([BangCard(), BangCard()])
     gm = GameManager(deck=deck)
     p1 = Player("A")
     p2 = Player("B")

--- a/tests/test_start_turn_effects.py
+++ b/tests/test_start_turn_effects.py
@@ -8,7 +8,7 @@ from bang_py.player import Player
 
 def test_jail_auto_skip_turn():
     deck = Deck([])
-    deck.cards.extend([BangCard(), BangCard(), BangCard(suit="Clubs")])
+    deck.cards.extendleft([BangCard(), BangCard(), BangCard(suit="Clubs")])
     gm = GameManager(deck=deck)
     p1 = Player("Jailbird")
     p2 = Player("Other")
@@ -26,7 +26,7 @@ def test_jail_auto_skip_turn():
 
 def test_dynamite_explodes_on_turn_start():
     deck = Deck([])
-    deck.cards.extend([BangCard(), BangCard(), BangCard(suit="Spades", rank=5)])
+    deck.cards.extendleft([BangCard(), BangCard(), BangCard(suit="Spades", rank=5)])
     gm = GameManager(deck=deck)
     p1 = Player("One")
     p2 = Player("Two")
@@ -43,7 +43,7 @@ def test_dynamite_explodes_on_turn_start():
 
 def test_dynamite_passes_to_next_player():
     deck = Deck([])
-    deck.cards.extend([BangCard(), BangCard(), BangCard(suit="Hearts", rank=1)])
+    deck.cards.extendleft([BangCard(), BangCard(), BangCard(suit="Hearts", rank=1)])
     gm = GameManager(deck=deck)
     p1 = Player("One")
     p2 = Player("Two")


### PR DESCRIPTION
## Summary
- replace list-based deck with deque
- shuffle discard pile into deck using deque
- update tests for deque-based deck semantics

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6892fa9ed1f08323a648e7fecef6ace8