### PR TITLE
Allow None target in card play signatures

### DIFF
--- a/bang_py/cards/bang.py
+++ b/bang_py/cards/bang.py
@@ -1,10 +1,9 @@
 """Bang! card from the base game. Basic attack that deals 1 damage unless dodged."""
 
 from __future__ import annotations
-
 from .card import BaseCard
 from ..player import Player
-from typing import TYPE_CHECKING
+from typing import Any, TYPE_CHECKING, override
 from .barrel import BarrelCard
 from ..characters.jourdonnais import Jourdonnais
 
@@ -18,21 +17,22 @@ class BangCard(BaseCard):
     card_set = "base"
     description = "Basic attack that deals 1 damage unless dodged."
 
+    @override
     def play(
         self,
-        target: Player,
+        target: Player | None,
         deck: Deck | None = None,
         *,
         ignore_equipment: bool = False,
+        **kwargs: Any,
     ) -> None:
         if not target:
             return
         if deck and not ignore_equipment:
             barrel = target.equipment.get("Barrel")
-            if barrel and getattr(barrel, "draw_check", None):
-                if barrel.draw_check(deck, target):
-                    target.metadata.dodged = True
-                    return
+            if isinstance(barrel, BarrelCard) and barrel.draw_check(deck, target):
+                target.metadata.dodged = True
+                return
             if isinstance(target.character, Jourdonnais) or target.metadata.virtual_barrel:
                 if BarrelCard().draw_check(deck, target):
                     target.metadata.dodged = True

--- a/bang_py/cards/barrel.py
+++ b/bang_py/cards/barrel.py
@@ -1,12 +1,10 @@
 """Barrel card from the base game. Draw when targeted by Bang!; on Heart, ignore it."""
 
 from __future__ import annotations
-
 from .card import BaseCard
 from ..player import Player
 
-
-from typing import TYPE_CHECKING
+from typing import Any, TYPE_CHECKING, override
 
 from ..helpers import is_heart
 
@@ -23,7 +21,8 @@ class BarrelCard(BaseCard):
         super().__init__(suit, rank)
         self.active = True
 
-    def play(self, target: Player, deck: Deck | None = None) -> None:
+    @override
+    def play(self, target: Player | None, deck: Deck | None = None, **kwargs: Any) -> None:
         if not target:
             return
         target.equip(self, active=self.active)

--- a/bang_py/cards/beer.py
+++ b/bang_py/cards/beer.py
@@ -1,11 +1,9 @@
 """Beer card from the base game. Heals 1 health if allowed by the game rules."""
 
 from __future__ import annotations
-
 from .card import BaseCard
 from ..player import Player
-from typing import TYPE_CHECKING
-
+from typing import Any, TYPE_CHECKING, override
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from ..game_manager import GameManager
@@ -17,11 +15,13 @@ class BeerCard(BaseCard):
     card_set = "base"
     description = "Heals 1 health if allowed by the game rules."
 
+    @override
     def play(
         self,
-        target: Player,
+        target: Player | None,
         player: Player | None = None,
         game: "GameManager" | None = None,
+        **kwargs: Any,
     ) -> None:
         """Heal the target if allowed by game state and abilities."""
         if not target:

--- a/bang_py/cards/bible.py
+++ b/bang_py/cards/bible.py
@@ -1,10 +1,9 @@
 """Bible card from the Dodge City expansion. Play as Missed! and then draw one card."""
 
 from __future__ import annotations
-
 from .card import BaseCard
 from ..player import Player
-from typing import TYPE_CHECKING
+from typing import Any, TYPE_CHECKING, override
 
 if TYPE_CHECKING:
     from ..game_manager import GameManager
@@ -18,11 +17,13 @@ class BibleCard(BaseCard):
     card_set = "dodge_city"
     description = "Play as Missed! and then draw one card."
 
+    @override
     def play(
         self,
-        target: Player,
+        target: Player | None,
         player: Player | None = None,
         game: GameManager | None = None,
+        **kwargs: Any,
     ) -> None:
         if not target:
             return

--- a/bang_py/cards/binoculars.py
+++ b/bang_py/cards/binoculars.py
@@ -1,7 +1,7 @@
 """Binoculars card from the Dodge City expansion. Increases attack range by 1."""
 
 from __future__ import annotations
-
+from typing import Any, override
 from .card import BaseCard
 from ..player import Player
 
@@ -19,7 +19,8 @@ class BinocularsCard(BaseCard):
         super().__init__(suit, rank)
         self.active = True
 
-    def play(self, target: Player) -> None:
+    @override
+    def play(self, target: Player | None, **kwargs: Any) -> None:
         if not target:
             return
         target.equip(self, active=self.active)

