### PR TITLE
Move PyInstaller spec into scripts directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 build-exe:
 >mkdir -p build/bang
 >echo "[Paths]\nPrefix=." > build/bang/qt.conf
->pyinstaller bang.spec
+>pyinstaller scripts/bang.spec
 
 lint:
 >@pre-commit run --files $(FILES)

--- a/scripts/bang.spec
+++ b/scripts/bang.spec
@@ -4,13 +4,13 @@ from PyInstaller.utils.hooks import collect_dynamic_libs, collect_submodules
 from glob import glob
 
 asset_patterns = (
-    'bang_py/assets/*.png',
-    'bang_py/assets/*.svg',
-    'bang_py/assets/icons/*.svg',
-    'bang_py/assets/characters/*.webp',
-    'bang_py/assets/audio/*.mp3',
-    'bang_py/assets/audio/*.wav',
-    'bang_py/assets/*.md',
+    '../bang_py/assets/*.png',
+    '../bang_py/assets/*.svg',
+    '../bang_py/assets/icons/*.svg',
+    '../bang_py/assets/characters/*.webp',
+    '../bang_py/assets/audio/*.mp3',
+    '../bang_py/assets/audio/*.wav',
+    '../bang_py/assets/*.md',
 )
 
 asset_paths = [
@@ -20,7 +20,7 @@ asset_paths = [
 ]
 
 a = Analysis(
-    ['pyinstaller_entry.py'],
+    ['../pyinstaller_entry.py'],
     pathex=[],
     binaries=collect_dynamic_libs('PySide6'),
     datas=asset_paths,


### PR DESCRIPTION
## Summary
- relocate `bang.spec` into `scripts` and adjust paths for assets and entry script
- update Makefile to call PyInstaller with the new spec path

## Testing
- `pre-commit run --files Makefile scripts/bang.spec` (all hooks skipped)
- `pytest` *(fails: ModuleNotFoundError: No module named 'bang_py')*


------
https://chatgpt.com/codex/tasks/task_e_68942bc151488323ab29c00ecfa585c9