### PR TITLE
Mark full game simulation test as slow

### DIFF
--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,6 +1,8 @@
 # Test Guidelines
 - Set the event deck explicitly or call `random.seed()` in tests to avoid flaky behavior.
-- The following tests are marked `@pytest.mark.slow` and skipped by default:
+- Mark slow tests with the `slow` pytest marker. Use `pytestmark = pytest.mark.slow`
+  at the top of modules where every test is slow.
+- The following tests are marked with the `slow` marker and skipped by default:
   - `test_bang_executable` verifies the PyInstaller build. Run it with
     `pytest -m slow tests/test_bang_executable.py` when PyInstaller is available.
   - `test_full_game_simulation` plays automated games for multiple player counts.

--- a/tests/test_full_game_simulation.py
+++ b/tests/test_full_game_simulation.py
@@ -1,5 +1,4 @@
 import random
-from typing import List
 
 import pytest
 
@@ -40,6 +39,8 @@ from bang_py.characters.vulture_sam import VultureSam
 from bang_py.characters.willy_the_kid import WillyTheKid
 from bang_py.game_manager import GameManager
 from bang_py.player import Player
+
+pytestmark = pytest.mark.slow
 
 CHAR_CLASSES = [
     BartCassidy,
@@ -178,7 +179,7 @@ def simulate_game(num_players: int) -> str:
     for i in range(num_players):
         player = Player(f"P{i}", role=roles[i](), character=chars[i]())
         gm.add_player(player)
-    result: List[str] = []
+    result: list[str] = []
 
     def _record_result(res: str) -> None:
         result.append(res)
@@ -193,7 +194,6 @@ def simulate_game(num_players: int) -> str:
     return result[0]
 
 
-@pytest.mark.slow
 @pytest.mark.parametrize("num_players", range(4, 8))
 def test_full_game_simulation(num_players: int) -> None:
     outcome = simulate_game(num_players)


### PR DESCRIPTION
## Summary
- mark the full game simulation test module as slow
- switch typing.List usage to built-in list generics
- clarify slow test usage in test guidelines

## Testing
- `pre-commit run --files tests/AGENTS.md tests/test_full_game_simulation.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68957e41ebbc8323920ae375a4cb210e