### PR TITLE
Use override for Missed and hat cards

### DIFF
--- a/bang_py/cards/iron_plate.py
+++ b/bang_py/cards/iron_plate.py
@@ -1,6 +1,8 @@
-"""Iron Plate card from the Dodge City expansion. Counts as a Missed!"""
+"""Iron Plate card from the Dodge City expansion. Counts as a Missed card."""
 
 from __future__ import annotations
+
+from typing import override
 
 from .missed import MissedCard
 from ..player import Player
@@ -14,5 +16,6 @@ class IronPlateCard(MissedCard):
     card_set = "dodge_city"
     description = "Counts as a Missed!"
 
-    def play(self, target: Player) -> None:  # type: ignore[override]
-        super().play(target)
+    @override
+    def play(self, target: Player | None, **kwargs) -> None:
+        super().play(target, **kwargs)

--- a/bang_py/cards/missed.py
+++ b/bang_py/cards/missed.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import override
+
 from .card import BaseCard
 from ..player import Player
 
@@ -12,7 +14,8 @@ class MissedCard(BaseCard):
     card_set = "base"
     description = "Negates one Bang! targeting you."
 
-    def play(self, target: Player) -> None:
+    @override
+    def play(self, target: Player | None, **kwargs) -> None:
         if not target:
             return
         target.metadata.dodged = True

--- a/bang_py/cards/sombrero.py
+++ b/bang_py/cards/sombrero.py
@@ -1,6 +1,8 @@
-"""Sombrero card from the Dodge City expansion. Counts as a Missed!"""
+"""Sombrero card from the Dodge City expansion. Counts as a Missed card."""
 
 from __future__ import annotations
+
+from typing import override
 
 from .missed import MissedCard
 from ..player import Player
@@ -14,5 +16,6 @@ class SombreroCard(MissedCard):
     card_set = "dodge_city"
     description = "Counts as a Missed!"
 
-    def play(self, target: Player) -> None:  # type: ignore[override]
-        super().play(target)
+    @override
+    def play(self, target: Player | None, **kwargs) -> None:
+        super().play(target, **kwargs)

--- a/bang_py/cards/ten_gallon_hat.py
+++ b/bang_py/cards/ten_gallon_hat.py
@@ -1,6 +1,8 @@
-"""Ten Gallon Hat card from the Dodge City expansion. Counts as a Missed!"""
+"""Ten Gallon Hat card from the Dodge City expansion. Counts as a Missed card."""
 
 from __future__ import annotations
+
+from typing import override
 
 from .missed import MissedCard
 from ..player import Player
@@ -14,5 +16,6 @@ class TenGallonHatCard(MissedCard):
     card_set = "dodge_city"
     description = "Counts as a Missed!"
 
-    def play(self, target: Player) -> None:  # type: ignore[override]
-        super().play(target)
+    @override
+    def play(self, target: Player | None, **kwargs) -> None:
+        super().play(target, **kwargs)


### PR DESCRIPTION
## Summary
- allow MissedCard.play to accept optional targets and keyword args
- update Ten Gallon Hat, Sombrero, and Iron Plate to override play with the new signature

## Testing
- `pre-commit run --files bang_py/cards/missed.py bang_py/cards/ten_gallon_hat.py bang_py/cards/sombrero.py bang_py/cards/iron_plate.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893deccfc4c8323ba1270059163f005