### PR TITLE
refactor: consolidate network client test

### DIFF
--- a/tests/test_network_client.py
+++ b/tests/test_network_client.py
@@ -1,8 +1,0 @@
-import importlib
-
-from websockets.asyncio.client import connect as async_connect
-
-
-def test_client_uses_asyncio_connect() -> None:
-    module = importlib.import_module("bang_py.network.client")
-    assert module.connect is async_connect

--- a/tests/test_network_serialization.py
+++ b/tests/test_network_serialization.py
@@ -1,12 +1,14 @@
 import json
 
 import pytest
-
-pytest.importorskip("cryptography")
+from websockets.asyncio.client import connect as async_connect
 
 from bang_py.player import Player
 from bang_py.cards.roles import SheriffRoleCard, OutlawRoleCard
+from bang_py.network import client as network_client
 from bang_py.network.server import _serialize_players
+
+pytest.importorskip("cryptography")
 
 
 def test_serialize_players_json_roundtrip():
@@ -61,3 +63,7 @@ def test_serialize_players_without_role():
             "equipment": [],
         }
     ]
+
+
+def test_client_uses_asyncio_connect() -> None:
+    assert network_client.connect is async_connect


### PR DESCRIPTION
## Summary
- remove redundant `test_network_client` file
- check network client uses asyncio connect inside serialization tests

## Testing
- `pre-commit run --files tests/test_network_serialization.py`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_6893e1ba1b908323815b27d5a093b956