### PR TITLE
Switch to pyproject-based dependency management

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -22,11 +22,7 @@ jobs:
           sudo apt-get install -y libxcb-cursor0 libxkbcommon-x11-0 libegl1
       - name: Install dependencies
         run: |
-          pip install "PySide6>=6.9.1" --pre
-          pip install cryptography
-          pip install -r requirements.txt
-          pip install -e .
-          pip install pytest pre-commit
+          pip install .[dev] --pre
       - name: Run pre-commit
         run: pre-commit run --files $(git ls-files '*.py')
         continue-on-error: true

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -20,11 +20,10 @@ jobs:
           python-version: '3.13-dev'
       - name: Install dependencies
         run: |
-          python -m pip install -r requirements.txt
-          python -m pip install pyinstaller
+          python -m pip install .[dev] --pre
       - name: Build executable
         run: |
-          pyinstaller bang.spec
+          pyinstaller scripts/bang.spec
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ This repository now contains a Python implementation of the Bang card game along
 
 This project uses [pre-commit](https://pre-commit.com/) to run linters,
 formatters and static type checks (Black, Flake8, pydocstyle and mypy).
-Install the hooks with:
+Install the project with its development dependencies and set up the hooks:
 
 ```bash
-pip install pre-commit
+pip install .[dev]
 pre-commit install
 ```
 
@@ -89,10 +89,10 @@ The interface now runs entirely on Qt Quick. A single ``QQuickView`` loads
 between screens and the **Settings** dialog are implemented in QML and expose
 signals that the Python backend connects to.
 
-Install the Qt requirements first (PySide6 6.9.1 or newer):
+Install the package first; it pulls in the Qt requirements (PySide6 6.9.1 or newer):
 
 ```bash
-pip install "PySide6>=6.9.1"
+pip install .[dev]
 ```
 
 On Linux, the UI and tests also require the system packages
@@ -161,10 +161,10 @@ These packages provide the OpenGL and keyboard functionality that PySide6 needs.
 ## Building a Windows Executable
 
 `pyinstaller` can bundle the UI into a standalone Windows executable. Install the
-build dependencies (PyInstaller 6.14.2 or newer) and run the target:
+build dependencies and run the target:
 
 ```bash
-pip install -r requirements.txt
+pip install .[dev]
 make build-exe
 ```
 
@@ -183,14 +183,10 @@ needs the `contents: write` permission (or a PAT) to upload the file.
 
 ## Running Tests
 
-Install the Qt bindings before running the test suite. The CI workflow installs
-`PySide6>=6.9.1` first along with `cryptography` for the network tests:
+Install the development dependencies before running the test suite:
 
 ```bash
-pip install "PySide6>=6.9.1"
-pip install cryptography
-pip install -r requirements.txt
-pip install -e .
+pip install .[dev]
 pytest
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,13 @@ dependencies = [
     "cryptography>=42.0.5",
 ]
 
+[project.optional-dependencies]
+dev = [
+    "pytest",
+    "pre-commit",
+    "pyinstaller>=6.14.2",
+]
+
 [project.scripts]
 bang-server = "bang_py.network.cli:main"
 bang-client = "bang_py.network.client:run"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,1 @@
-websockets>=15.0.1
-pyinstaller>=6.14.2
-PySide6>=6.9.1
-cryptography>=42.0.5
+-e .[dev]


### PR DESCRIPTION
## Summary
- consolidate dependency management via pyproject optional `dev` extras
- update docs to install with `pip install .[dev]`
- simplify CI workflows to rely on pyproject for dependencies

## Testing
- `pre-commit run --files requirements.txt pyproject.toml README.md .github/workflows/python-tests.yml .github/workflows/windows-build.yml`
- `BANG_AUTO_CLOSE=1 pytest`


------
https://chatgpt.com/codex/tasks/task_e_68943475c54c83239d2a98f74743106c