### PR TITLE
Default lint target to all tracked Python files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ build-exe:
 >pyinstaller scripts/bang.spec
 
 lint:
->@pre-commit run --files $(FILES)
+>@pre-commit run --files $(if $(FILES),$(FILES),$(shell git ls-files '*.py'))
 
 test:
 >@pytest


### PR DESCRIPTION
## Summary
- Run pre-commit on all tracked Python files when `FILES` isn't provided

## Testing
- `pre-commit run --files Makefile`
- `make lint` *(fails: black reformats files and flake8 reports unused imports)*
- `PYTHONPATH=. make test`


------
https://chatgpt.com/codex/tasks/task_e_689566c6364c8323ae8e380c23c5e97d