### PR TITLE
Add deck top helper methods

### DIFF
--- a/bang_py/characters/kit_carlson.py
+++ b/bang_py/characters/kit_carlson.py
@@ -1,4 +1,5 @@
 """View top 3 cards; keep 2 and return 1 to the deck. Core set."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -32,7 +33,7 @@ class KitCarlson(BaseCharacter):
                 if c is None:
                     continue
                 if i == back_index:
-                    gm.deck.cards.appendleft(c)
+                    gm.deck.push_top(c)
                 else:
                     player.hand.append(c)
             return True

--- a/bang_py/deck.py
+++ b/bang_py/deck.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from random import shuffle
 from collections import deque
+from typing import Iterable
 
 from .cards.card import BaseCard
 
@@ -24,6 +25,17 @@ class Deck:
 
     def add(self, card: BaseCard) -> None:
         self.cards.append(card)
+
+    def push_top(self, card: BaseCard) -> None:
+        """Place a card on top of the deck."""
+        self.cards.appendleft(card)
+
+    def extend_top(self, cards: Iterable[BaseCard]) -> None:
+        """Place multiple cards on top of the deck.
+
+        The last card from ``cards`` will be drawn first.
+        """
+        self.cards.extendleft(cards)
 
     def __len__(self) -> int:
         return len(self.cards)

--- a/bang_py/turn_phases/discard_phase.py
+++ b/bang_py/turn_phases/discard_phase.py
@@ -18,11 +18,11 @@ class DiscardPhaseMixin:
     discard_pile: list[BaseCard]
     event_flags: dict
 
-    def discard_phase(self: 'GameManager', player: 'Player') -> None:
+    def discard_phase(self: "GameManager", player: "Player") -> None:
         limit = self._hand_limit(player)
         self._discard_to_limit(player, limit)
 
-    def _hand_limit(self, player: 'Player') -> int:
+    def _hand_limit(self, player: "Player") -> int:
         limit = player.health
         if player.metadata.hand_limit is not None:
             limit = max(limit, player.metadata.hand_limit)
@@ -32,10 +32,10 @@ class DiscardPhaseMixin:
             limit = min(limit, int(self.event_flags["reverend_limit"]))
         return limit
 
-    def _discard_to_limit(self, player: 'Player', limit: int) -> None:
+    def _discard_to_limit(self, player: "Player", limit: int) -> None:
         while len(player.hand) > limit:
             card = player.hand.pop()
             if self.event_flags.get("abandoned_mine"):
-                self.deck.cards.appendleft(card)
+                self.deck.push_top(card)
             else:
                 self._pass_left_or_discard(player, card)

--- a/tests/test_cards.py
+++ b/tests/test_cards.py
@@ -73,7 +73,7 @@ def test_barrel_dodges_bang_on_heart():
     target = Player("Target")
     BarrelCard().play(target)
     deck = create_standard_deck()
-    deck.cards.appendleft(BeerCard(suit="Hearts"))
+    deck.push_top(BeerCard(suit="Hearts"))
     BangCard().play(target, deck)
     assert target.health == target.max_health
     assert target.metadata.dodged is True
@@ -83,7 +83,7 @@ def test_barrel_fails_on_non_heart():
     target = Player("Target")
     BarrelCard().play(target)
     deck = create_standard_deck()
-    deck.cards.appendleft(BeerCard(suit="Clubs"))
+    deck.push_top(BeerCard(suit="Clubs"))
     BangCard().play(target, deck)
     assert target.health == target.max_health - 1
 
@@ -93,7 +93,7 @@ def test_jail_skip_turn():
     jail = JailCard()
     jail.play(player)
     deck = create_standard_deck()
-    deck.cards.appendleft(BangCard(suit="Clubs"))
+    deck.push_top(BangCard(suit="Clubs"))
     skipped = jail.check_turn(player, deck)
     assert skipped is True
     assert "Jail" not in player.equipment
@@ -104,7 +104,7 @@ def test_jail_freed_on_heart():
     jail = JailCard()
     jail.play(player)
     deck = create_standard_deck()
-    deck.cards.appendleft(BangCard(suit="Hearts"))
+    deck.push_top(BangCard(suit="Hearts"))
     skipped = jail.check_turn(player, deck)
     assert skipped is False
     assert "Jail" not in player.equipment
@@ -116,7 +116,7 @@ def test_dynamite_explodes():
     dyn = DynamiteCard()
     dyn.play(p1)
     deck = create_standard_deck()
-    deck.cards.appendleft(BangCard(suit="Spades", rank=5))
+    deck.push_top(BangCard(suit="Spades", rank=5))
     exploded = dyn.check_dynamite(p1, p2, deck)
     assert exploded is True
     assert p1.health == p1.max_health - 3
@@ -129,7 +129,7 @@ def test_dynamite_passes():
     dyn = DynamiteCard()
     dyn.play(p1)
     deck = create_standard_deck()
-    deck.cards.appendleft(BangCard(suit="Hearts", rank=1))
+    deck.push_top(BangCard(suit="Hearts", rank=1))
     exploded = dyn.check_dynamite(p1, p2, deck)
     assert exploded is False
     assert "Dynamite" not in p1.equipment

--- a/tests/test_characters.py
+++ b/tests/test_characters.py
@@ -77,7 +77,7 @@ def test_character_ability_registered():
 
 def test_bart_cassidy_draw_on_damage():
     deck = create_standard_deck()
-    deck.cards.appendleft(BangCard())
+    deck.push_top(BangCard())
     gm = GameManager(deck=deck)
     p1 = Player("Bart", character=BartCassidy())
     p2 = Player("Shooter")
@@ -90,7 +90,7 @@ def test_bart_cassidy_draw_on_damage():
 
 def test_black_jack_extra_draw():
     deck = create_standard_deck()
-    deck.cards.extendleft(
+    deck.extend_top(
         [
             BeerCard(suit="Clubs"),
             BeerCard(suit="Diamonds"),
@@ -144,7 +144,7 @@ def test_el_gringo_steals_on_damage():
 
 def test_jesse_jones_draws_from_opponent():
     deck = create_standard_deck()
-    deck.cards.appendleft(BangCard())
+    deck.push_top(BangCard())
     gm = GameManager(deck=deck)
     jj = Player("JJ", character=JesseJones())
     other = Player("Other")
@@ -158,7 +158,7 @@ def test_jesse_jones_draws_from_opponent():
 
 def test_jesse_jones_selects_card_index():
     deck = create_standard_deck()
-    deck.cards.appendleft(BangCard())
+    deck.push_top(BangCard())
     gm = GameManager(deck=deck)
     jj = Player("JJ", character=JesseJones())
     other = Player("Other")
@@ -173,7 +173,7 @@ def test_jesse_jones_selects_card_index():
 
 def test_jourdonnais_has_virtual_barrel():
     deck = create_standard_deck()
-    deck.cards.appendleft(BeerCard(suit="Hearts"))
+    deck.push_top(BeerCard(suit="Hearts"))
     target = Player("Jour", character=Jourdonnais())
     BangCard().play(target, deck)
     assert target.metadata.dodged is True
@@ -181,7 +181,7 @@ def test_jourdonnais_has_virtual_barrel():
 
 def test_kit_carlson_draw_three_keep_two():
     deck = create_standard_deck()
-    deck.cards.extendleft([BangCard(), BeerCard(), MissedCard()])
+    deck.extend_top([BangCard(), BeerCard(), MissedCard()])
     gm = GameManager(deck=deck)
     kit = Player("Kit", character=KitCarlson())
     gm.add_player(kit)
@@ -192,7 +192,7 @@ def test_kit_carlson_draw_three_keep_two():
 
 def test_lucky_duke_draw_two_on_jail():
     deck = create_standard_deck()
-    deck.cards.extendleft([BangCard(suit="Clubs"), BangCard(suit="Hearts")])
+    deck.extend_top([BangCard(suit="Clubs"), BangCard(suit="Hearts")])
     gm = GameManager(deck=deck)
     player = Player("Lucky", character=LuckyDuke())
     gm.add_player(player)
@@ -216,7 +216,7 @@ def test_barrel_draw_card_discarded():
 
 def test_pedro_ramirez_takes_from_discard():
     deck = create_standard_deck()
-    deck.cards.appendleft(BangCard())
+    deck.push_top(BangCard())
     gm = GameManager(deck=deck)
     gm.discard_pile.append(MissedCard())
     pedro = Player("Pedro", character=PedroRamirez())
@@ -227,7 +227,7 @@ def test_pedro_ramirez_takes_from_discard():
 
 def test_pedro_ramirez_draws_from_deck_when_chosen():
     deck = create_standard_deck()
-    deck.cards.extendleft([BangCard(), BeerCard()])
+    deck.extend_top([BangCard(), BeerCard()])
     gm = GameManager(deck=deck)
     gm.discard_pile.append(MissedCard())
     pedro = Player("Pedro", character=PedroRamirez())
@@ -266,7 +266,7 @@ def test_sid_ketchum_discard_two_to_heal():
 
 def test_suzy_lafayette_draws_when_empty():
     deck = create_standard_deck()
-    deck.cards.appendleft(BangCard())
+    deck.push_top(BangCard())
     gm = GameManager(deck=deck)
     suzy = Player("Suzy", character=SuzyLafayette())
     target = Player("Target")

--- a/tests/test_expansions.py
+++ b/tests/test_expansions.py
@@ -79,7 +79,7 @@ def test_high_noon_draws_card_for_all():
     p2 = Player("B")
     gm.add_player(p1)
     gm.add_player(p2)
-    gm.deck.cards.extendleft([PunchCard(), PunchCard()])
+    gm.deck.extend_top([PunchCard(), PunchCard()])
     card = HighNoonCard()
     p1.hand.append(card)
     gm.play_card(p1, card, p1)

--- a/tests/test_gamemanager.py
+++ b/tests/test_gamemanager.py
@@ -6,7 +6,7 @@ from bang_py.cards.bang import BangCard
 
 def test_drawing_and_playing() -> None:
     deck = create_standard_deck()
-    deck.cards.extendleft([BangCard(), BangCard()])
+    deck.extend_top([BangCard(), BangCard()])
     gm = GameManager(deck=deck)
     p1 = Player("A")
     p2 = Player("B")

--- a/tests/test_start_turn_effects.py
+++ b/tests/test_start_turn_effects.py
@@ -8,7 +8,7 @@ from bang_py.player import Player
 
 def test_jail_auto_skip_turn():
     deck = Deck([])
-    deck.cards.extendleft([BangCard(), BangCard(), BangCard(suit="Clubs")])
+    deck.extend_top([BangCard(), BangCard(), BangCard(suit="Clubs")])
     gm = GameManager(deck=deck)
     p1 = Player("Jailbird")
     p2 = Player("Other")
@@ -26,7 +26,7 @@ def test_jail_auto_skip_turn():
 
 def test_dynamite_explodes_on_turn_start():
     deck = Deck([])
-    deck.cards.extendleft([BangCard(), BangCard(), BangCard(suit="Spades", rank=5)])
+    deck.extend_top([BangCard(), BangCard(), BangCard(suit="Spades", rank=5)])
     gm = GameManager(deck=deck)
     p1 = Player("One")
     p2 = Player("Two")
@@ -43,7 +43,7 @@ def test_dynamite_explodes_on_turn_start():
 
 def test_dynamite_passes_to_next_player():
     deck = Deck([])
-    deck.cards.extendleft([BangCard(), BangCard(), BangCard(suit="Hearts", rank=1)])
+    deck.extend_top([BangCard(), BangCard(), BangCard(suit="Hearts", rank=1)])
     gm = GameManager(deck=deck)
     p1 = Player("One")
     p2 = Player("Two")


### PR DESCRIPTION
## Summary
- add push_top and extend_top helpers to Deck
- replace direct deque operations in discard phase, Kit Carlson ability, and tests

## Testing
- `pre-commit run --files bang_py/deck.py bang_py/turn_phases/discard_phase.py bang_py/characters/kit_carlson.py tests/test_cards.py tests/test_characters.py tests/test_start_turn_effects.py tests/test_gamemanager.py tests/test_expansions.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68952cdfa1788323bee61767e92ef475