### PR TITLE
Refactor join token utilities

### DIFF
--- a/bang_py/network/client.py
+++ b/bang_py/network/client.py
@@ -6,9 +6,8 @@ import logging
 import ssl
 
 from websockets.asyncio.client import connect
-from websockets.exceptions import WebSocketException
 
-from .server import parse_join_token
+from .token_utils import parse_join_token
 
 
 async def main(
@@ -47,9 +46,7 @@ async def main(
     """
 
     if token:
-        host, port, room_code = parse_join_token(
-            token, token_key.encode() if token_key else None
-        )
+        host, port, room_code = parse_join_token(token, token_key.encode() if token_key else None)
         uri = f"ws://{host}:{port}"
 
     ssl_ctx = None

--- a/bang_py/network/token_utils.py
+++ b/bang_py/network/token_utils.py
@@ -1,0 +1,46 @@
+"""Utilities for generating and parsing encrypted join tokens."""
+
+from __future__ import annotations
+
+import json
+import os
+from cryptography.fernet import Fernet
+
+# Default key for join tokens used in tests and examples.
+DEFAULT_TOKEN_KEY = b"xPv7Sx0hWCLo5A9HhF_zvg87gdRSB8OYBjWM7lV-H2I="
+
+ENV_TOKEN_KEY = "BANG_TOKEN_KEY"
+
+
+def _token_key_bytes(key: bytes | str | None) -> bytes:
+    """Return ``key`` as bytes or read it from ``BANG_TOKEN_KEY``.
+
+    Raises:
+        ValueError: If no key is provided and the environment variable is unset.
+    """
+
+    if key is None:
+        env = os.getenv(ENV_TOKEN_KEY)
+        if env is None:
+            raise ValueError(
+                "Token key not provided and BANG_TOKEN_KEY environment variable is missing"
+            )
+        key = env
+    return key if isinstance(key, bytes) else key.encode()
+
+
+def generate_join_token(host: str, port: int, code: str, key: bytes | str | None = None) -> str:
+    """Return an encrypted token identifying a game room."""
+
+    key_bytes = _token_key_bytes(key)
+    data = json.dumps({"host": host, "port": port, "code": code}).encode()
+    return Fernet(key_bytes).encrypt(data).decode()
+
+
+def parse_join_token(token: str, key: bytes | str | None = None) -> tuple[str, int, str]:
+    """Decode ``token`` and return ``(host, port, code)``."""
+
+    key_bytes = _token_key_bytes(key)
+    data = Fernet(key_bytes).decrypt(token.encode())
+    obj = json.loads(data.decode())
+    return obj["host"], int(obj["port"]), obj["code"]

--- a/bang_py/ui/main.py
+++ b/bang_py/ui/main.py
@@ -12,7 +12,7 @@ from PySide6 import QtCore, QtWidgets, QtQuick
 from .components import ClientThread, ServerThread
 from .components.card_images import get_loader
 from .theme import get_current_theme
-from ..network.server import parse_join_token
+from ..network.token_utils import parse_join_token
 from cryptography.fernet import InvalidToken
 
 CHARACTER_ASSETS = resources.files("bang_py") / "assets" / "characters"
@@ -36,9 +36,7 @@ class BangUI(QtCore.QObject):
             self.root.joinRequested.connect(self._join_menu)
             self.root.settingsChanged.connect(self._settings_changed)
             self.root.drawCard.connect(lambda: self._send_action({"action": "draw"}))
-            self.root.discardCard.connect(
-                lambda: self._send_action({"action": "discard"})
-            )
+            self.root.discardCard.connect(lambda: self._send_action({"action": "discard"}))
             self.root.endTurn.connect(self._end_turn)
             self.root.playCard.connect(
                 lambda i: self._send_action({"action": "play_card", "card_index": int(i)})
@@ -139,9 +137,7 @@ class BangUI(QtCore.QObject):
         uri = f"{scheme}://localhost:{port}"
         self._start_client(uri, room_code, cafile=certfile)
 
-    def _start_join(
-        self, addr: str, port: int, code: str, cafile: str | None = None
-    ) -> None:
+    def _start_join(self, addr: str, port: int, code: str, cafile: str | None = None) -> None:
         scheme = "wss" if cafile else "ws"
         uri = f"{scheme}://{addr}:{port}"
         self._start_client(uri, code, cafile)
@@ -178,13 +174,9 @@ class BangUI(QtCore.QObject):
                 if "BangCard" in text:
                     QtCore.QMetaObject.invokeMethod(self.game_root, "playBang")
                 if "GatlingCard" in text:
-                    QtCore.QMetaObject.invokeMethod(
-                        self.game_root, "playManyBangs"
-                    )
+                    QtCore.QMetaObject.invokeMethod(self.game_root, "playManyBangs")
                 if "IndiansCard" in text:
-                    QtCore.QMetaObject.invokeMethod(
-                        self.game_root, "playIndians"
-                    )
+                    QtCore.QMetaObject.invokeMethod(self.game_root, "playIndians")
                 if "MissedCard" in text:
                     QtCore.QMetaObject.invokeMethod(self.game_root, "playMissed")
             if "players" in data:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ import importlib.util
 import pytest
 
 try:
-    from bang_py.network.server import DEFAULT_TOKEN_KEY
+    from bang_py.network.token_utils import DEFAULT_TOKEN_KEY
 except ImportError:
     DEFAULT_TOKEN_KEY = None
 
@@ -41,7 +41,7 @@ def _set_token_key(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.fixture
-def qt_app() -> "QtWidgets.QApplication":
+def qt_app() -> "QtWidgets.QApplication":  # noqa: F821
     """Create a ``QApplication`` instance for Qt tests."""
     pytest.importorskip("PySide6")
     pytest.importorskip("PySide6.QtWidgets")
@@ -57,4 +57,3 @@ def qt_app() -> "QtWidgets.QApplication":
     yield app
     if created:
         app.quit()
-

--- a/tests/test_join_token.py
+++ b/tests/test_join_token.py
@@ -1,16 +1,15 @@
 import pytest
-
-pytest.importorskip("cryptography")
-
-from bang_py.network.server import (
+from bang_py.network.token_utils import (
     generate_join_token,
     parse_join_token,
     DEFAULT_TOKEN_KEY,
 )
 from cryptography.fernet import InvalidToken
 
+pytest.importorskip("cryptography")
 
-def test_generate_and_parse_token():
+
+def test_generate_and_parse_token() -> None:
     token = generate_join_token("host", 1234, "code", DEFAULT_TOKEN_KEY)
     host, port, code = parse_join_token(token, DEFAULT_TOKEN_KEY)
     assert host == "host"
@@ -18,14 +17,14 @@ def test_generate_and_parse_token():
     assert code == "code"
 
 
-def test_token_invalid_key():
+def test_token_invalid_key() -> None:
     token = generate_join_token("host", 1, "c", DEFAULT_TOKEN_KEY)
     bad_key = b"fh-IQhdbcUCrWTWyQ7WcM5VqCPU-ixXvSawvMkE415Q="
     with pytest.raises(InvalidToken):
         parse_join_token(token, bad_key)
 
 
-def test_token_env_fallback(monkeypatch):
+def test_token_env_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("BANG_TOKEN_KEY", DEFAULT_TOKEN_KEY.decode())
     token = generate_join_token("host", 2, "abc")
     host, port, code = parse_join_token(token)
@@ -34,7 +33,7 @@ def test_token_env_fallback(monkeypatch):
     assert code == "abc"
 
 
-def test_missing_key_raises(monkeypatch):
+def test_missing_key_raises(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("BANG_TOKEN_KEY", raising=False)
     with pytest.raises(ValueError):
         generate_join_token("h", 1, "c")
@@ -42,4 +41,3 @@ def test_missing_key_raises(monkeypatch):
     monkeypatch.delenv("BANG_TOKEN_KEY", raising=False)
     with pytest.raises(ValueError):
         parse_join_token(token)
-


### PR DESCRIPTION
## Summary
- move join token helpers into new `token_utils` module
- update server, client, UI, and tests to use the shared utilities
- drop unnecessary `BangServer.parse_join_token` wrapper

## Testing
- `pre-commit run --files bang_py/network/token_utils.py bang_py/network/client.py bang_py/network/server.py bang_py/ui/main.py tests/conftest.py tests/test_join_token.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893bbcccee08323b74e0073db4dc353