### PR TITLE
Skip join token tests without cryptography

### DIFF
--- a/tests/test_join_token.py
+++ b/tests/test_join_token.py
@@ -1,12 +1,13 @@
 import pytest
-from bang_py.network.token_utils import (
+
+pytest.importorskip("cryptography")
+from cryptography.fernet import InvalidToken  # noqa: E402
+
+from bang_py.network.token_utils import (  # noqa: E402
     generate_join_token,
     parse_join_token,
     DEFAULT_TOKEN_KEY,
 )
-from cryptography.fernet import InvalidToken
-
-pytest.importorskip("cryptography")
 
 
 def test_generate_and_parse_token() -> None:


### PR DESCRIPTION
## Summary
- ensure join token tests import `cryptography` only when available

## Testing
- `pre-commit run --files tests/test_join_token.py`
- `pytest tests/test_join_token.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68959af806e48323bd8205797d4fef0a