### PR TITLE
Add mypy pre-commit hook and document usage

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,3 +8,8 @@ repos:
     rev: 7.1.1
     hooks:
       - id: flake8
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.11.2
+    hooks:
+      - id: mypy
+        args: ["--ignore-missing-imports"]

--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ Run the checks on changed files before committing:
 pre-commit run --files <path> [<path> ...]
 ```
 
+Run the type checker directly with:
+
+```bash
+mypy bang_py tests
+```
+
 Alternatively, use the Makefile targets:
 
 ```bash


### PR DESCRIPTION
## Summary
- run mypy in pre-commit hooks
- document running pre-commit and mypy

## Testing
- `pre-commit run --files .pre-commit-config.yaml README.md`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68956701d3b48323bafb8d38e070a36a