### PR TITLE
test: drop websockets skip in network serialization

### DIFF
--- a/tests/test_network_serialization.py
+++ b/tests/test_network_serialization.py
@@ -2,11 +2,8 @@ import json
 
 import pytest
 
-pytest.importorskip("websockets")
-from websockets.asyncio.client import connect as async_connect  # noqa: F401,E402
-
-from bang_py.player import Player  # noqa: E402
 from bang_py.cards.roles import SheriffRoleCard, OutlawRoleCard  # noqa: E402
+from bang_py.player import Player  # noqa: E402
 from bang_py.network.server import _serialize_players  # noqa: E402
 
 pytest.importorskip("cryptography")


### PR DESCRIPTION
## Summary
- remove obsolete websockets skip and async connect import from network serialization tests
- reorder imports to avoid circular import for Player

## Testing
- `python -m pre_commit run --files tests/test_network_serialization.py`
- `pytest tests/test_network_serialization.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6895c60d80f88323b3e2558d59a3b4d5