### PR TITLE
Guard turn access and deck draws

### DIFF
--- a/bang_py/deck_manager.py
+++ b/bang_py/deck_manager.py
@@ -27,13 +27,13 @@ class DeckManagerMixin:
 
     deck: Deck | None
     expansions: list[str]
-    _players: list['Player']
+    _players: list["Player"]
     discard_pile: list[BaseCard]
     event_flags: dict
     current_turn: int
     turn_order: list[int]
 
-    def _initialize_main_deck(self: 'GameManager') -> None:
+    def _initialize_main_deck(self: "GameManager") -> None:
         """Create the main deck if needed and ensure event flags exist."""
         if self.deck is None:
             if not self.expansions:
@@ -41,14 +41,14 @@ class DeckManagerMixin:
             self.deck = create_standard_deck(self.expansions)
         self.event_flags = {}
 
-    def add_player(self: 'GameManager', player: 'Player') -> None:
+    def add_player(self: "GameManager", player: "Player") -> None:
         """Add a player to the game and record the game reference."""
         player.metadata.game = self
         self._players.append(player)
         if player.character is not None:
             player.character.ability(self, player)
 
-    def remove_player(self: 'GameManager', player: 'Player') -> None:
+    def remove_player(self: "GameManager", player: "Player") -> None:
         """Remove ``player`` from the game and update turn order."""
         if player not in self._players:
             return
@@ -62,7 +62,7 @@ class DeckManagerMixin:
             return
         self._reset_current_turn(current_obj)
 
-    def start_game(self: 'GameManager', deal_roles: bool = True) -> None:
+    def start_game(self: "GameManager", deal_roles: bool = True) -> None:
         """Begin the game and deal starting hands."""
         if deal_roles:
             self._deal_roles_and_characters()
@@ -75,7 +75,7 @@ class DeckManagerMixin:
 
     # ------------------------------------------------------------------
     # Setup helpers
