### PR TITLE
Import secrets in server room code test

### DIFF
--- a/tests/test_server_room_code.py
+++ b/tests/test_server_room_code.py
@@ -1,9 +1,9 @@
-import secrets
 import pytest
+import secrets
 
 pytest.importorskip("cryptography")
 
-from bang_py.network.server import BangServer
+from bang_py.network.server import BangServer  # noqa: E402
 
 
 def test_default_room_code_format(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- Import `secrets` and keep cryptography optional in `test_server_room_code`
- Silence flake8 E402 for server import

## Testing
- `pre-commit run --files tests/test_server_room_code.py`
- `pytest tests/test_server_room_code.py`


------
https://chatgpt.com/codex/tasks/task_e_6893e7ad24c083238a682b58ad62db93