### PR TITLE
Refactor server CLI into dedicated module

### DIFF
--- a/bang_py/network/cli.py
+++ b/bang_py/network/cli.py
@@ -1,0 +1,48 @@
+"""Command-line interface for the Bang websocket server."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+from collections.abc import Sequence
+
+from .server import BangServer
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    """Parse ``argv`` and launch the Bang websocket server.
+
+    When ``--show-token`` is supplied, the function prints a join token for the
+    configured server and exits without starting it.
+    """
+
+    parser = argparse.ArgumentParser(description="Start Bang websocket server")
+    parser.add_argument("--host", default="localhost")
+    parser.add_argument("--port", type=int, default=8765)
+    parser.add_argument("--certfile", help="Path to SSL certificate", default=None)
+    parser.add_argument("--keyfile", help="Path to SSL key", default=None)
+    parser.add_argument("--token-key", help="Key for join tokens", default=None)
+    parser.add_argument(
+        "--show-token",
+        action="store_true",
+        help="Display join token and exit",
+    )
+    args = parser.parse_args(argv)
+
+    server = BangServer(
+        host=args.host,
+        port=args.port,
+        certfile=args.certfile,
+        keyfile=args.keyfile,
+        token_key=args.token_key,
+    )
+
+    if args.show_token:
+        print(server.generate_join_token())
+        return
+
+    asyncio.run(server.start())
+
+
+if __name__ == "__main__":
+    main()

--- a/bang_py/network/server.py
+++ b/bang_py/network/server.py
@@ -683,35 +683,3 @@ class BangServer:
                 self.room_code,
             )
             await asyncio.Future()  # run forever
-
-
-def main() -> None:
-    """Entry point for the ``bang-server`` console script."""
-    import argparse
-
-    parser = argparse.ArgumentParser(description="Start Bang websocket server")
-    parser.add_argument("--host", default="localhost")
-    parser.add_argument("--port", type=int, default=8765)
-    parser.add_argument("--certfile", help="Path to SSL certificate", default=None)
-    parser.add_argument("--keyfile", help="Path to SSL key", default=None)
-    parser.add_argument("--token-key", help="Key for join tokens", default=None)
-    parser.add_argument("--show-token", action="store_true", help="Display join token and exit")
-    args = parser.parse_args()
-
-    server = BangServer(
-        host=args.host,
-        port=args.port,
-        certfile=args.certfile,
-        keyfile=args.keyfile,
-        token_key=args.token_key,
-    )
-
-    if args.show_token:
-        print(server.generate_join_token())
-        return
-
-    asyncio.run(server.start())
-
-
-if __name__ == "__main__":
-    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
 ]
 
 [project.scripts]
-bang-server = "bang_py.network.server:main"
+bang-server = "bang_py.network.cli:main"
 bang-client = "bang_py.network.client:run"
 bang-ui = "bang_py.ui:main"
 


### PR DESCRIPTION
## Summary
- add `bang_py.network.cli` with argument parsing and token printing
- remove CLI code from `BangServer` module
- point `bang-server` entry point at the new CLI module

## Testing
- `pre-commit run --files bang_py/network/cli.py bang_py/network/server.py pyproject.toml` *(fails: mypy reports numerous errors)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68941005f9688323bb3c4aa2da927d85