### PR TITLE
Add network guidelines and use TaskGroup for broadcasts

### DIFF
--- a/bang_py/network/AGENTS.md
+++ b/bang_py/network/AGENTS.md
@@ -1,0 +1,5 @@
+# Agent Guidelines
+
+- Use `asyncio` APIs with `TaskGroup` for managing concurrency when suitable.
+- Decorate methods that override base class implementations with `@override`.
+- Keep lines at or below 100 characters and write docstrings for public functions.


### PR DESCRIPTION
## Summary
- add AGENTS guidelines for the network package
- supervise broadcast tasks with a TaskGroup and helper
- update server broadcast logic to leverage TaskGroup

## Testing
- `SKIP=mypy pre-commit run --files bang_py/network/AGENTS.md bang_py/network/server.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68942ba868c083238ff38a3a01312c07