### PR TITLE
docs: add scripts agent guidelines

### DIFF
--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -1,0 +1,6 @@
+# Scripts Guidelines
+
+- Use Python 3.13+.
+- Provide descriptive module and function docstrings.
+- Limit lines to 100 characters.
+- After modifying these scripts, run `pre-commit run --files <files>`.


### PR DESCRIPTION
## Summary
- document Python version, docstring expectations, and line limits for scripts

## Testing
- `pre-commit run --files scripts/AGENTS.md`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68955b3182dc83238e58a40a82de5469