### PR TITLE
test: verify root asset usage

### DIFF
--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -18,3 +18,7 @@
 - `test_icon_usage` ensures every file in `bang_py/assets/icons/` is referenced
   by the codebase. Any intentionally unused icons must be added to
   `KNOWN_UNUSED` within `tests/test_icon_usage.py`.
+- `test_root_asset_usage` checks that PNG files in `bang_py/assets/`, excluding
+  `audio/`, `icons/`, and `characters/`, are referenced by the codebase. Any
+  intentionally unused files must be added to `KNOWN_UNUSED` within
+  `tests/test_root_asset_usage.py`.

--- a/tests/test_root_asset_usage.py
+++ b/tests/test_root_asset_usage.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+"""Tests for ensuring root-level PNG assets are referenced in the codebase."""
+
+from pathlib import Path
+
+
+# Root-level PNG assets that are intentionally present but unused.
+# Document such files here to prevent false positives.
+KNOWN_UNUSED: set[str] = {"bullet.png", "table.png"}
+
+
+def load_text_files(root: Path, assets_dir: Path) -> list[tuple[Path, str]]:
+    """Return (path, content) pairs for text files outside the assets directory."""
+
+    files: list[tuple[Path, str]] = []
+    for path in root.rglob("*"):
+        if not path.is_file():
+            continue
+        if path.is_relative_to(assets_dir):
+            continue
+        try:
+            files.append((path, path.read_text(encoding="utf-8")))
+        except UnicodeDecodeError:
+            continue
+    return files
+
+
+def test_all_root_png_assets_are_used() -> None:
+    """Ensure that PNG files outside excluded folders are referenced."""
+
+    repo_root = Path(__file__).resolve().parents[1]
+    assets_dir = repo_root / "bang_py" / "assets"
+    text_files = load_text_files(repo_root, assets_dir)
+
+    excluded = {assets_dir / name for name in ("audio", "icons", "characters")}
+    unused: list[str] = []
+
+    for path in assets_dir.rglob("*.png"):
+        if any(path.is_relative_to(folder) for folder in excluded):
+            continue
+        if path.name in KNOWN_UNUSED:
+            continue
+        if not any(path.name in content for _, content in text_files):
+            unused.append(path.name)
+
+    assert (
+        not unused
+    ), "Unused root PNG assets: {unused}. Remove them or add to KNOWN_UNUSED.".format(unused=unused)


### PR DESCRIPTION
## Summary
- add test ensuring root-level asset PNGs are referenced or explicitly allowed
- document the new asset verification in testing guidelines

## Testing
- `python -m pre_commit run --files tests/test_root_asset_usage.py tests/AGENTS.md`
- `pytest tests/test_root_asset_usage.py`


------
https://chatgpt.com/codex/tasks/task_e_689566f537a483239e46059994341ebc