### PR TITLE
chore: remove redundant network alias test

### DIFF
--- a/tests/test_network_serialization.py
+++ b/tests/test_network_serialization.py
@@ -34,6 +34,7 @@ def test_serialize_players_json_roundtrip():
             "equipment": [],
         },
     ]
+    assert network_client.connect is async_connect
 
 
 def test_serialize_players_with_health_changes():
@@ -63,7 +64,3 @@ def test_serialize_players_without_role():
             "equipment": [],
         }
     ]
-
-
-def test_client_uses_asyncio_connect() -> None:
-    assert network_client.connect is async_connect


### PR DESCRIPTION
## Summary
- remove duplicate test for client connection alias
- fold connection alias check into existing serialization round-trip test

## Testing
- `pre-commit run --files tests/test_network_serialization.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689584cdd96c8323ac262a534bd84960