### PR TITLE
cache sound objects

### DIFF
--- a/tests/test_load_sound.py
+++ b/tests/test_load_sound.py
@@ -12,11 +12,11 @@ pytest.importorskip(
     exc_type=ImportError,
 )
 
-from PySide6 import QtWidgets
-from bang_py.ui.components.card_images import load_sound
+from PySide6 import QtWidgets  # noqa: E402
+from bang_py.ui.components.card_images import clear_sound_cache, load_sound  # noqa: E402
 
 
-def test_load_sound_mp3():
+def _prepare_app():
     os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
     audio_path = (
         Path(__file__).resolve().parents[1] / "bang_py" / "assets" / "audio" / "ui_click.mp3"
@@ -27,9 +27,36 @@ def test_load_sound_mp3():
     created = app is None
     if created:
         app = QtWidgets.QApplication([])
+    return app, created
+
+
+def test_load_sound_mp3():
+    app, created = _prepare_app()
+    clear_sound_cache()
     sound = load_sound("ui_click")
     if created:
         app.quit()
     if sound is None:
         pytest.skip("QtMultimedia not available")
     assert hasattr(sound, "play")
+    clear_sound_cache()
+
+
+def test_load_sound_cache():
+    app, created = _prepare_app()
+    clear_sound_cache()
+    sound1 = load_sound("ui_click")
+    sound2 = load_sound("ui_click")
+    if sound1 is None:
+        if created:
+            app.quit()
+        pytest.skip("QtMultimedia not available")
+    assert sound1 is sound2
+    clear_sound_cache()
+    sound3 = load_sound("ui_click")
+    if created:
+        app.quit()
+    if sound3 is None:
+        pytest.skip("QtMultimedia not available")
+    assert sound1 is not sound3
+    clear_sound_cache()


### PR DESCRIPTION
## Summary
- cache loaded sounds and provide test hook for clearing
- add tests for sound caching

## Testing
- `python -m pre_commit run --files bang_py/ui/components/card_images.py tests/test_load_sound.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893ce6b3b90832381cefb6960939b25