### PR TITLE
Refine thread run methods and error handling

### DIFF
--- a/bang_py/cards/missed.py
+++ b/bang_py/cards/missed.py
@@ -14,7 +14,7 @@ class MissedCard(BaseCard):
     card_set = "base"
     description = "Negates one Bang! targeting you."
 
-    @override
+    @override  # type: ignore[misc]
     def play(self, target: Player | None, **kwargs) -> None:
         if not target:
             return

--- a/bang_py/cards/missed.py
+++ b/bang_py/cards/missed.py
@@ -14,7 +14,7 @@ class MissedCard(BaseCard):
     card_set = "base"
     description = "Negates one Bang! targeting you."
 
-    @override  # type: ignore[misc]
+    @override
     def play(self, target: Player | None, **kwargs) -> None:
         if not target:
             return


### PR DESCRIPTION
## Summary
- remove `type: ignore` markers from QThread `run` overrides and provide a type-checking stub so signatures match `QtCore.QThread.run`
- tighten client thread shutdown to log and re-raise unexpected websocket closure errors
- drop `type: ignore` from `MissedCard.play`

## Testing
- `pre-commit run --files bang_py/ui/components/network_threads.py bang_py/cards/missed.py bang_py/cards/card.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895cdc9d4088323ab911f27e98b02f1