### PR TITLE
Expand mypy checks to entire codebase

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,4 +14,3 @@ repos:
       - id: mypy
         args: ["--ignore-missing-imports", "--follow-imports=skip"]
         pass_filenames: true
-        files: "^tests/"


### PR DESCRIPTION
## Summary
- remove tests-only restriction from mypy pre-commit hook to cover all Python files

## Testing
- `pre-commit run --files .pre-commit-config.yaml`
- `pre-commit run --files $(git ls-files '*.py')` *(fails: BangHandlersMixin type mismatch, DrawPayload arg-type, etc.)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895953b28908323a44f980ea34df044