### PR TITLE
Add lint and test make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,13 @@
 .RECIPEPREFIX := >
-.PHONY: build-exe
+.PHONY: build-exe lint test
 
 build-exe:
 >mkdir -p build/bang
 >echo "[Paths]\nPrefix=." > build/bang/qt.conf
 >pyinstaller bang.spec
+
+lint:
+>@pre-commit run --files $(FILES)
+
+test:
+>@pytest

--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ Run the checks on changed files before committing:
 pre-commit run --files <path> [<path> ...]
 ```
 
+Alternatively, use the Makefile targets:
+
+```bash
+make lint FILES="<path> [<path> ...]"  # run pre-commit on specific files
+make test                              # execute the test suite
+```
+
 ## Running the server
 
 Install the package using **Python 3.13+**. This pulls in

--- a/bang_py/cards/cat_balou.py
+++ b/bang_py/cards/cat_balou.py
@@ -1,5 +1,7 @@
-"""Cat Balou card from the base game. Choose a card from the target's hand or in play and discard
-it."""
+"""Cat Balou card from the base game.
+
+Choose a card from the target's hand or in play and discard it.
+"""
 
 from __future__ import annotations
 from .card import BaseCard
@@ -15,9 +17,7 @@ class CatBalouCard(BaseCard):
     card_name = "Cat Balou"
     card_type = "action"
     card_set = "base"
-    description = (
-        "Choose a card from the target's hand or in play and discard it."
-    )
+    description = "Choose a card from the target's hand or in play and discard it."
 
     def play(
         self,

--- a/bang_py/cards/events/fistful_of_cards.py
+++ b/bang_py/cards/events/fistful_of_cards.py
@@ -1,5 +1,8 @@
-"""A Fistful of Cards card from the Fistful of Cards expansion. At the beginning of his turn, each
-player is the target of as many Bangs! as cards in their hand."""
+"""A Fistful of Cards card from the Fistful of Cards expansion.
+
+At the beginning of his turn, each player is the target of as many Bangs! as
+cards in their hand.
+"""
 
 from __future__ import annotations
 

--- a/bang_py/cards/events/the_judge.py
+++ b/bang_py/cards/events/the_judge.py
@@ -1,5 +1,7 @@
-"""The Judge card from the Fistful of Cards expansion. Players cannot play cards in front of
-themselves or others."""
+"""The Judge card from the Fistful of Cards expansion.
+
+Players cannot play cards in front of themselves or others.
+"""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary
- add `lint` and `test` targets to the Makefile
- document linting and testing commands in the README
- tidy up card docstrings to satisfy pydocstyle

## Testing
- `pre-commit run --files Makefile README.md bang_py/cards/cat_balou.py bang_py/cards/events/fistful_of_cards.py bang_py/cards/events/the_judge.py`
- `pytest`
- `make lint FILES="Makefile README.md bang_py/cards/cat_balou.py bang_py/cards/events/fistful_of_cards.py bang_py/cards/events/the_judge.py"`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6893d5ab848083238f5d82e04f7f9866