### PR TITLE
Define discard card hook in protocol and clean handler mixins

### DIFF
--- a/bang_py/card_handlers/bang_handlers.py
+++ b/bang_py/card_handlers/bang_handlers.py
@@ -18,7 +18,7 @@ class BangHandlersMixin:
     """Mixin providing Bang-specific card resolution helpers."""
 
     def _play_bang_card(
-        self: GameManagerProtocol,
+        self,
         player: "Player",
         card: BangCard,
         target: "Player" | None,
@@ -67,7 +67,7 @@ class BangHandlersMixin:
         if not self.event_flags.get("river"):
             handle_out_of_turn_discard(self, player, card)
 
-    def _auto_miss(self: GameManagerProtocol, target: "Player") -> bool:
+    def _auto_miss(self, target: "Player") -> bool:
         """Attempt to satisfy a Bang! with automatic Missed! effects."""
         if not self._should_use_auto_miss(target):
             return False
@@ -85,7 +85,7 @@ class BangHandlersMixin:
             return False
         return target.metadata.auto_miss is not False
 
-    def _use_miss_card(self: GameManagerProtocol, target: "Player") -> bool:
+    def _use_miss_card(self, target: "Player") -> bool:
         """Use a Missed! card from ``target`` if available."""
         miss = next((c for c in target.hand if isinstance(c, MissedCard)), None)
         if miss:
@@ -95,7 +95,7 @@ class BangHandlersMixin:
             return True
         return False
 
-    def _use_bang_as_miss(self: GameManagerProtocol, target: "Player") -> bool:
+    def _use_bang_as_miss(self, target: "Player") -> bool:
         """Use a Bang! card as a Missed! if allowed."""
         if target.metadata.bang_as_missed:
             bang = next((c for c in target.hand if isinstance(c, BangCard)), None)
@@ -106,7 +106,7 @@ class BangHandlersMixin:
                 return True
         return False
 
-    def _use_any_card_as_miss(self: GameManagerProtocol, target: "Player") -> bool:
+    def _use_any_card_as_miss(self, target: "Player") -> bool:
         """Use any card as a Missed! if permitted by effects."""
         if target.metadata.any_card_as_missed and target.hand:
             card = target.hand.pop()

--- a/bang_py/card_handlers/dispatch.py
+++ b/bang_py/card_handlers/dispatch.py
@@ -109,7 +109,7 @@ class DispatchMixin:
         register_handler_groups(self, groups or HANDLER_MODULES.keys())
 
     def _dispatch_play(
-        self: GameManagerProtocol,
+        self,
         player: "Player",
         card: BaseCard,
         target: "Player" | None,

--- a/bang_py/game_manager_protocol.py
+++ b/bang_py/game_manager_protocol.py
@@ -47,6 +47,9 @@ class GameManagerProtocol(Protocol):
     def _pass_left_or_discard(self, player: Player, card: BaseCard) -> None:
         """Discard ``card`` or pass it left based on active events."""
 
+    def discard_card(self, player: Player, card: BaseCard) -> None:
+        """Remove ``card`` from ``player``'s hand and discard it."""
+
     def play_card(self, player: Player, card: BaseCard, target: Player | None = None) -> None:
         """Play ``card`` from ``player`` targeting ``target`` if provided."""
 


### PR DESCRIPTION
## Summary
- expose `discard_card` on `GameManagerProtocol`
- drop stale `GameManagerProtocol` annotations from internal handler helpers
- simplify dispatch mixin play routing

## Testing
- `pre-commit run --files bang_py/game_manager_protocol.py bang_py/card_handlers/dispatch.py bang_py/card_handlers/bang_handlers.py` *(failed: mypy - Found 105 errors in 26 files)*
- `pytest` *(failed: NameError: name 'cards' is not defined in general_store.py)*

------
https://chatgpt.com/codex/tasks/task_e_689671dc814c832395fb0f61fb376cc8