### PR TITLE
Remove redundant module registry test

### DIFF
--- a/tests/test_handler_registry.py
+++ b/tests/test_handler_registry.py
@@ -1,12 +1,9 @@
-import sys
-
 from bang_py.game_manager import GameManager
 from bang_py.deck import Deck
 from bang_py.player import Player
 from bang_py.cards import BangCard
 from bang_py.cards.pony_express import PonyExpressCard
 from bang_py.card_handlers import (
-    MODULE_REGISTRY,
     CardHandlersMixin,
     register_handler_groups,
 )
@@ -29,12 +26,6 @@ def test_register_specific_handler_groups():
     register_handler_groups(gm, ["basic", "green"])
     gm.play_card(p1, p1.hand[0])
     assert len(p1.hand) == 3
-
-
-def test_module_registry_loaded() -> None:
-    """Ensure modules declared in the registry are imported."""
-    for path in MODULE_REGISTRY.values():
-        assert path in sys.modules
 
 
 def test_card_handlers_mixin_includes_methods() -> None:


### PR DESCRIPTION
## Summary
- remove `test_module_registry_loaded` from handler registry tests
- drop unused imports after test removal

## Testing
- `pre-commit run --files tests/test_handler_registry.py`
- `pytest tests/test_handler_registry.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6895c613b5988323a863b85935d93dc6