### PR TITLE
Use postponed evaluation of annotations across packages

### DIFF
--- a/bang_py/__init__.py
+++ b/bang_py/__init__.py
@@ -1,5 +1,7 @@
 """Bang card game modules."""
 
+from __future__ import annotations
+
 from importlib import import_module
 from typing import Any
 

--- a/bang_py/cards/__init__.py
+++ b/bang_py/cards/__init__.py
@@ -1,5 +1,7 @@
 """Card module exports for Bang! base game and expansions."""
 
+from __future__ import annotations
+
 from .card import BaseCard
 from .bang import BangCard
 from .beer import BeerCard

--- a/bang_py/cards/events/__init__.py
+++ b/bang_py/cards/events/__init__.py
@@ -1,5 +1,7 @@
 """Event card exports for expansions like High Noon and Fistful of Cards."""
 
+from __future__ import annotations
+
 from .base import BaseEventCard
 from .abandoned_mine import AbandonedMineEventCard
 from .ambush import AmbushEventCard

--- a/bang_py/cards/roles/__init__.py
+++ b/bang_py/cards/roles/__init__.py
@@ -1,5 +1,7 @@
 """Role card exports defining player objectives."""
 
+from __future__ import annotations
+
 from .base import BaseRole
 from .sheriff import SheriffRoleCard
 from .deputy import DeputyRoleCard

--- a/bang_py/characters/__init__.py
+++ b/bang_py/characters/__init__.py
@@ -1,4 +1,7 @@
 """Character classes from the core, Dodge City, and Bullet expansions."""
+
+from __future__ import annotations
+
 from .base import BaseCharacter
 from .apache_kid import ApacheKid
 from .bart_cassidy import BartCassidy
@@ -70,5 +73,5 @@ __all__ = [
     "UncleWill",
     "VeraCuster",
     "VultureSam",
-    "WillyTheKid"
+    "WillyTheKid",
 ]

--- a/bang_py/events/__init__.py
+++ b/bang_py/events/__init__.py
@@ -5,3 +5,5 @@ effects during gameplay, and notifying game components of event-driven
 changes. It centralizes all event-related utilities used by the Bang game
 manager.
 """
+
+from __future__ import annotations

--- a/bang_py/network/__init__.py
+++ b/bang_py/network/__init__.py
@@ -1,0 +1,3 @@
+"""Networking utilities for the Bang game."""
+
+from __future__ import annotations

--- a/bang_py/ui/__init__.py
+++ b/bang_py/ui/__init__.py
@@ -6,6 +6,8 @@ interactive client.
 See AGENTS.md for UI coding guidelines.
 """
 
+from __future__ import annotations
+
 from .main import BangUI, main
 
 __all__ = ["BangUI", "main"]

--- a/bang_py/ui/components/__init__.py
+++ b/bang_py/ui/components/__init__.py
@@ -1,5 +1,7 @@
 """UI utilities for the Bang game."""
 
+from __future__ import annotations
+
 from .network_threads import ClientThread, ServerThread
 
 __all__ = [


### PR DESCRIPTION
## Summary
- Enable postponed evaluation of type annotations in package `__init__` modules to allow forward references without string quoting.
- Add missing module docstring for the network package.

## Testing
- `pre-commit run --files bang_py/__init__.py bang_py/cards/__init__.py bang_py/cards/events/__init__.py bang_py/cards/roles/__init__.py bang_py/characters/__init__.py bang_py/events/__init__.py bang_py/network/__init__.py bang_py/ui/__init__.py bang_py/ui/components/__init__.py`
- `python - <<'PY'
import importlib
modules = [
    "bang_py",
    "bang_py.cards",
    "bang_py.cards.events",
    "bang_py.cards.roles",
    "bang_py.characters",
    "bang_py.events",
    "bang_py.network",
    "bang_py.ui",
    "bang_py.ui.components",
]
for m in modules:
    importlib.import_module(m)
print("Imported", len(modules), "modules successfully.")
PY`
- `BANG_AUTO_CLOSE=1 pytest`

------
https://chatgpt.com/codex/tasks/task_e_68952978d11c83239aebdfc17f2076f7