### PR TITLE
Use typing.cast for optional Qt modules

### DIFF
--- a/bang_py/helpers.py
+++ b/bang_py/helpers.py
@@ -7,12 +7,14 @@ from .player import Player
 from .characters.base import BaseCharacter
 from .characters.vera_custer import VeraCuster
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, cast
 
 try:  # Qt is optional for non-UI use
     from PySide6 import QtCore, QtGui, QtSvg
 except ImportError:  # pragma: no cover - Qt may not be installed
-    QtCore = QtGui = QtSvg = None  # type: ignore
+    QtCore = cast(Any, None)
+    QtGui = cast(Any, None)
+    QtSvg = cast(Any, None)
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from .game_manager import GameManager


### PR DESCRIPTION
## Summary
- cast optional PySide6 modules as Any when PySide6 isn't installed

## Testing
- `pre-commit run --files bang_py/helpers.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893db78d5d48323ad4ae9073b4e920b