### PR TITLE
docs(events): add guidelines for event modules

### DIFF
--- a/bang_py/events/AGENTS.md
+++ b/bang_py/events/AGENTS.md
@@ -1,0 +1,5 @@
+# Agent Guidelines for events
+
+- All modules in this directory must include a module-level docstring.
+- Use built-in collection generics such as `list[int]` and `dict[str, str]` rather than `typing.List` or `typing.Dict`.
+- Apply the `@override` decorator from `typing` when overriding methods.


### PR DESCRIPTION
## Summary
- document event module style: module docstrings, built-in generics, and `@override`

## Testing
- `pre-commit run --files bang_py/events/AGENTS.md`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68955b32a4c08323aefc0a797a7c7685