### PR TITLE
mark server task cleanup test as slow

### DIFF
--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -10,4 +10,4 @@
   - `test_network_messages` checks server handling of malformed or oversized messages.
     Execute it with `pytest -m slow tests/test_network_messages.py`.
   - `test_server_task_cleanup` ensures server tasks shut down cleanly after a disconnect.
-    Run it with `pytest -m slow tests/test_server_task_cleanup.py`.
+    Execute it with `pytest -m slow tests/test_server_task_cleanup.py`.

--- a/tests/test_server_task_cleanup.py
+++ b/tests/test_server_task_cleanup.py
@@ -1,13 +1,15 @@
 import asyncio
 import pytest
 
+pytestmark = pytest.mark.slow
+
 pytest.importorskip("cryptography")
 
-from bang_py.network.server import BangServer
+from bang_py.network.server import BangServer  # noqa: E402
 
 websockets = pytest.importorskip("websockets")
-from websockets.asyncio.client import connect
-from websockets.asyncio.server import serve
+from websockets.asyncio.client import connect  # noqa: E402
+from websockets.asyncio.server import serve  # noqa: E402
 
 
 def test_disconnect_cleans_tasks(capsys) -> None:


### PR DESCRIPTION
## Summary
- mark server task cleanup test module as `@pytest.mark.slow`
- document new slow test in test guidelines

## Testing
- `pre-commit run --files tests/test_server_task_cleanup.py tests/AGENTS.md`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893c2458a6c8323abe151f7b80e6218