### PR TITLE
Localize QML UI strings using qsTr

### DIFF
--- a/bang_py/ui/qml/GameBoard.qml
+++ b/bang_py/ui/qml/GameBoard.qml
@@ -70,7 +70,7 @@ Item {
         radius: 4 * scale
     }
     StyledButton {
-        text: "Draw"
+        text: qsTr("Draw")
         theme: root.theme
         scale: root.scale
         iconSource: "../assets/icons/draw.svg"
@@ -90,7 +90,7 @@ Item {
         radius: 4 * scale
     }
     StyledButton {
-        text: "Discard"
+        text: qsTr("Discard")
         theme: root.theme
         scale: root.scale
         iconSource: "../assets/icons/discard.svg"
@@ -176,7 +176,7 @@ Item {
     }
 
     StyledButton {
-        text: "End Turn"
+        text: qsTr("End Turn")
         theme: root.theme
         scale: root.scale
         iconSource: "../assets/icons/end_turn.svg"

--- a/bang_py/ui/qml/Main.qml
+++ b/bang_py/ui/qml/Main.qml
@@ -61,34 +61,34 @@ Item {
     Dialog {
         id: hostDialog
         modal: true
-        title: "Host Game"
+        title: qsTr("Host Game")
         standardButtons: Dialog.Ok | Dialog.Cancel
         contentItem: Column {
             spacing: 8
             TextField {
                 id: portField
-                placeholderText: "Port (1-65535)"
+                placeholderText: qsTr("Port (1-65535)")
                 text: "8765"
                 validator: IntValidator { bottom: 1; top: 65535 }
             }
             Label {
-                text: "Enter a valid port"
+                text: qsTr("Enter a valid port")
                 color: "red"
                 visible: !portField.acceptableInput
             }
             TextField {
                 id: maxField
-                placeholderText: "Max Players (2-8)"
+                placeholderText: qsTr("Max Players (2-8)")
                 text: "7"
                 validator: IntValidator { bottom: 2; top: 8 }
             }
             Label {
-                text: "Players must be 2-8"
+                text: qsTr("Players must be 2-8")
                 color: "red"
                 visible: !maxField.acceptableInput
             }
-            TextField { id: certField; placeholderText: "Certificate" }
-            TextField { id: keyField; placeholderText: "Key File" }
+            TextField { id: certField; placeholderText: qsTr("Certificate") }
+            TextField { id: keyField; placeholderText: qsTr("Key File") }
         }
         onAccepted: {
             if (!portField.acceptableInput || !maxField.acceptableInput) {
@@ -108,43 +108,43 @@ Item {
     Dialog {
         id: joinDialog
         modal: true
-        title: "Join Game"
+        title: qsTr("Join Game")
         standardButtons: Dialog.Ok | Dialog.Cancel
         contentItem: Column {
             spacing: 8
             TextField {
                 id: tokenField
-                placeholderText: "Token"
+                placeholderText: qsTr("Token")
                 validator: RegExpValidator { regExp: /^[A-Za-z0-9+\/_=-]{0,256}$/ }
             }
             Label {
-                text: "Invalid token"
+                text: qsTr("Invalid token")
                 color: "red"
                 visible: tokenField.text !== "" && !tokenField.acceptableInput
             }
-            TextField { id: addrField; placeholderText: "Host Address"; text: "localhost" }
+            TextField { id: addrField; placeholderText: qsTr("Host Address"); text: "localhost" }
             TextField {
                 id: portJoinField
-                placeholderText: "Port (1-65535)"
+                placeholderText: qsTr("Port (1-65535)")
                 text: "8765"
                 validator: IntValidator { bottom: 1; top: 65535 }
             }
             Label {
-                text: "Enter a valid port"
+                text: qsTr("Enter a valid port")
                 color: "red"
                 visible: !portJoinField.acceptableInput
             }
             TextField {
                 id: codeField
-                placeholderText: "Room Code (6 hex)"
+                placeholderText: qsTr("Room Code (6 hex)")
                 validator: RegExpValidator { regExp: /^[0-9A-Fa-f]{6}$/ }
             }
             Label {
-                text: "Code must be 6 hex chars"
+                text: qsTr("Code must be 6 hex chars")
                 color: "red"
                 visible: codeField.text !== "" && !codeField.acceptableInput
             }
-            TextField { id: cafileField; placeholderText: "CA File" }
+            TextField { id: cafileField; placeholderText: qsTr("CA File") }
         }
         onAccepted: {
             if (tokenField.text !== "") {
@@ -178,13 +178,13 @@ Item {
     Dialog {
         id: settingsDialog
         modal: true
-        title: "Settings"
+        title: qsTr("Settings")
         standardButtons: Dialog.Ok | Dialog.Cancel
         contentItem: Column {
             spacing: 8
             ComboBox {
                 id: themeCombo
-                model: ["light", "dark"]
+                model: [qsTr("light"), qsTr("dark")]
                 currentIndex: root.theme === "dark" ? 1 : 0
             }
         }

--- a/bang_py/ui/qml/MainMenu.qml
+++ b/bang_py/ui/qml/MainMenu.qml
@@ -21,14 +21,14 @@ Rectangle {
         spacing: 10 * scale
 
         Text {
-            text: "Bang!"
+            text: qsTr("Bang!")
             font.pointSize: 24
             color: theme === "dark" ? "white" : "black"
         }
 
         TextField {
             id: nameField
-            placeholderText: "Name (max 20 chars)"
+            placeholderText: qsTr("Name (max 20 chars)")
             width: 200 * scale
             color: theme === "dark" ? "white" : "black"
             background: Rectangle {
@@ -38,13 +38,13 @@ Rectangle {
         }
 
         Label {
-            text: "Use up to 20 printable characters"
+            text: qsTr("Use up to 20 printable characters")
             color: "red"
             visible: nameField.text !== "" && !nameField.acceptableInput
         }
 
         StyledButton {
-            text: "Host Game"
+            text: qsTr("Host Game")
             theme: root.theme
             scale: root.scale
             width: 200 * root.scale
@@ -52,7 +52,7 @@ Rectangle {
             onClicked: root.hostGame()
         }
         StyledButton {
-            text: "Join Game"
+            text: qsTr("Join Game")
             theme: root.theme
             scale: root.scale
             width: 200 * root.scale
@@ -60,7 +60,7 @@ Rectangle {
             onClicked: root.joinGame()
         }
         StyledButton {
-            text: "Settings"
+            text: qsTr("Settings")
             theme: root.theme
             scale: root.scale
             width: 200 * root.scale


### PR DESCRIPTION
## Summary
- Wrap main menu labels and buttons in `qsTr` for translation readiness
- Localize host/join/settings dialogs and theme options
- Translate game board action buttons

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689326b195dc832393efd9549a971fa8