### PR TITLE
chore: add protocol hooks to mixins

### DIFF
--- a/bang_py/card_handlers/dispatch.py
+++ b/bang_py/card_handlers/dispatch.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from importlib import import_module
 from collections.abc import Iterable
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from ..cards.bang import BangCard
 from ..cards.missed import MissedCard
@@ -17,6 +17,7 @@ from ..cards.panic import PanicCard
 from ..cards.jail import JailCard
 from ..cards.roles import SheriffRoleCard
 from ..helpers import handle_out_of_turn_discard
+from ..game_manager_protocol import GameManagerProtocol
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from ..game_manager import GameManager
@@ -293,10 +294,11 @@ class DispatchMixin:
     ) -> None:
         """Trigger damage or heal callbacks if ``target`` changed health."""
         if target and before is not None:
+            gm = cast(GameManagerProtocol, self)
             if target.health < before:
-                self.on_player_damaged(target, source)  # type: ignore[attr-defined]
+                gm.on_player_damaged(target, source)
             elif target.health > before:
-                self.on_player_healed(target)  # type: ignore[attr-defined]
+                gm.on_player_healed(target)
 
     def _draw_if_empty(self: "GameManager", player: "Player") -> None:
         """Draw a card if the player has an empty hand and may draw."""

--- a/bang_py/game_manager_protocol.py
+++ b/bang_py/game_manager_protocol.py
@@ -1,0 +1,36 @@
+"""Protocols for :class:`GameManager` interactions across mixins."""
+
+from __future__ import annotations
+
+from typing import Protocol, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - imported for type checking
+    from .player import Player
+    from .cards.card import BaseCard
+
+
+class GameManagerProtocol(Protocol):
+    """Interface exposing cross-mixin hooks used by ``GameManager``."""
+
+    def draw_card(self, player: "Player", num: int = 1) -> None:
+        """Draw ``num`` cards for ``player``."""
+
+    def _pass_left_or_discard(self, player: "Player", card: "BaseCard") -> None:
+        """Discard ``card`` or pass it left depending on events."""
+
+    def play_card(
+        self,
+        player: "Player",
+        card: "BaseCard",
+        target: "Player" | None = None,
+    ) -> None:
+        """Play ``card`` from ``player`` targeting ``target`` if provided."""
+
+    def on_player_damaged(self, player: "Player", source: "Player" | None = None) -> None:
+        """Handle damage taken by ``player`` from ``source``."""
+
+    def on_player_healed(self, player: "Player") -> None:
+        """Handle ``player`` regaining health."""
+
+
+__all__ = ["GameManagerProtocol"]


### PR DESCRIPTION
## Summary
- define `GameManagerProtocol` with card draw, play, and damage hooks
- cast mixins to `GameManagerProtocol` to remove `attr-defined` ignores

## Testing
- `pre-commit run --files bang_py/game_manager_protocol.py bang_py/card_handlers/dispatch.py bang_py/turn_phases/draw_phase.py` *(fails: mypy reports existing errors)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689661f2edf4832396724007cd17db90