--- a/bang_py/cards/brawl.py
+++ b/bang_py/cards/brawl.py
@@ -1,10 +1,9 @@
 """Brawl card from the Dodge City expansion. Discard a card to make all others discard one."""
 
 from __future__ import annotations
-
 from .card import BaseCard
 from ..player import Player
-from typing import TYPE_CHECKING
+from typing import Any, TYPE_CHECKING, override
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from ..game_manager import GameManager
@@ -20,6 +19,7 @@ class BrawlCard(BaseCard):
     card_set = "dodge_city"
     description = "Discard a card to make all others discard one."
 
+    @override
     def play(
         self,
         target: Player | None = None,
@@ -28,6 +28,7 @@ class BrawlCard(BaseCard):
         *,
         discard_idx: int = 0,
         victim_indices: dict[int, int] | None = None,
+        **kwargs: Any,
     ) -> None:
         if not player or not game or not player.hand:
             return

--- a/bang_py/cards/buffalo_rifle.py
+++ b/bang_py/cards/buffalo_rifle.py
@@ -1,10 +1,9 @@
 """Buffalo Rifle card from the Dodge City expansion. Bang any player regardless of distance."""
 
 from __future__ import annotations
-
 from .card import BaseCard
 from ..player import Player
-from typing import TYPE_CHECKING
+from typing import Any, TYPE_CHECKING, override
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from ..game_manager import GameManager
@@ -21,12 +20,14 @@ class BuffaloRifleCard(BaseCard):
     card_set = "dodge_city"
     description = "Bang any player regardless of distance."
 
+    @override
     def play(
         self,
-        target: Player,
+        target: Player | None,
         player: Player | None = None,
         game: GameManager | None = None,
         deck: Deck | None = None,
+        **kwargs: Any,
     ) -> None:
         if not target:
             return

--- a/bang_py/cards/can_can.py
+++ b/bang_py/cards/can_can.py
@@ -1,10 +1,9 @@
 """Can Can card from the Dodge City expansion. Choose a card to discard from any one player."""
 
 from __future__ import annotations
-
 from .card import BaseCard
 from ..player import Player
-from typing import TYPE_CHECKING
+from typing import Any, TYPE_CHECKING, override
 from ..helpers import handle_out_of_turn_discard
 
 if TYPE_CHECKING:
@@ -19,14 +18,16 @@ class CanCanCard(BaseCard):
     card_set = "dodge_city"
     description = "Choose a card to discard from any one player."
 
+    @override
     def play(
         self,
-        target: Player,
+        target: Player | None,
         player: Player | None = None,
         game: GameManager | None = None,
         *,
         hand_idx: int | None = None,
         equip_name: str | None = None,
+        **kwargs: Any,
     ) -> None:
         if not target or not game:
             return
@@ -37,6 +38,6 @@ class CanCanCard(BaseCard):
             handle_out_of_turn_discard(game, target, card)
         elif target.equipment:
             name = equip_name or next(iter(target.equipment))
-            card = target.unequip(name)
-            if card:
-                game.discard_pile.append(card)
+            equip_card = target.unequip(name)
+            if equip_card:
+                game.discard_pile.append(equip_card)

--- a/bang_py/cards/canteen.py
+++ b/bang_py/cards/canteen.py
@@ -1,10 +1,9 @@
 """Canteen card from the Dodge City expansion. Heal 1 health."""
 
 from __future__ import annotations
-
 from .card import BaseCard
 from ..player import Player
-from typing import TYPE_CHECKING
+from typing import Any, TYPE_CHECKING, override
 
 if TYPE_CHECKING:
     from ..game_manager import GameManager
@@ -18,11 +17,13 @@ class CanteenCard(BaseCard):
     card_set = "dodge_city"
     description = "Heal 1 health."
 
+    @override
     def play(
         self,
-        target: Player,
+        target: Player | None,
         player: Player | None = None,
         game: GameManager | None = None,
+        **kwargs: Any,
     ) -> None:
         if not target:
             return

--- a/bang_py/cards/carbine.py
+++ b/bang_py/cards/carbine.py
@@ -1,7 +1,7 @@
 """Carbine card from the base game. Gun with range 4."""
 
 from __future__ import annotations
-
+from typing import Any, override
 from .card import BaseCard
 from ..player import Player
 
@@ -17,7 +17,8 @@ class CarbineCard(BaseCard):
         super().__init__(suit, rank)
         self.active = True
 
-    def play(self, target: Player) -> None:
+    @override
+    def play(self, target: Player | None, **kwargs: Any) -> None:
         if not target:
             return
         target.equip(self, active=self.active)

