### PR TITLE
Use slots for network Connection dataclass

### DIFF
--- a/bang_py/network/server.py
+++ b/bang_py/network/server.py
@@ -75,7 +75,8 @@ def parse_join_token(
     return obj["host"], int(obj["port"]), obj["code"]
 
 
-@dataclass
+# Use slots to reduce memory footprint and prevent dynamic attribute assignment.
+@dataclass(slots=True)
 class Connection:
     websocket: ServerConnection
     player: Player


### PR DESCRIPTION
## Summary
- use slots for `Connection` dataclass to prevent dynamic attributes and lower memory use
- verify no code adds attributes dynamically to `Connection`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68932defc91483239c2f0c9bc6a3284a