### PR TITLE
Handle missing pydub during asset generation

### DIFF
--- a/scripts/generate_assets.py
+++ b/scripts/generate_assets.py
@@ -107,7 +107,7 @@ def create_beep(path: Path, freq: int = 440) -> None:
     raw = b"".join(frames)
     try:  # Attempt MP3 export
         from pydub import AudioSegment  # type: ignore
-    except Exception:
+    except ImportError:  # pydub not installed; skip MP3 export
         return
     audio = AudioSegment(
         data=raw,


### PR DESCRIPTION
## Summary
- handle missing `pydub` by narrowing the exception to `ImportError`

## Testing
- `BANG_AUTO_CLOSE=1 pytest`

------
https://chatgpt.com/codex/tasks/task_e_6892ffa7441c8323bd80e7e0b9cbf1d4