### PR TITLE
docs: add card module guidelines

### DIFF
--- a/bang_py/cards/AGENTS.md
+++ b/bang_py/cards/AGENTS.md
@@ -1,0 +1,10 @@
+# Card Module Guidelines
+
+To keep card implementations consistent, follow these rules for files in this
+folder.
+
+- Start every file with a short module-level docstring.
+- In docstrings, mention the expansion a card belongs to, when applicable.
+- Prefer built-in generics such as `list` and `dict`, and use the `| None` syntax
+  for optional types.
+- Use `@override` when overriding methods from parent classes.


### PR DESCRIPTION
## Summary
- add card module guidelines for module docstrings, expansion references, built-in generics, and @override usage

## Testing
- `pre-commit run --files bang_py/cards/AGENTS.md`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893d44f9de08323831e204c30c332ae