--- a/bang_py/cards/cat_balou.py
+++ b/bang_py/cards/cat_balou.py
@@ -1,12 +1,11 @@
 """Cat Balou card from the base game.
-
 Choose a card from the target's hand or in play and discard it.
 """
 
 from __future__ import annotations
 from .card import BaseCard
 from ..player import Player
-from typing import TYPE_CHECKING
+from typing import Any, TYPE_CHECKING, override
 from ..helpers import handle_out_of_turn_discard
 
 if TYPE_CHECKING:
@@ -19,13 +18,15 @@ class CatBalouCard(BaseCard):
     card_set = "base"
     description = "Choose a card from the target's hand or in play and discard it."
 
+    @override
     def play(
         self,
-        target: Player,
+        target: Player | None,
         game: GameManager | None = None,
         *,
         hand_idx: int | None = None,
         equip_name: str | None = None,
+        **kwargs: Any,
     ) -> None:
         """Discard a chosen card from the target's hand or equipment."""
         if not target:
@@ -41,6 +42,6 @@ class CatBalouCard(BaseCard):
 
         if target.equipment:
             name = equip_name or next(iter(target.equipment))
-            card = target.unequip(name)
-            if card and game:
-                game.discard_pile.append(card)
+            equip_card = target.unequip(name)
+            if equip_card and game:
+                game.discard_pile.append(equip_card)

--- a/bang_py/cards/conestoga.py
+++ b/bang_py/cards/conestoga.py
@@ -1,10 +1,9 @@
 """Conestoga card from the Dodge City expansion. Steal a card from any player."""
 
 from __future__ import annotations
-
 from .card import BaseCard
 from ..player import Player
-from typing import TYPE_CHECKING
+from typing import Any, TYPE_CHECKING, override
 
 if TYPE_CHECKING:
     from ..game_manager import GameManager
@@ -18,23 +17,25 @@ class ConestogaCard(BaseCard):
     card_set = "dodge_city"
     description = "Steal a card from any player."
 
+    @override
     def play(
         self,
-        target: Player,
+        target: Player | None,
         player: Player | None = None,
         game: GameManager | None = None,
         *,
         hand_idx: int | None = None,
         equip_name: str | None = None,
+        **kwargs: Any,
     ) -> None:
         if not target or not player:
             return
+        card: BaseCard | None = None
         if target.hand and (hand_idx is not None or not target.equipment):
             idx = hand_idx if hand_idx is not None and 0 <= hand_idx < len(target.hand) else 0
             card = target.hand.pop(idx)
-            player.hand.append(card)
         elif target.equipment:
             name = equip_name or next(iter(target.equipment))
             card = target.unequip(name)
-            if card:
-                player.hand.append(card)
+        if card:
+            player.hand.append(card)

--- a/bang_py/cards/derringer.py
+++ b/bang_py/cards/derringer.py
@@ -1,10 +1,9 @@
 """Derringer card from the Dodge City expansion. Bang at range 1, then draw a card."""
 
 from __future__ import annotations
-
 from .card import BaseCard
 from ..player import Player
-from typing import TYPE_CHECKING
+from typing import Any, TYPE_CHECKING, override
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from ..game_manager import GameManager
@@ -21,12 +20,14 @@ class DerringerCard(BaseCard):
     card_set = "dodge_city"
     description = "Bang at range 1, then draw a card."
 
+    @override
     def play(
         self,
-        target: Player,
+        target: Player | None,
         player: Player | None = None,
         game: GameManager | None = None,
         deck: Deck | None = None,
+        **kwargs: Any,
     ) -> None:
         if not target or not player:
             return

--- a/bang_py/cards/duel.py
+++ b/bang_py/cards/duel.py
@@ -1,11 +1,10 @@
 """Duel card from the base game. Players alternate discarding Bang! cards; loser takes 1 damage."""
 
 from __future__ import annotations
-
 from .card import BaseCard
 from ..player import Player
 from ..helpers import handle_out_of_turn_discard
-from typing import TYPE_CHECKING
+from typing import Any, TYPE_CHECKING, override
 
 if TYPE_CHECKING:
     from ..game_manager import GameManager
@@ -17,8 +16,13 @@ class DuelCard(BaseCard):
     card_set = "base"
     description = "Players alternate discarding Bang! cards; loser takes 1 damage."
 
+    @override
     def play(
-        self, target: Player, player: Player | None = None, game: GameManager | None = None
+        self,
+        target: Player | None,
+        player: Player | None = None,
+        game: GameManager | None = None,
+        **kwargs: Any,
     ) -> None:
         if not target or not player or not game:
             return

