### PR TITLE
ci: test against multiple Python versions

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.13-dev"]
+        python-version: ["3.12", "3.13-dev"]
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
## Summary
- run GitHub Actions tests for Python 3.12 and 3.13-dev
- ensure each job installs deps, runs pre-commit hooks, and executes pytest

## Testing
- `pre-commit run --files .github/workflows/python-tests.yml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689573e04d80832395858f2dabec19c9