### PR TITLE
Document icon usage test in guidelines

### DIFF
--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -15,3 +15,6 @@
 - `test_audio_usage` verifies that every file in `bang_py/assets/audio/` is
   referenced by the codebase. Any intentionally unused audio must be added to
   `KNOWN_UNUSED` within `tests/test_audio_usage.py`.
+- `test_icon_usage` ensures every file in `bang_py/assets/icons/` is referenced
+  by the codebase. Any intentionally unused icons must be added to
+  `KNOWN_UNUSED` within `tests/test_icon_usage.py`.


### PR DESCRIPTION
## Summary
- document `test_icon_usage`'s role in verifying icons under `bang_py/assets/icons/`
- explain how to whitelist icons via `KNOWN_UNUSED` in `tests/test_icon_usage.py`

## Testing
- `pre-commit run --files tests/AGENTS.md`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893fd741bb88323b11bc3e58b53f999