--- a/bang_py/cards/dynamite.py
+++ b/bang_py/cards/dynamite.py
@@ -2,10 +2,9 @@
 is a spade between 2 and 9, Dynamite explodes for 3 damage."""
 
 from __future__ import annotations
-
 from .card import BaseCard
 from ..player import Player
-from typing import TYPE_CHECKING
+from typing import Any, TYPE_CHECKING, override
 from ..helpers import is_spade_between
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
@@ -24,14 +23,13 @@ class DynamiteCard(BaseCard):
         super().__init__(suit, rank)
         self.active = True
 
-    def play(self, target: Player, deck: Deck | None = None) -> None:
+    @override
+    def play(self, target: Player | None, deck: Deck | None = None, **kwargs: Any) -> None:
         if not target:
             return
         target.equip(self, active=self.active)
 
-    def check_dynamite(
-        self, current: Player, next_player: Player, deck: Deck
-    ) -> bool:
+    def check_dynamite(self, current: Player, next_player: Player, deck: Deck) -> bool:
         """Resolve Dynamite at the start of the current player's turn.
 
         Returns True if it exploded on the current player.

--- a/bang_py/cards/gatling.py
+++ b/bang_py/cards/gatling.py
@@ -1,10 +1,9 @@
 """Gatling card from the base game. Bang every other player once."""
 
 from __future__ import annotations
-
 from .card import BaseCard
 from ..player import Player
-from typing import TYPE_CHECKING
+from typing import Any, TYPE_CHECKING, override
 
 if TYPE_CHECKING:
     from ..game_manager import GameManager
@@ -17,9 +16,14 @@ class GatlingCard(BaseCard):
     card_set = "base"
     description = "Bang every other player once."
 
+    @override
     def play(
-        self, target: Player, player: Player | None = None, game: GameManager | None = None,
-        deck: Deck | None = None
+        self,
+        target: Player | None,
+        player: Player | None = None,
+        game: GameManager | None = None,
+        deck: Deck | None = None,
+        **kwargs: Any,
     ) -> None:
         if not game or not player:
             return

