### PR TITLE
chore: refine mypy config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,5 +12,4 @@ repos:
     rev: v1.11.2
     hooks:
       - id: mypy
-        args: ["--ignore-missing-imports", "--follow-imports=skip"]
         pass_filenames: true

--- a/bang_py/card_handlers/__init__.py
+++ b/bang_py/card_handlers/__init__.py
@@ -3,23 +3,25 @@
 from __future__ import annotations
 
 from importlib import import_module
+from typing import TYPE_CHECKING
 
 MODULE_REGISTRY = {
     "dispatch": "bang_py.card_handlers.dispatch",
     "bang": "bang_py.card_handlers.bang_handlers",
 }
 
-_modules = {name: import_module(path) for name, path in MODULE_REGISTRY.items()}
+if TYPE_CHECKING:
+    from .dispatch import DispatchMixin, register_handler_groups  # pragma: no cover
+    from .bang_handlers import BangHandlersMixin  # pragma: no cover
+else:  # pragma: no cover - dynamic import for runtime flexibility
+    _modules = {name: import_module(path) for name, path in MODULE_REGISTRY.items()}
+    register_handler_groups = _modules["dispatch"].register_handler_groups
+    DispatchMixin = _modules["dispatch"].DispatchMixin
+    BangHandlersMixin = _modules["bang"].BangHandlersMixin
 
-register_handler_groups = _modules["dispatch"].register_handler_groups
 
-
-class CardHandlersMixin(
-    _modules["dispatch"].DispatchMixin,
-    _modules["bang"].BangHandlersMixin,
-):
+class CardHandlersMixin(DispatchMixin, BangHandlersMixin):
     """Mixin implementing card play dispatch for ``GameManager``."""
 
 
 __all__ = ["CardHandlersMixin", "register_handler_groups", "MODULE_REGISTRY"]
-

--- a/bang_py/ui/components/card_images.py
+++ b/bang_py/ui/components/card_images.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 from importlib import resources
 
 from contextlib import suppress
-from typing import TYPE_CHECKING
+from pathlib import Path
+from typing import TYPE_CHECKING, cast
 
 from PySide6 import QtCore, QtGui, QtWidgets
 
@@ -20,7 +21,7 @@ if TYPE_CHECKING:
 from .ranksuit_loader import RankSuitIconLoader
 
 DEFAULT_SIZE = (60, 90)
-ASSETS_DIR = resources.files("bang_py") / "assets"
+ASSETS_DIR = cast(Path, resources.files("bang_py").joinpath("assets"))
 CHARACTER_DIR = ASSETS_DIR / "characters"
 AUDIO_DIR = ASSETS_DIR / "audio"
 ICON_DIR = ASSETS_DIR / "icons"


### PR DESCRIPTION
## Summary
- run mypy with default import handling by removing ignore flags
- clarify handler mixin imports for typing
- cast resource paths to concrete `Path` objects for card image loader

## Testing
- `pre-commit run --files .pre-commit-config.yaml`
- `pre-commit run --files .pre-commit-config.yaml bang_py/card_handlers/__init__.py bang_py/ui/components/card_images.py` *(fails: many mypy errors across repository)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'websockets')*


------
https://chatgpt.com/codex/tasks/task_e_6895df176fd88323bcab10a3fd53d6d5