### PR TITLE
Use shared name validation in UI

### DIFF
--- a/bang_py/network/server.py
+++ b/bang_py/network/server.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 # Maximum allowed size for incoming websocket messages
 MAX_MESSAGE_SIZE = 4096
 
-__all__ = ["BangServer", "generate_join_token", "parse_join_token"]
+__all__ = ["BangServer", "generate_join_token", "parse_join_token", "validate_player_name"]
 
 
 # Use slots to reduce memory footprint and prevent dynamic attribute assignment.

--- a/bang_py/ui/main.py
+++ b/bang_py/ui/main.py
@@ -13,6 +13,7 @@ from .components import ClientThread, ServerThread
 from .components.card_images import get_loader
 from .theme import get_current_theme
 from ..network.token_utils import parse_join_token
+from ..network.server import validate_player_name
 from cryptography.fernet import InvalidToken
 
 CHARACTER_ASSETS = resources.files("bang_py") / "assets" / "characters"
@@ -60,7 +61,7 @@ class BangUI(QtCore.QObject):
         key: str,
     ) -> None:
         name = name.strip()
-        if not self._validate_name(name):
+        if not validate_player_name(name):
             QtWidgets.QMessageBox.critical(None, "Error", "Please enter a valid name")
             return
         try:
@@ -83,7 +84,7 @@ class BangUI(QtCore.QObject):
         cafile: str,
     ) -> None:
         name = name.strip()
-        if not self._validate_name(name):
+        if not validate_player_name(name):
             QtWidgets.QMessageBox.critical(None, "Error", "Please enter a valid name")
             return
         cafile_opt = cafile.strip() or None
@@ -269,9 +270,6 @@ class BangUI(QtCore.QObject):
             if self.game_root is not None:
                 cur = self.game_root.property("logText") or ""
                 self.game_root.setProperty("logText", cur + f"Prompt: {prompt}\n")
-
-    def _validate_name(self, name: str) -> bool:
-        return bool(name and len(name) <= 20 and name.isprintable())
 
     def show(self) -> None:
         self.view.setTitle("Bang!")

--- a/tests/test_name_validation.py
+++ b/tests/test_name_validation.py
@@ -2,8 +2,13 @@ import pytest
 
 pytest.importorskip("cryptography")
 pytest.importorskip("websockets")
+pytest.importorskip("PySide6")
+pytest.importorskip("PySide6.QtWidgets")
 
-from bang_py.network.server import validate_player_name
+from PySide6 import QtWidgets  # noqa: E402
+
+from bang_py.network.server import validate_player_name  # noqa: E402
+from bang_py import ui as ui_module  # noqa: E402
 
 
 def test_name_too_long_rejected() -> None:
@@ -13,3 +18,24 @@ def test_name_too_long_rejected() -> None:
 def test_name_with_unprintable_rejected() -> None:
     assert not validate_player_name("bad\x00name")
 
+
+def test_ui_invalid_name_shows_error(qt_app, monkeypatch) -> None:
+    errors: dict[str, str] = {}
+
+    def fake_critical(parent, title, text):
+        errors["text"] = text
+
+    monkeypatch.setattr(QtWidgets.QMessageBox, "critical", fake_critical)
+
+    called: dict[str, bool] = {}
+
+    def fake_start_host(self, port, max_players, certfile, keyfile):
+        called["called"] = True
+
+    monkeypatch.setattr(ui_module.BangUI, "_start_host", fake_start_host)
+
+    ui = ui_module.BangUI()
+    ui._host_menu("bad\x00name", "8765", "7", "", "")
+    assert errors["text"] == "Please enter a valid name"
+    assert "called" not in called
+    ui.close()


### PR DESCRIPTION
## Summary
- expose `validate_player_name` from the server module
- use shared `validate_player_name` in the Qt UI instead of a private helper
- test that the UI rejects invalid player names

## Testing
- `pre-commit run --files bang_py/network/server.py bang_py/ui/main.py tests/test_name_validation.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68953cf0adc08323a4949a70bd8b308b