--- a/bang_py/cards/general_store.py
+++ b/bang_py/cards/general_store.py
@@ -2,10 +2,9 @@
 order."""
 
 from __future__ import annotations
-
 from .card import BaseCard
 from ..player import Player
-from typing import TYPE_CHECKING
+from typing import Any, TYPE_CHECKING, override
 
 if TYPE_CHECKING:
     from ..game_manager import GameManager
@@ -17,12 +16,14 @@ class GeneralStoreCard(BaseCard):
     card_set = "base"
     description = "Reveal cards for all players to choose one in turn order."
 
+    @override
     def play(
         self,
-        target: Player,
+        target: Player | None,
         player: Player | None = None,
         game: GameManager | None = None,
         choices: list[int] | None = None,
+        **kwargs: Any,
     ) -> None:
         """Reveal cards equal to players and let each choose in order."""
         if not game or not player:

--- a/bang_py/cards/hideout.py
+++ b/bang_py/cards/hideout.py
@@ -1,7 +1,7 @@
 """Hideout card from the Dodge City expansion. Opponents see you at +1 distance."""
 
 from __future__ import annotations
-
+from typing import Any, override
 from .card import BaseCard
 from ..player import Player
 
@@ -19,7 +19,8 @@ class HideoutCard(BaseCard):
         super().__init__(suit, rank)
         self.active = True
 
-    def play(self, target: Player) -> None:
+    @override
+    def play(self, target: Player | None, **kwargs: Any) -> None:
         if not target:
             return
         target.equip(self, active=self.active)

--- a/bang_py/cards/high_noon_card.py
+++ b/bang_py/cards/high_noon_card.py
@@ -1,10 +1,9 @@
 """High Noon card from the High Noon expansion. Event: everyone draws one card."""
 
 from __future__ import annotations
-
 from .card import BaseCard
 from ..player import Player
-from typing import TYPE_CHECKING
+from typing import Any, TYPE_CHECKING, override
 
 if TYPE_CHECKING:
     from ..game_manager import GameManager
@@ -18,11 +17,13 @@ class HighNoonCard(BaseCard):
     card_set = "high_noon"
     description = "Event: everyone draws one card."
 
+    @override
     def play(
         self,
         target: Player | None = None,
         player: Player | None = None,
         game: GameManager | None = None,
+        **kwargs: Any,
     ) -> None:
         if not game:
             return

--- a/bang_py/cards/howitzer.py
+++ b/bang_py/cards/howitzer.py
@@ -1,10 +1,9 @@
 """Howitzer card from the Dodge City expansion. Bang all opponents ignoring distance."""
 
 from __future__ import annotations
-
 from .card import BaseCard
 from ..player import Player
-from typing import TYPE_CHECKING
+from typing import Any, TYPE_CHECKING, override
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from ..game_manager import GameManager
@@ -21,9 +20,14 @@ class HowitzerCard(BaseCard):
     card_set = "dodge_city"
     description = "Bang all opponents ignoring distance."
 
+    @override
     def play(
-        self, target: Player, player: Player | None = None, game: GameManager | None = None,
-        deck: Deck | None = None
+        self,
+        target: Player | None,
+        player: Player | None = None,
+        game: GameManager | None = None,
+        deck: Deck | None = None,
+        **kwargs: Any,
     ) -> None:
         if not game or not player:
             return

--- a/bang_py/cards/indians.py
+++ b/bang_py/cards/indians.py
@@ -1,11 +1,10 @@
 """Indians! card from the base game. Others discard Bang! or suffer 1 damage."""
 
 from __future__ import annotations
-
 from .card import BaseCard
 from ..player import Player
 from ..helpers import handle_out_of_turn_discard
-from typing import TYPE_CHECKING
+from typing import Any, TYPE_CHECKING, override
 
 if TYPE_CHECKING:
     from ..game_manager import GameManager
@@ -17,8 +16,13 @@ class IndiansCard(BaseCard):
     card_set = "base"
     description = "Others discard Bang! or suffer 1 damage."
 
+    @override
     def play(
-        self, target: Player, player: Player | None = None, game: GameManager | None = None
+        self,
+        target: Player | None,
+        player: Player | None = None,
+        game: GameManager | None = None,
+        **kwargs: Any,
     ) -> None:
         if not game or not player:
             return

--- a/bang_py/cards/jail.py
+++ b/bang_py/cards/jail.py
@@ -1,10 +1,9 @@
 """Jail card from the base game. Skip your turn unless you draw a Heart."""
 
 from __future__ import annotations
-
 from .card import BaseCard
 from ..player import Player
-from typing import TYPE_CHECKING
+from typing import Any, TYPE_CHECKING, override
 from ..helpers import is_heart
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
@@ -20,7 +19,8 @@ class JailCard(BaseCard):
         super().__init__(suit, rank)
         self.active = True
 
-    def play(self, target: Player, deck: Deck | None = None) -> None:
+    @override
+    def play(self, target: Player | None, deck: Deck | None = None, **kwargs: Any) -> None:
         if not target:
             return
         target.equip(self, active=self.active)

--- a/bang_py/cards/knife.py
+++ b/bang_py/cards/knife.py
@@ -1,10 +1,9 @@
 """Knife card from the Dodge City expansion. Attack at distance 1 that can be dodged."""
 
 from __future__ import annotations
-
 from .card import BaseCard
 from ..player import Player
-from typing import TYPE_CHECKING
+from typing import Any, TYPE_CHECKING, override
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from ..game_manager import GameManager
@@ -20,8 +19,13 @@ class KnifeCard(BaseCard):
     card_set = "dodge_city"
     description = "Attack at distance 1 that can be dodged."
 
+    @override
     def play(
-        self, target: Player, player: Player | None = None, game: GameManager | None = None
+        self,
+        target: Player | None,
+        player: Player | None = None,
+        game: GameManager | None = None,
+        **kwargs: Any,
     ) -> None:
         if not target or not player:
             return

--- a/bang_py/cards/mustang.py
+++ b/bang_py/cards/mustang.py
@@ -1,7 +1,7 @@
 """Mustang card from the base game. Opponents see you at 1 greater distance."""
 
 from __future__ import annotations
-
+from typing import Any, override
 from .card import BaseCard
 from ..player import Player
 
@@ -16,7 +16,8 @@ class MustangCard(BaseCard):
         super().__init__(suit, rank)
         self.active = True
 
-    def play(self, target: Player) -> None:
+    @override
+    def play(self, target: Player | None, **kwargs: Any) -> None:
         if not target:
             return
         target.equip(self, active=self.active)

--- a/bang_py/cards/panic.py
+++ b/bang_py/cards/panic.py
@@ -4,7 +4,7 @@ it."""
 from __future__ import annotations
 from .card import BaseCard
 from ..player import Player
-from typing import TYPE_CHECKING
+from typing import Any, TYPE_CHECKING, override
 from ..helpers import handle_out_of_turn_discard
 
 if TYPE_CHECKING:
@@ -15,18 +15,18 @@ class PanicCard(BaseCard):
     card_name = "Panic!"
     card_type = "action"
     card_set = "base"
-    description = (
-        "Range 1: choose a card from the target's hand or in play and take it."
-    )
+    description = "Range 1: choose a card from the target's hand or in play and take it."
 
