### PR TITLE
Add pre-commit configuration and documentation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.8.0
+    hooks:
+      - id: black
+        args: ["--line-length", "100"]
+  - repo: https://github.com/PyCQA/flake8
+    rev: 7.1.1
+    hooks:
+      - id: flake8
+  - repo: https://github.com/PyCQA/pydocstyle
+    rev: 6.3.0
+    hooks:
+      - id: pydocstyle

--- a/README.md
+++ b/README.md
@@ -2,6 +2,22 @@
 
 This repository now contains a Python implementation of the Bang card game along with a very small websocket server to experiment with multiplayer connectivity.
 
+## Development
+
+This project uses [pre-commit](https://pre-commit.com/) to run linters and
+formatters. Install the hooks with:
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+Run the checks on changed files before committing:
+
+```bash
+pre-commit run --files <path> [<path> ...]
+```
+
 ## Running the server
 
 Install the package using **Python 3.13+**. This pulls in


### PR DESCRIPTION
## Summary
- configure pre-commit with black, flake8, and pydocstyle
- document how to install and run pre-commit hooks

## Testing
- `pre-commit run --files README.md bang_py/__init__.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893361ac1088323a5b102e9b90d25c7