### PR TITLE
refactor: lazy re-exports

### DIFF
--- a/bang_py/__init__.py
+++ b/bang_py/__init__.py
@@ -1,62 +1,47 @@
 """Bang card game modules."""
 
-from .game_manager import GameManager
-from .deck_factory import create_standard_deck
-from .player import Player, PlayerMetadata
-from .cards.roles import (
-    BaseRole,
-    SheriffRoleCard,
-    DeputyRoleCard,
-    OutlawRoleCard,
-    RenegadeRoleCard,
-)
-from .characters.base import BaseCharacter
-from .characters.bart_cassidy import BartCassidy
-from .characters.black_jack import BlackJack
-from .characters.calamity_janet import CalamityJanet
-from .characters.el_gringo import ElGringo
-from .characters.jesse_jones import JesseJones
-from .characters.jourdonnais import Jourdonnais
-from .characters.kit_carlson import KitCarlson
-from .characters.lucky_duke import LuckyDuke
-from .characters.paul_regret import PaulRegret
-from .characters.pedro_ramirez import PedroRamirez
-from .characters.rose_doolan import RoseDoolan
-from .characters.sid_ketchum import SidKetchum
-from .characters.slab_the_killer import SlabTheKiller
-from .characters.suzy_lafayette import SuzyLafayette
-from .characters.vulture_sam import VultureSam
-from .characters.willy_the_kid import WillyTheKid
-from .helpers import RankSuitIconLoader
-from .network.server import BangServer
+from importlib import import_module
+from typing import Any
 
 __all__ = [
-    "GameManager",
-    "Player",
-    "PlayerMetadata",
-    "BaseRole",
-    "SheriffRoleCard",
-    "DeputyRoleCard",
-    "OutlawRoleCard",
-    "RenegadeRoleCard",
-    "BaseCharacter",
-    "BartCassidy",
-    "BlackJack",
-    "CalamityJanet",
-    "ElGringo",
-    "JesseJones",
-    "Jourdonnais",
-    "KitCarlson",
-    "LuckyDuke",
-    "PaulRegret",
-    "PedroRamirez",
-    "RoseDoolan",
-    "SidKetchum",
-    "SlabTheKiller",
-    "SuzyLafayette",
-    "VultureSam",
-    "WillyTheKid",
-    "create_standard_deck",
-    "RankSuitIconLoader",
-    "BangServer",
+    "ability_dispatch",
+    "card_handlers",
+    "cards",
+    "characters",
+    "deck",
+    "deck_factory",
+    "deck_manager",
+    "events",
+    "game_manager",
+    "general_store",
+    "helpers",
+    "network",
+    "player",
+    "turn_phases",
+    "ui",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    """Dynamically import ``bang_py`` submodules on first access.
+
+    Parameters
+    ----------
+    name:
+        Name of the submodule to import.
+
+    Returns
+    -------
+    ModuleType
+        The requested submodule.
+
+    Raises
+    ------
+    AttributeError
+        If the submodule does not exist.
+    """
+
+    try:
+        return import_module(f"bang_py.{name}")
+    except ModuleNotFoundError as exc:  # pragma: no cover - defensive
+        raise AttributeError(f"module 'bang_py' has no attribute {name!r}") from exc


### PR DESCRIPTION
## Summary
- simplify bang_py package init by switching to lazy submodule imports
- restrict the exported API to top-level packages

## Testing
- `pre-commit run --files bang_py/__init__.py`
- `BANG_AUTO_CLOSE=1 pytest`


------
https://chatgpt.com/codex/tasks/task_e_689451dacd7c83239556e2c9f368390a