### PR TITLE
docs: add character guidelines

### DIFF
--- a/bang_py/characters/AGENTS.md
+++ b/bang_py/characters/AGENTS.md
@@ -1,0 +1,19 @@
+# Character Guidelines
+
+These rules apply to files under `bang_py/characters/`.
+
+## Docstrings
+- Each character module must start with a brief docstring describing the character's ability.
+- The docstring must reference the expansion where the character appears. Note "Core Set" for
+  base game characters.
+
+## Type hints
+- Include `from __future__ import annotations` at the top of each module.
+- Provide type hints for all function arguments and return types.
+
+## Expansion references
+- If a character belongs to an expansion, mention it in the module docstring, e.g., "Dodge City
+  expansion".
+- When multiple expansions apply, list each one.
+
+Always consult this file before adding or modifying character classes.

--- a/bang_py/characters/__init__.py
+++ b/bang_py/characters/__init__.py
@@ -1,4 +1,7 @@
-"""Character classes from the core, Dodge City, and Bullet expansions."""
+"""Character classes from the core, Dodge City, and Bullet expansions.
+
+See AGENTS.md for character guidelines.
+"""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary
- document character conventions and expansion references
- reference AGENTS instructions in characters package init

## Testing
- `python -m pre_commit run --files bang_py/characters/AGENTS.md bang_py/characters/__init__.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'bang_py')*

------
https://chatgpt.com/codex/tasks/task_e_6895617262f08323bf98dc0d8ad1c982