-    def _build_role_deck(self: 'GameManager') -> list[BaseRole]:
+    def _build_role_deck(self: "GameManager") -> list[BaseRole]:
         role_map = {
             3: [DeputyRoleCard, OutlawRoleCard, RenegadeRoleCard],
             4: [SheriffRoleCard, RenegadeRoleCard, OutlawRoleCard, OutlawRoleCard],
@@ -119,22 +119,16 @@ class DeckManagerMixin:
             raise ValueError("Unsupported player count")
         return [cls() for cls in classes]
 
-    def _build_character_deck(self: 'GameManager') -> list[type[BaseCharacter]]:
+    def _build_character_deck(self: "GameManager") -> list[type[BaseCharacter]]:
         from . import characters
 
-        return [
-            getattr(characters, name)
-            for name in characters.__all__
-            if name != "BaseCharacter"
-        ]
+        return [getattr(characters, name) for name in characters.__all__ if name != "BaseCharacter"]
 
-    def choose_character(
-        self, player: 'Player', options: list[BaseCharacter]
-    ) -> BaseCharacter:
+    def choose_character(self, player: "Player", options: list[BaseCharacter]) -> BaseCharacter:
         """Select which character a player will use. Defaults to the first."""
         return options[0]
 
-    def _deal_roles_and_characters(self: 'GameManager') -> None:
+    def _deal_roles_and_characters(self: "GameManager") -> None:
         role_deck = self._build_role_deck()
         random.shuffle(role_deck)
         char_deck = [cls() for cls in self._build_character_deck()]
@@ -152,7 +146,7 @@ class DeckManagerMixin:
             player.character.ability(self, player)
             player.metadata.game = self
 
-    def _next_alive_player(self: 'GameManager', player: 'Player') -> 'Player' | None:
+    def _next_alive_player(self: "GameManager", player: "Player") -> "Player" | None:
         """Return the next living player to the left."""
         if player not in self._players:
             return None
@@ -163,7 +157,7 @@ class DeckManagerMixin:
                 return nxt
         return None
 
-    def _pass_left_or_discard(self: 'GameManager', source: 'Player', card: BaseCard) -> None:
+    def _pass_left_or_discard(self: "GameManager", source: "Player", card: BaseCard) -> None:
         """Pass card left if The River is active, else discard."""
         if self.event_flags.get("river"):
             target = self._next_alive_player(source)
@@ -174,19 +168,22 @@ class DeckManagerMixin:
 
     # ------------------------------------------------------------------
     # Turn management helpers
-    def _current_player_obj(self: 'GameManager') -> 'Player':
-        """Return the Player instance whose turn it currently is."""
-        return self._players[self.turn_order[self.current_turn]]
+    def _current_player_obj(self: "GameManager") -> "Player | None":
+        """Return the Player whose turn it currently is or ``None``."""
+        if not self.turn_order or not self._players:
+            return None
+        idx = self.turn_order[self.current_turn % len(self.turn_order)]
+        if idx >= len(self._players):
+            return None
+        return self._players[idx]
 
-    def _reindex_turn_order(self: 'GameManager', removed_idx: int) -> None:
+    def _reindex_turn_order(self: "GameManager", removed_idx: int) -> None:
         """Remove ``removed_idx`` from turn order and shift indices."""
         self.turn_order = [
             i - 1 if i > removed_idx else i for i in self.turn_order if i != removed_idx
         ]
 
-    def _reset_current_turn(
-        self: 'GameManager', current_obj: 'Player' | None
-    ) -> None:
+    def _reset_current_turn(self: "GameManager", current_obj: "Player" | None) -> None:
         """Update ``current_turn`` after player removal."""
         if current_obj and current_obj in self._players:
             cur_idx = self._players.index(current_obj)
@@ -195,11 +192,11 @@ class DeckManagerMixin:
                 return
         self.current_turn %= len(self.turn_order)
 
-    def _get_player_by_index(self: 'GameManager', idx: int) -> 'Player' | None:
+    def _get_player_by_index(self: "GameManager", idx: int) -> "Player" | None:
         if 0 <= idx < len(self._players):
             return self._players[idx]
         return None
 
-    def get_player_by_index(self: 'GameManager', idx: int) -> 'Player' | None:
+    def get_player_by_index(self: "GameManager", idx: int) -> "Player" | None:
         """Return the player at ``idx`` if it exists."""
         return self._get_player_by_index(idx)

--- a/bang_py/events/event_logic.py
+++ b/bang_py/events/event_logic.py
@@ -28,7 +28,7 @@ class EventLogicMixin:
     current_turn: int
     first_eliminated: object | None
 
-    def draw_event_card(self: 'GameManager') -> None:
+    def draw_event_card(self: "GameManager") -> None:
         """Draw and apply the next event card."""
         if not self.event_deck:
             return
@@ -36,7 +36,7 @@ class EventLogicMixin:
         self.event_flags.clear()
         self.current_event.apply(self)
 
-    def _initialize_event_deck(self: 'GameManager') -> None:
+    def _initialize_event_deck(self: "GameManager") -> None:
         """Build and shuffle the event deck based on active expansions."""
         if "high_noon" in self.expansions:
             self.event_deck = self._prepare_high_noon_deck()
@@ -47,7 +47,7 @@ class EventLogicMixin:
             random.shuffle(deck_list)
             self.event_deck = deque(deck_list)
 
-    def _prepare_high_noon_deck(self: 'GameManager') -> deque[EventCard] | None:
+    def _prepare_high_noon_deck(self: "GameManager") -> deque[EventCard] | None:
         """Create and shuffle the High Noon event deck."""
         deck = create_high_noon_deck()
         if deck:
@@ -60,7 +60,7 @@ class EventLogicMixin:
             deck = deque(deck_list)
         return deck
 
-    def _prepare_fistful_deck(self: 'GameManager') -> deque[EventCard] | None:
+    def _prepare_fistful_deck(self: "GameManager") -> deque[EventCard] | None:
         """Create and shuffle the Fistful of Cards event deck."""
         deck = create_fistful_deck()
         if deck:
@@ -73,7 +73,7 @@ class EventLogicMixin:
             deck = deque(deck_list)
         return deck
 
-    def _apply_event_start_effects(self: 'GameManager', player: Player) -> Player | None:
+    def _apply_event_start_effects(self: "GameManager", player: Player) -> Player | None:
         """Run start-of-turn event logic."""
         pre_ghost = self.event_flags.get("ghost_town")
         player = self._sheriff_event_updates(player, bool(pre_ghost))
@@ -93,7 +93,7 @@ class EventLogicMixin:
 
         return player
 
-    def _sheriff_event_updates(self: 'GameManager', player, pre_ghost: bool):
+    def _sheriff_event_updates(self: "GameManager", player, pre_ghost: bool):
         """Update sheriff counters and remove Ghost Town revivals."""
         if isinstance(player.role, SheriffRoleCard):
             self._increment_sheriff_turns()
@@ -101,13 +101,13 @@ class EventLogicMixin:
                 player = self._ghost_town_cleanup(player)
         return player
 
-    def _increment_sheriff_turns(self: 'GameManager') -> None:
+    def _increment_sheriff_turns(self: "GameManager") -> None:
         """Increment sheriff turn count and draw events when eligible."""
         self.sheriff_turns += 1
         if self.event_deck and self.sheriff_turns >= 2:
             self.draw_event_card()
 
-    def _ghost_town_cleanup(self: 'GameManager', player):
+    def _ghost_town_cleanup(self: "GameManager", player):
         """Remove revived ghosts after two sheriff turns."""
         removed = False
         for pl in self._players:
@@ -117,17 +117,21 @@ class EventLogicMixin:
                 removed = True
         if removed:
             self.turn_order = [i for i, pl in enumerate(self._players) if pl.is_alive()]
-            self.current_turn = self.turn_order.index(self._players.index(player))
-            idx = self.turn_order[self.current_turn]
-            player = self._players[idx]
+            if player in self._players and self.turn_order:
+                player_idx = self._players.index(player)
+                if player_idx in self.turn_order:
+                    self.current_turn = self.turn_order.index(player_idx)
+                    idx = self.turn_order[self.current_turn]
+                    if idx < len(self._players):
+                        player = self._players[idx]
         return player
 
-    def _process_new_identity(self: 'GameManager', player) -> None:
+    def _process_new_identity(self: "GameManager", player) -> None:
         if self.event_flags.get("new_identity") and player.metadata.unused_character:
             if self.prompt_new_identity(player):
                 self.apply_new_identity(player)
 
-    def apply_new_identity(self: 'GameManager', player: Player) -> None:
+    def apply_new_identity(self: "GameManager", player: Player) -> None:
         """Swap ``player`` to their unused character if the event is active."""
 
         if not self.event_flags.get("new_identity"):
@@ -142,7 +146,7 @@ class EventLogicMixin:
         player.character.ability(self, player)
         player.health = min(2, player.max_health)
 
-    def _skip_turn_if_needed(self: 'GameManager') -> bool:
+    def _skip_turn_if_needed(self: "GameManager") -> bool:
         if self.event_flags.get("skip_turn"):
             self.event_flags.pop("skip_turn")
             self.current_turn = (self.current_turn + 1) % len(self.turn_order)
@@ -150,7 +154,7 @@ class EventLogicMixin:
             return True
         return False
 
-    def _apply_start_damage(self: 'GameManager', player) -> bool:
+    def _apply_start_damage(self: "GameManager", player) -> bool:
         dmg = self.event_flags.get("start_damage", 0)
         if dmg:
             player.take_damage(dmg)
@@ -160,7 +164,7 @@ class EventLogicMixin:
                 return False
         return True
 
-    def _apply_fistful_of_cards(self: 'GameManager', player) -> bool:
+    def _apply_fistful_of_cards(self: "GameManager", player) -> bool:
         if self.event_flags.get("fistful_of_cards"):
             for _ in range(len(player.hand)):
                 if not self._auto_miss(player):
@@ -171,7 +175,7 @@ class EventLogicMixin:
                         return False
         return True
 
-    def _handle_dead_man(self: 'GameManager', player) -> None:
+    def _handle_dead_man(self: "GameManager", player) -> None:
         if (
             self.event_flags.get("dead_man")
             and self.event_flags.get("dead_man_player") is player
@@ -182,7 +186,7 @@ class EventLogicMixin:
             self.draw_card(player, 2)
             self.event_flags["dead_man_used"] = True
 
-    def _maybe_revive_ghost_town(self: 'GameManager', player) -> bool:
+    def _maybe_revive_ghost_town(self: "GameManager", player) -> bool:
         if self.event_flags.get("ghost_town") and not player.is_alive():
             player.health = 1
             player.metadata.ghost_revived = True
@@ -193,10 +197,9 @@ class EventLogicMixin:
             return True
         return False
 
-    def _handle_vendetta(self: 'GameManager', player) -> bool:
-        if (
-            not self.event_flags.get("vendetta")
-            or player in self.event_flags.get("vendetta_used", set())
+    def _handle_vendetta(self: "GameManager", player) -> bool:
+        if not self.event_flags.get("vendetta") or player in self.event_flags.get(
+            "vendetta_used", set()
         ):
             return False
         card = self._draw_from_deck()
@@ -208,9 +211,8 @@ class EventLogicMixin:
                 return True
         return False
 
-    def _finish_ghost_town(self: 'GameManager', player) -> None:
+    def _finish_ghost_town(self: "GameManager", player) -> None:
         if self.event_flags.get("ghost_town") and player.metadata.ghost_revived:
             player.health = 0
             player.metadata.ghost_revived = False
             self._check_win_conditions()
-

--- a/bang_py/network/server.py
+++ b/bang_py/network/server.py
@@ -520,7 +520,10 @@ class BangServer:
     def _start_kit_carlson(self, conn: Connection, player: Player) -> bool:
         if not isinstance(player.character, KitCarlson):
             return False
-        cards = [self.game.deck.draw() for _ in range(3)]
+        deck = self.game.deck
+        if deck is None:
+            return False
+        cards = [deck.draw() for _ in range(3)]
         player.metadata.kit_cards = [c for c in cards if c]
         names = [c.card_name for c in player.metadata.kit_cards or []]
         payload = json.dumps({"prompt": "kit_carlson", "cards": names})
@@ -573,7 +576,10 @@ class BangServer:
     def _start_lucky_duke(self, conn: Connection, player: Player) -> bool:
         if not isinstance(player.character, LuckyDuke):
             return False
-        cards = [self.game.deck.draw(), self.game.deck.draw()]
+        deck = self.game.deck
+        if deck is None:
+            return False
+        cards = [deck.draw(), deck.draw()]
         player.metadata.lucky_cards = [c for c in cards if c]
         names = [c.card_name for c in player.metadata.lucky_cards or []]
         if names:

--- a/bang_py/turn_phases/draw_phase.py
+++ b/bang_py/turn_phases/draw_phase.py
@@ -7,11 +7,6 @@ import random
 from collections import deque
 
 from ..cards.card import BaseCard
-from ..characters.jesse_jones import JesseJones
-from ..characters.jose_delgado import JoseDelgado
-from ..characters.kit_carlson import KitCarlson
-from ..characters.pat_brennan import PatBrennan
-from ..characters.pedro_ramirez import PedroRamirez
 
 if TYPE_CHECKING:  # pragma: no cover - imported for type checking
     from ..player import Player
@@ -24,7 +19,7 @@ class DrawPhaseMixin:
     deck: object
     discard_pile: list[BaseCard]
     event_flags: dict
-    _players: list['Player']
+    _players: list["Player"]
     turn_order: list[int]
     current_turn: int
     phase: str
@@ -34,8 +29,10 @@ class DrawPhaseMixin:
 
     # ------------------------------------------------------------------
     # Deck helpers
-    def _draw_from_deck(self: 'GameManager') -> BaseCard | None:
+    def _draw_from_deck(self: "GameManager") -> BaseCard | None:
         """Draw a card reshuffling the discard pile if needed."""
+        if self.deck is None:
+            return None
         card = self.deck.draw()
         if card is None and self.discard_pile:
             self.deck.cards.extend(self.discard_pile)
@@ -46,7 +43,7 @@ class DrawPhaseMixin:
             card = self.deck.draw()
         return card
 
-    def draw_card(self: 'GameManager', player: 'Player', num: int = 1) -> None:
+    def draw_card(self: "GameManager", player: "Player", num: int = 1) -> None:
         """Draw ``num`` cards for ``player`` applying event modifiers."""
         bonus = int(self.event_flags.get("peyote_bonus", 0))
         for _ in range(num + bonus):
@@ -65,20 +62,20 @@ class DrawPhaseMixin:
     # Draw phase
     def draw_phase(
         self,
-        player: 'Player',
+        player: "Player",
         *,
-        jesse_target: 'Player' | None = None,
+        jesse_target: "Player" | None = None,
         jesse_card: int | None = None,
         kit_back: int | None = None,
         pedro_use_discard: bool | None = None,
         jose_equipment: int | None = None,
-        pat_target: 'Player' | None = None,
+        pat_target: "Player" | None = None,
         pat_card: str | None = None,
         skip_heal: bool | None = None,
         peyote_guesses: list[str] | None = None,
         ranch_discards: list[int] | None = None,
         handcuffs_suit: str | None = None,
-        blood_target: 'Player' | None = None,
+        blood_target: "Player" | None = None,
     ) -> None:
         """Execute the draw phase for ``player``."""
         if self._draw_pre_checks(player, skip_heal=skip_heal, blood_target=blood_target):
@@ -105,16 +102,16 @@ class DrawPhaseMixin:
 
     def _draw_pre_checks(
         self,
-        player: 'Player',
+        player: "Player",
         *,
         skip_heal: bool | None,
-        blood_target: 'Player' | None,
+        blood_target: "Player" | None,
     ) -> bool:
         if self.event_flags.get("no_draw"):
             return True
         if self.event_flags.get("hard_liquor") and skip_heal:
             player.heal(1)
-            self.on_player_healed(player)
+            self.on_player_healed(player)  # type: ignore[attr-defined]
             return True
         custom_draw = self.event_flags.get("draw_count")
         if custom_draw is not None:
@@ -126,14 +123,14 @@ class DrawPhaseMixin:
 
     def _dispatch_draw_listeners(
         self,
-        player: 'Player',
+        player: "Player",
         *,
-        jesse_target: 'Player' | None,
+        jesse_target: "Player" | None,
         jesse_card: int | None,
         kit_back: int | None,
         pedro_use_discard: bool | None,
         jose_equipment: int | None,
-        pat_target: 'Player' | None,
+        pat_target: "Player" | None,
         pat_card: str | None,
     ) -> bool:
         for cb in self.draw_phase_listeners:
@@ -152,13 +149,13 @@ class DrawPhaseMixin:
                 return True
         return False
 
-    def _perform_draw(self, player: 'Player', peyote_guesses: list[str] | None) -> None:
+    def _perform_draw(self, player: "Player", peyote_guesses: list[str] | None) -> None:
         if self.event_flags.get("peyote"):
             self._draw_with_peyote(player, peyote_guesses or [])
         else:
             self.draw_card(player, 2)
 
-    def _draw_with_peyote(self, player: 'Player', guesses: list[str]) -> None:
+    def _draw_with_peyote(self, player: "Player", guesses: list[str]) -> None:
         cont = True
         while cont:
             card = self._draw_from_deck()
@@ -174,7 +171,7 @@ class DrawPhaseMixin:
 
     def _post_draw_events(
         self,
-        player: 'Player',
+        player: "Player",
         *,
         ranch_discards: list[int] | None,
         handcuffs_suit: str | None,
@@ -185,12 +182,12 @@ class DrawPhaseMixin:
         if self.event_flags.get("handcuffs"):
             self._set_turn_suit(handcuffs_suit)
 
-    def _apply_law_of_the_west(self, player: 'Player') -> None:
+    def _apply_law_of_the_west(self, player: "Player") -> None:
         if self.event_flags.get("law_of_the_west") and len(player.hand) >= 2:
             card = player.hand[-1]
-            self.play_card(player, card)
+            self.play_card(player, card)  # type: ignore[attr-defined]
 
-    def _handle_ranch(self, player: 'Player', discards: list[int]) -> None:
+    def _handle_ranch(self, player: "Player", discards: list[int]) -> None:
         discards = sorted(discards, reverse=True)
         drawn = 0
         for idx in discards:
@@ -207,9 +204,9 @@ class DrawPhaseMixin:
     # ------------------------------------------------------------------
     # Misc helpers
     def _blood_brothers_transfer(
-        self: 'GameManager',
-        player: 'Player',
-        target: 'Player',
+        self: "GameManager",
+        player: "Player",
+        target: "Player",
     ) -> None:
         if not self.event_flags.get("blood_brothers"):
             return
@@ -218,6 +215,6 @@ class DrawPhaseMixin:
         if player.health <= 1:
             return
         player.take_damage(1)
-        self.on_player_damaged(player)
+        self.on_player_damaged(player)  # type: ignore[attr-defined]
         target.heal(1)
-        self.on_player_healed(target)
+        self.on_player_healed(target)  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary
- prevent draws from missing decks
- guard handcuffs checks with turn order and player availability
- stabilize ghost town cleanup and current-player lookup

## Testing
- `pre-commit run --files bang_py/turn_phases/draw_phase.py bang_py/card_handlers/dispatch.py bang_py/events/event_logic.py bang_py/network/server.py bang_py/deck_manager.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68965bd6602c83239dd9ea1b6c6e9e98