+    @override
     def play(
         self,
-        target: Player,
+        target: Player | None,
         player: Player | None = None,
         game: GameManager | None = None,
         *,
         hand_idx: int | None = None,
         equip_name: str | None = None,
+        **kwargs: Any,
     ) -> None:
         """Steal a chosen card from the target."""
         if not target or not player:
@@ -35,12 +35,13 @@ class PanicCard(BaseCard):
         if target.hand and (hand_idx is not None or not target.equipment):
             idx = hand_idx if hand_idx is not None and 0 <= hand_idx < len(target.hand) else 0
             card = target.hand.pop(idx)
-            handle_out_of_turn_discard(game, target, card)
+            if game:
+                handle_out_of_turn_discard(game, target, card)
             player.hand.append(card)
             return
 
         if target.equipment:
             name = equip_name or next(iter(target.equipment))
-            card = target.unequip(name)
-            if card:
-                player.hand.append(card)
+            equip_card = target.unequip(name)
+            if equip_card:
+                player.hand.append(equip_card)

--- a/bang_py/cards/pepperbox.py
+++ b/bang_py/cards/pepperbox.py
@@ -1,10 +1,9 @@
 """Pepperbox card from the Dodge City expansion. Acts as a normal Bang!"""
 
 from __future__ import annotations
-
 from .card import BaseCard
 from ..player import Player
-from typing import TYPE_CHECKING
+from typing import Any, TYPE_CHECKING, override
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from ..game_manager import GameManager
@@ -21,12 +20,14 @@ class PepperboxCard(BaseCard):
     card_set = "dodge_city"
     description = "Acts as a normal Bang!"
 
+    @override
     def play(
         self,
-        target: Player,
+        target: Player | None,
         player: Player | None = None,
         game: GameManager | None = None,
         deck: Deck | None = None,
+        **kwargs: Any,
     ) -> None:
         if not target or not player:
             return

--- a/bang_py/cards/pony_express.py
+++ b/bang_py/cards/pony_express.py
@@ -1,10 +1,9 @@
 """Pony Express card from the Fistful of Cards expansion. Draw three cards."""
 
 from __future__ import annotations
-
 from .card import BaseCard
 from ..player import Player
-from typing import TYPE_CHECKING
+from typing import Any, TYPE_CHECKING, override
 
 if TYPE_CHECKING:
     from ..game_manager import GameManager
@@ -18,11 +17,13 @@ class PonyExpressCard(BaseCard):
     card_set = "fistful_of_cards"
     description = "Draw three cards."
 
+    @override
     def play(
         self,
         target: Player | None = None,
         player: Player | None = None,
         game: GameManager | None = None,
+        **kwargs: Any,
     ) -> None:
         if player and game:
             game.draw_card(player, 3)

--- a/bang_py/cards/punch.py
+++ b/bang_py/cards/punch.py
@@ -1,7 +1,7 @@
 """Punch card from the Dodge City expansion. Deal 1 damage if the target is within distance 1."""
 
 from __future__ import annotations
-
+from typing import Any, override
 from .card import BaseCard
 from ..player import Player
 
@@ -14,7 +14,8 @@ class PunchCard(BaseCard):
     card_set = "dodge_city"
     description = "Deal 1 damage if the target is within distance 1."
 
-    def play(self, target: Player, player: Player | None = None) -> None:
+    @override
+    def play(self, target: Player | None, player: Player | None = None, **kwargs: Any) -> None:
         """Deal one damage if the target is within distance 1."""
         if not target or not player:
             return

