### PR TITLE
docs: add AGENTS guidelines for card handlers and turn phases

### DIFF
--- a/bang_py/card_handlers/AGENTS.md
+++ b/bang_py/card_handlers/AGENTS.md
@@ -1,0 +1,7 @@
+# Card Handler Guidelines
+
+These rules apply to modules under `bang_py/card_handlers/`.
+
+- Include a brief module-level docstring at the top of each file.
+- Prefer built-in generics such as `list` and `dict` over `typing.List` and `typing.Dict`.
+- Use `@override` from `typing` when overriding methods from parent classes.

--- a/bang_py/turn_phases/AGENTS.md
+++ b/bang_py/turn_phases/AGENTS.md
@@ -1,0 +1,7 @@
+# Turn Phase Guidelines
+
+These rules apply to modules under `bang_py/turn_phases/`.
+
+- Include a brief module-level docstring at the top of each file.
+- Prefer built-in generics such as `list` and `dict` over `typing.List` and `typing.Dict`.
+- Use `@override` from `typing` when overriding methods from parent classes.


### PR DESCRIPTION
## Summary
- add agent guidelines for card handlers to require module docstrings, built-in generics, and `@override`
- establish similar rules for turn phase modules

## Testing
- `pre-commit run --files bang_py/card_handlers/AGENTS.md bang_py/turn_phases/AGENTS.md`
- `pytest` *(fails: 19 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68956d1350208323854c13d28c30dc25