### PR TITLE
Remove typing_extensions override imports

### DIFF
--- a/bang_py/cards/iron_plate.py
+++ b/bang_py/cards/iron_plate.py
@@ -2,10 +2,7 @@
 
 from __future__ import annotations
 
-try:
-    from typing import override
-except ImportError:  # pragma: no cover - fallback for Python <3.12
-    from typing_extensions import override
+from typing import override
 
 from .missed import MissedCard
 from ..player import Player

--- a/bang_py/cards/missed.py
+++ b/bang_py/cards/missed.py
@@ -2,10 +2,7 @@
 
 from __future__ import annotations
 
-try:
-    from typing import override
-except ImportError:  # pragma: no cover - fallback for Python <3.12
-    from typing_extensions import override
+from typing import override
 
 from .card import BaseCard
 from ..player import Player

--- a/bang_py/cards/sombrero.py
+++ b/bang_py/cards/sombrero.py
@@ -2,10 +2,7 @@
 
 from __future__ import annotations
 
-try:
-    from typing import override
-except ImportError:  # pragma: no cover - fallback for Python <3.12
-    from typing_extensions import override
+from typing import override
 
 from .missed import MissedCard
 from ..player import Player

--- a/bang_py/cards/ten_gallon_hat.py
+++ b/bang_py/cards/ten_gallon_hat.py
@@ -2,10 +2,7 @@
 
 from __future__ import annotations
 
-try:
-    from typing import override
-except ImportError:  # pragma: no cover - fallback for Python <3.12
-    from typing_extensions import override
+from typing import override
 
 from .missed import MissedCard
 from ..player import Player

--- a/bang_py/ui/components/network_threads.py
+++ b/bang_py/ui/components/network_threads.py
@@ -6,11 +6,7 @@ import asyncio
 import json
 import logging
 import ssl
-
-try:
-    from typing import override
-except ImportError:  # pragma: no cover - fallback for Python <3.12
-    from typing_extensions import override
+from typing import override
 
 from PySide6 import QtCore
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ dependencies = [
     "websockets>=15.0.1",
     "PySide6>=6.9.1",
     "cryptography>=42.0.5",
-    "typing_extensions>=4.9.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- import `override` directly from `typing`
- drop `typing_extensions` dependency

## Testing
- `pre-commit run --files bang_py/cards/missed.py bang_py/cards/ten_gallon_hat.py bang_py/cards/iron_plate.py bang_py/cards/sombrero.py bang_py/ui/components/network_threads.py pyproject.toml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895c1fdad808323a46866f7c4f6939f