--- a/bang_py/cards/rag_time.py
+++ b/bang_py/cards/rag_time.py
@@ -2,10 +2,9 @@
 player."""
 
 from __future__ import annotations
-
 from .card import BaseCard
 from ..player import Player
-from typing import TYPE_CHECKING
+from typing import Any, TYPE_CHECKING, override
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from ..game_manager import GameManager
@@ -21,14 +20,16 @@ class RagTimeCard(BaseCard):
     card_set = "fistful_of_cards"
     description = "Discard another card to take a card from any player."
 
+    @override
     def play(
         self,
-        target: Player,
+        target: Player | None,
         player: Player | None = None,
         game: GameManager | None = None,
         *,
         discard_idx: int = 0,
         steal_idx: int = 0,
+        **kwargs: Any,
     ) -> None:
         if not target or not player or not game or not player.hand:
             return

--- a/bang_py/cards/remington.py
+++ b/bang_py/cards/remington.py
@@ -1,7 +1,7 @@
 """Remington card from the base game. Gun with range 3."""
 
 from __future__ import annotations
-
+from typing import Any, override
 from .card import BaseCard
 from ..player import Player
 
@@ -17,7 +17,8 @@ class RemingtonCard(BaseCard):
         super().__init__(suit, rank)
         self.active = True
 
-    def play(self, target: Player) -> None:
+    @override
+    def play(self, target: Player | None, **kwargs: Any) -> None:
         if not target:
             return
         target.equip(self, active=self.active)

--- a/bang_py/cards/rev_carabine.py
+++ b/bang_py/cards/rev_carabine.py
@@ -1,7 +1,7 @@
 """Rev. Carabine card from the Dodge City expansion. Gun with range 4."""
 
 from __future__ import annotations
-
+from typing import Any, override
 from .card import BaseCard
 from ..player import Player
 
@@ -20,7 +20,8 @@ class RevCarabineCard(BaseCard):
         super().__init__(suit, rank)
         self.active = True
 
-    def play(self, target: Player) -> None:
+    @override
+    def play(self, target: Player | None, **kwargs: Any) -> None:
         if not target:
             return
         target.equip(self, active=self.active)

--- a/bang_py/cards/saloon.py
+++ b/bang_py/cards/saloon.py
@@ -1,10 +1,9 @@
 """Saloon card from the base game. All players heal 1 health."""
 
 from __future__ import annotations
-
 from .card import BaseCard
 from ..player import Player
-from typing import TYPE_CHECKING
+from typing import Any, TYPE_CHECKING, override
 
 if TYPE_CHECKING:
     from ..game_manager import GameManager
@@ -16,8 +15,13 @@ class SaloonCard(BaseCard):
     card_set = "base"
     description = "All players heal 1 health."
 
+    @override
     def play(
-        self, target: Player, player: Player | None = None, game: GameManager | None = None
+        self,
+        target: Player | None,
+        player: Player | None = None,
+        game: GameManager | None = None,
+        **kwargs: Any,
     ) -> None:
         if not game:
             return

--- a/bang_py/cards/schofield.py
+++ b/bang_py/cards/schofield.py
@@ -1,7 +1,7 @@
 """Schofield card from the base game. Gun with range 2."""
 
 from __future__ import annotations
-
+from typing import Any, override
 from .card import BaseCard
 from ..player import Player
 
@@ -17,7 +17,8 @@ class SchofieldCard(BaseCard):
         super().__init__(suit, rank)
         self.active = True
 
-    def play(self, target: Player) -> None:
+    @override
+    def play(self, target: Player | None, **kwargs: Any) -> None:
         if not target:
             return
         target.equip(self, active=self.active)

--- a/bang_py/cards/scope.py
+++ b/bang_py/cards/scope.py
@@ -1,7 +1,7 @@
 """Scope card from the base game. Increases your attack range by 1."""
 
 from __future__ import annotations
-
+from typing import Any, override
 from .card import BaseCard
 from ..player import Player
 
@@ -16,7 +16,8 @@ class ScopeCard(BaseCard):
         super().__init__(suit, rank)
         self.active = True
 
-    def play(self, target: Player) -> None:
+    @override
+    def play(self, target: Player | None, **kwargs: Any) -> None:
         if not target:
             return
         target.equip(self, active=self.active)

--- a/bang_py/cards/springfield.py
+++ b/bang_py/cards/springfield.py
@@ -1,10 +1,9 @@
 """Springfield card from the Dodge City expansion. Discard another card to Bang! any player."""
 
 from __future__ import annotations
-
 from .card import BaseCard
 from ..player import Player
-from typing import TYPE_CHECKING
+from typing import Any, TYPE_CHECKING, override
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from ..game_manager import GameManager
@@ -21,13 +20,15 @@ class SpringfieldCard(BaseCard):
     card_set = "dodge_city"
     description = "Discard another card to Bang! any player."
 
+    @override
     def play(
         self,
-        target: Player,
+        target: Player | None,
         player: Player | None = None,
         game: GameManager | None = None,
         *,
         discard_idx: int = 0,
+        **kwargs: Any,
     ) -> None:
         if not target or not player or not game or not player.hand:
             return

--- a/bang_py/cards/stagecoach.py
+++ b/bang_py/cards/stagecoach.py
@@ -1,10 +1,9 @@
 """Stagecoach card from the base game. Draw two cards."""
 
 from __future__ import annotations
-
 from .card import BaseCard
 from ..player import Player
-from typing import TYPE_CHECKING
+from typing import Any, TYPE_CHECKING, override
 
 if TYPE_CHECKING:
     from ..deck import Deck
@@ -17,9 +16,16 @@ class StagecoachCard(BaseCard):
     card_set = "base"
     description = "Draw two cards."
 
+    @override
     def play(
-        self, target: Player, game: GameManager | None = None, deck: Deck | None = None
+        self,
+        target: Player | None,
+        game: GameManager | None = None,
+        deck: Deck | None = None,
+        **kwargs: Any,
     ) -> None:
+        if not target:
+            return
         if game:
             game.draw_card(target, 2)
         elif deck:

--- a/bang_py/cards/tequila.py
+++ b/bang_py/cards/tequila.py
@@ -2,10 +2,9 @@
 health."""
 
 from __future__ import annotations
