### PR TITLE
ci: run pre-commit and test across Python versions

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -5,12 +5,15 @@ on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.12", "3.13-dev"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.13-dev'
+          python-version: ${{ matrix.python-version }}
       - name: Install system packages
         run: |
           sudo apt-get update
@@ -21,6 +24,8 @@ jobs:
           pip install cryptography
           pip install -r requirements.txt
           pip install -e .
-          pip install pytest
+          pip install pytest pre-commit
+      - name: Run pre-commit
+        run: pre-commit run --files $(git ls-files '*.py')
       - name: Run tests
         run: pytest


### PR DESCRIPTION
## Summary
- run CI pre-commit hooks before executing tests
- test workflow across Python 3.12 and 3.13-dev

## Testing
- `pre-commit run --files .github/workflows/python-tests.yml`
- `BANG_AUTO_CLOSE=1 pytest`


------
https://chatgpt.com/codex/tasks/task_e_68940055fc2c832390e4b9ac3c487030