### PR TITLE
Use dataclass slots for core game types

### DIFF
--- a/bang_py/events/event_decks.py
+++ b/bang_py/events/event_decks.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from collections import deque
 from collections.abc import Callable
 from typing import TYPE_CHECKING
@@ -158,7 +158,7 @@ def _russian_roulette_event(game: GameManager) -> None:
     RussianRouletteEventCard().play(game=game)
 
 
-@dataclass
+@dataclass(slots=True)
 class EventCard:
     """Card used in event deck expansions."""
 
@@ -170,6 +170,7 @@ class EventCard:
     card_set: str = "event_deck"
     suit: str | None = None
     rank: int | None = None
+    card_name: str = field(init=False)
 
     def __post_init__(self) -> None:
         """Set ``card_name`` to the event name."""
@@ -192,41 +193,45 @@ class EventCard:
 
 def create_high_noon_deck() -> deque[BaseEventCard]:
     """Return a simple High Noon event deck."""
-    return deque([
-        BlessingEventCard(),
-        CurseEventCard(),
-        GhostTownEventCard(),
-        GoldRushEventCard(),
-        HangoverEventCard(),
-        HighNoonEventCard(),
-        ShootoutEventCard(),
-        TheDaltonsEventCard(),
-        TheDoctorEventCard(),
-        TheReverendEventCard(),
-        TheSermonEventCard(),
-        ThirstEventCard(),
-        TrainArrivalEventCard(),
-        HandcuffsEventCard(),
-        NewIdentityEventCard(),
-    ])
+    return deque(
+        [
+            BlessingEventCard(),
+            CurseEventCard(),
+            GhostTownEventCard(),
+            GoldRushEventCard(),
+            HangoverEventCard(),
+            HighNoonEventCard(),
+            ShootoutEventCard(),
+            TheDaltonsEventCard(),
+            TheDoctorEventCard(),
+            TheReverendEventCard(),
+            TheSermonEventCard(),
+            ThirstEventCard(),
+            TrainArrivalEventCard(),
+            HandcuffsEventCard(),
+            NewIdentityEventCard(),
+        ]
+    )
 
 
 def create_fistful_deck() -> deque[BaseEventCard]:
     """Return a simple Fistful of Cards event deck."""
-    return deque([
-        AbandonedMineEventCard(),
-        AmbushEventCard(),
-        BloodBrothersEventCard(),
-        DeadManEventCard(),
-        HardLiquorEventCard(),
-        LassoEventCard(),
-        LawOfTheWestEventCard(),
-        PeyoteEventCard(),
-        RanchEventCard(),
-        RicochetEventCard(),
-        RussianRouletteEventCard(),
-        SniperEventCard(),
-        TheJudgeEventCard(),
-        VendettaEventCard(),
-        FistfulOfCardsEventCard(),
-    ])
+    return deque(
+        [
+            AbandonedMineEventCard(),
+            AmbushEventCard(),
+            BloodBrothersEventCard(),
+            DeadManEventCard(),
+            HardLiquorEventCard(),
+            LassoEventCard(),
+            LawOfTheWestEventCard(),
+            PeyoteEventCard(),
+            RanchEventCard(),
+            RicochetEventCard(),
+            RussianRouletteEventCard(),
+            SniperEventCard(),
+            TheJudgeEventCard(),
+            VendettaEventCard(),
+            FistfulOfCardsEventCard(),
+        ]
+    )

--- a/bang_py/game_manager.py
+++ b/bang_py/game_manager.py
@@ -19,7 +19,7 @@ from .ability_dispatch import AbilityDispatchMixin
 from .events.event_hooks import EventHooksMixin
 
 
-@dataclass
+@dataclass(slots=True)
 class GameManager(
     DeckManagerMixin,
     AbilityDispatchMixin,
@@ -50,15 +50,11 @@ class GameManager(
     general_store_index: int = 0
 
     # Event listeners
-    draw_phase_listeners: list[Callable[[Player, object], bool]] = field(
-        default_factory=list
-    )
+    draw_phase_listeners: list[Callable[[Player, object], bool]] = field(default_factory=list)
     player_damaged_listeners: list[Callable[[Player, Player | None], None]] = field(
         default_factory=list
     )
-    player_healed_listeners: list[Callable[[Player], None]] = field(
-        default_factory=list
-    )
+    player_healed_listeners: list[Callable[[Player], None]] = field(default_factory=list)
     player_death_listeners: list[Callable[[Player, Player | None], None]] = field(
         default_factory=list
     )
@@ -67,10 +63,11 @@ class GameManager(
     card_play_checks: list[Callable[[Player, BaseCard, Player | None], bool]] = field(
         default_factory=list
     )
-    card_played_listeners: list[
-        Callable[[Player, BaseCard, Player | None], None]
-    ] = field(default_factory=list)
+    card_played_listeners: list[Callable[[Player, BaseCard, Player | None], None]] = field(
+        default_factory=list
+    )
     play_phase_listeners: list[Callable[[Player], None]] = field(default_factory=list)
+    _card_handlers: dict = field(default_factory=dict, init=False, repr=False)
     _duel_counts: dict | None = field(default=None, init=False, repr=False)
 
     @property


### PR DESCRIPTION
## Summary
- Make EventCard a slotted dataclass and store `card_name` explicitly
- Use slotted dataclass for GameManager and declare `_card_handlers`

## Testing
- `pre-commit run --files bang_py/events/event_decks.py bang_py/game_manager.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893dcf3e7dc83238796d7fd2b1949fb