-
 from .card import BaseCard
 from ..player import Player
-from typing import TYPE_CHECKING
+from typing import Any, TYPE_CHECKING, override
 from ..helpers import handle_out_of_turn_discard
 
 if TYPE_CHECKING:
@@ -20,13 +19,15 @@ class TequilaCard(BaseCard):
     card_set = "fistful_of_cards"
     description = "Discard another card with Tequila to heal 1 health."
 
+    @override
     def play(
         self,
-        target: Player,
+        target: Player | None,
         player: Player | None = None,
         game: GameManager | None = None,
         *,
         discard_idx: int = 0,
+        **kwargs: Any,
     ) -> None:
         if not target or not player or not game or not player.hand:
             return

--- a/bang_py/cards/volcanic.py
+++ b/bang_py/cards/volcanic.py
@@ -1,7 +1,7 @@
 """Volcanic card from the base game. Gun with range 1. Allows unlimited Bang! cards per turn."""
 
 from __future__ import annotations
-
+from typing import Any, override
 from .card import BaseCard
 from ..player import Player
 
@@ -19,7 +19,8 @@ class VolcanicCard(BaseCard):
         super().__init__(suit, rank)
         self.active = True
 
-    def play(self, target: Player) -> None:
+    @override
+    def play(self, target: Player | None, **kwargs: Any) -> None:
         if not target:
             return
         target.equip(self, active=self.active)

--- a/bang_py/cards/wells_fargo.py
+++ b/bang_py/cards/wells_fargo.py
@@ -1,10 +1,9 @@
 """Wells Fargo card from the base game. Draw three cards."""
 
 from __future__ import annotations
-
 from .card import BaseCard
 from ..player import Player
-from typing import TYPE_CHECKING
+from typing import Any, TYPE_CHECKING, override
 
 if TYPE_CHECKING:
     from ..deck import Deck
@@ -17,9 +16,16 @@ class WellsFargoCard(BaseCard):
     card_set = "base"
     description = "Draw three cards."
 
+    @override
     def play(
-        self, target: Player, game: GameManager | None = None, deck: Deck | None = None
+        self,
+        target: Player | None,
+        game: GameManager | None = None,
+        deck: Deck | None = None,
+        **kwargs: Any,
     ) -> None:
+        if not target:
+            return
         if game:
             game.draw_card(target, 3)
         elif deck:

--- a/bang_py/cards/whisky.py
+++ b/bang_py/cards/whisky.py
@@ -2,10 +2,9 @@
 health."""
 
 from __future__ import annotations
-
 from .card import BaseCard
 from ..player import Player
-from typing import TYPE_CHECKING
+from typing import Any, TYPE_CHECKING, override
 from ..helpers import handle_out_of_turn_discard
 
 if TYPE_CHECKING:
@@ -20,13 +19,15 @@ class WhiskyCard(BaseCard):
     card_set = "fistful_of_cards"
     description = "Discard another card with Whisky to heal 2 health."
 
+    @override
     def play(
         self,
-        target: Player,
+        target: Player | None,
         player: Player | None = None,
         game: GameManager | None = None,
         *,
         discard_idx: int = 0,
+        **kwargs: Any,
     ) -> None:
         if not target or not player or not game or not player.hand:
             return

--- a/bang_py/cards/winchester.py
+++ b/bang_py/cards/winchester.py
@@ -1,7 +1,7 @@
 """Winchester card from the base game. Gun with range 5."""
 
 from __future__ import annotations
-
+from typing import Any, override
 from .card import BaseCard
 from ..player import Player
 
@@ -17,7 +17,8 @@ class WinchesterCard(BaseCard):
         super().__init__(suit, rank)
         self.active = True
 
-    def play(self, target: Player) -> None:
+    @override
+    def play(self, target: Player | None, **kwargs: Any) -> None:
         if not target:
             return
         target.equip(self, active=self.active)


### PR DESCRIPTION
## Summary
- Update all card `play` methods to accept `Player | None` targets and arbitrary keyword arguments
- Ensure cards handle optional targets safely

## Testing
- `pre-commit run --files bang_py/cards/winchester.py`
- `pre-commit run black --files <many files>`
- `pre-commit run flake8 --files <many files>`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689662355fac83238372084245478bb5