### PR TITLE
docs: clarify network client

### DIFF
--- a/bang_py/network/client.py
+++ b/bang_py/network/client.py
@@ -1,4 +1,8 @@
-"""Console client for connecting to a Bang websocket server."""
+"""Console client for the Bang websocket server.
+
+When a join token is provided, ``parse_join_token`` extracts the host, port, and
+room.
+"""
 
 import asyncio
 import json


### PR DESCRIPTION
## Summary
- clarify module purpose for `bang_client`
- note how join tokens rely on `parse_join_token`

## Testing
- `pre-commit run --files bang_py/network/client.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893c00b63a0832390c13f3efd7fe50c