### PR TITLE
docs: note pre-commit usage and server cleanup slow test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@ these rules when making changes.
 - Target `websockets>=15.0.1`, `PySide6>=6.9.1` and `PyInstaller>=6.14.2`.
 - After modifying code, run `pytest` from the repository root to ensure tests
   pass.
+- Before committing, run `pre-commit run --files` on the files you've changed.
 - Keep tests deterministic. If randomness is needed, seed the RNG inside the tests or offer hooks to bypass shuffling.
 - Set `BANG_AUTO_CLOSE=1` when launching the UI in tests so it quits automatically.
 

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -9,3 +9,5 @@
     with `pytest -m slow tests/test_network_integration.py`.
   - `test_network_messages` checks server handling of malformed or oversized messages.
     Execute it with `pytest -m slow tests/test_network_messages.py`.
+  - `test_server_task_cleanup` ensures server tasks shut down cleanly after a disconnect.
+    Run it with `pytest -m slow tests/test_server_task_cleanup.py`.


### PR DESCRIPTION
## Summary
- mention running `pre-commit run --files` before committing
- add `test_server_task_cleanup` to slow test list

## Testing
- `pre-commit run --files AGENTS.md tests/AGENTS.md`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68933c169fa08323adbddd6597a455a9