### PR TITLE
Add future annotations imports to networking and turn phases modules

### DIFF
--- a/bang_py/network/client.py
+++ b/bang_py/network/client.py
@@ -4,6 +4,8 @@ When a join token is provided, ``parse_join_token`` extracts the host, port, and
 room.
 """
 
+from __future__ import annotations
+
 import asyncio
 import json
 import logging

--- a/bang_py/network/server.py
+++ b/bang_py/network/server.py
@@ -1,5 +1,7 @@
 """Websocket server implementation for hosting a Bang game."""
 
+from __future__ import annotations
+
 import asyncio
 import json
 import secrets

--- a/bang_py/turn_phases/__init__.py
+++ b/bang_py/turn_phases/__init__.py
@@ -1,5 +1,7 @@
 """Turn phase mixins grouped into a package."""
 
+from __future__ import annotations
+
 from .draw_phase import DrawPhaseMixin
 from .discard_phase import DiscardPhaseMixin
 from .turn_flow import TurnFlowMixin


### PR DESCRIPTION
## Summary
- enable postponed evaluation of annotations in networking client and server modules
- enable postponed annotations in turn phases package

## Testing
- `pre-commit run --files bang_py/network/client.py bang_py/network/server.py bang_py/turn_phases/__init__.py` *(fails: Found 172 errors in 63 files (checked 3 source files))*
- `pytest` *(fails: ModuleNotFoundError: No module named 'bang_py')*

------
https://chatgpt.com/codex/tasks/task_e_68956d1448d88323bb21dd4c17a384bc