### PR TITLE
Initialize Molly Stark choice metadata

### DIFF
--- a/bang_py/characters/molly_stark.py
+++ b/bang_py/characters/molly_stark.py
@@ -1,4 +1,5 @@
 """Draw when playing or discarding out of turn, including Duels. Dodge City expansion."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -21,6 +22,7 @@ class MollyStark(BaseCharacter):
 
     def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
         player.metadata.abilities.add(MollyStark)
+        player.metadata.molly_choices = {}
         return True
 
     def on_out_of_turn_discard(self, gm: "GameManager", player: "Player", card: "BaseCard") -> None:

--- a/bang_py/player.py
+++ b/bang_py/player.py
@@ -33,6 +33,7 @@ class PlayerMetadata:
     kit_cards: list["BaseCard"] | None = None
     lucky_cards: list["BaseCard"] | None = None
     gringo_index: int | None = None
+    molly_choices: dict[int, bool] | None = None
     uncle_used: bool = False
     vera_copy: type["BaseCharacter"] | None = None
     unused_character: "BaseCharacter | None" = None


### PR DESCRIPTION
## Summary
- ensure Molly Stark's ability initializes `molly_choices` metadata
- add `molly_choices` field to player metadata

## Testing
- `SKIP=mypy pre-commit run --files bang_py/player.py bang_py/characters/molly_stark.py`
- `pytest` *(fails: NameError: name 'cards' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68967491dd8883239f38a1d7cc2cef40