### PR TITLE
Use qt_app fixture in load sound tests

### DIFF
--- a/tests/test_load_sound.py
+++ b/tests/test_load_sound.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 
 import pytest
@@ -12,50 +11,31 @@ pytest.importorskip(
     exc_type=ImportError,
 )
 
-from PySide6 import QtWidgets  # noqa: E402
 from bang_py.ui.components.card_images import clear_sound_cache, load_sound  # noqa: E402
 
-
-def _prepare_app():
-    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
-    audio_path = (
-        Path(__file__).resolve().parents[1] / "bang_py" / "assets" / "audio" / "ui_click.mp3"
-    )
-    if not audio_path.exists():
-        pytest.skip("ui_click.mp3 not generated")
-    app = QtWidgets.QApplication.instance()
-    created = app is None
-    if created:
-        app = QtWidgets.QApplication([])
-    return app, created
+AUDIO_PATH = Path(__file__).resolve().parents[1] / "bang_py" / "assets" / "audio" / "ui_click.mp3"
+if not AUDIO_PATH.exists():  # pragma: no cover - asset generation handled elsewhere
+    pytest.skip("ui_click.mp3 not generated", allow_module_level=True)
 
 
-def test_load_sound_mp3():
-    app, created = _prepare_app()
+def test_load_sound_mp3(qt_app):
     clear_sound_cache()
     sound = load_sound("ui_click")
-    if created:
-        app.quit()
     if sound is None:
         pytest.skip("QtMultimedia not available")
     assert hasattr(sound, "play")
     clear_sound_cache()
 
 
-def test_load_sound_cache():
-    app, created = _prepare_app()
+def test_load_sound_cache(qt_app):
     clear_sound_cache()
     sound1 = load_sound("ui_click")
     sound2 = load_sound("ui_click")
     if sound1 is None:
-        if created:
-            app.quit()
         pytest.skip("QtMultimedia not available")
     assert sound1 is sound2
     clear_sound_cache()
     sound3 = load_sound("ui_click")
-    if created:
-        app.quit()
     if sound3 is None:
         pytest.skip("QtMultimedia not available")
     assert sound1 is not sound3


### PR DESCRIPTION
## Summary
- remove custom `_prepare_app` helper in sound loading tests
- rely on `qt_app` fixture and module-level asset check

## Testing
- `pre-commit run --files tests/test_load_sound.py`
- `pytest tests/test_load_sound.py`

------
https://chatgpt.com/codex/tasks/task_e_6895df1443688323aa344ccbe061a757