### PR TITLE
refactor: drop Optional in card handlers

### DIFF
--- a/bang_py/card_handlers/bang_handlers.py
+++ b/bang_py/card_handlers/bang_handlers.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from ..cards.bang import BangCard
 from ..cards.missed import MissedCard
@@ -21,7 +21,7 @@ class BangHandlersMixin:
         self: "GameManager",
         player: "Player",
         card: BangCard,
-        target: Optional["Player"],
+        target: "Player" | None,
     ) -> None:
         """Resolve playing a Bang! card with event and equipment modifiers."""
         ignore_eq = player.metadata.ignore_others_equipment


### PR DESCRIPTION
## Summary
- use PEP 604 unions instead of `typing.Optional` in card handler modules
- import `Iterable` from `collections.abc` in `dispatch.py`
- clean up unused `typing` imports

## Testing
- `BANG_AUTO_CLOSE=1 pytest`


------
https://chatgpt.com/codex/tasks/task_e_689304fafc7c8323b7cac3c562e63c0f