### PR TITLE
Annotate character draw listeners with object options

### DIFF
--- a/bang_py/characters/bill_noface.py
+++ b/bang_py/characters/bill_noface.py
@@ -1,4 +1,5 @@
 """Draw one plus your wounds during phase 1. Dodge City expansion."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -12,15 +13,13 @@ if TYPE_CHECKING:  # pragma: no cover - for type hints only
 
 class BillNoface(BaseCharacter):
     name = "Bill Noface"
-    description = (
-        "During phase 1 of your turn, draw 1 card plus 1 for each wound you have."
-    )
+    description = "During phase 1 of your turn, draw 1 card plus 1 for each wound you have."
     starting_health = 4
 
     def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
         player.metadata.abilities.add(BillNoface)
 
-        def on_draw(p: "Player", _opts: dict) -> bool:
+        def on_draw(p: "Player", _opts: object) -> bool:
             if p is not player:
                 return True
             wounds = player.max_health - player.health

--- a/bang_py/characters/claus_the_saint.py
+++ b/bang_py/characters/claus_the_saint.py
@@ -1,4 +1,5 @@
 """Draw for all, keep two, gift the rest. Bullet expansion exclusive."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -21,7 +22,7 @@ class ClausTheSaint(BaseCharacter):
     def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
         player.metadata.abilities.add(ClausTheSaint)
 
-        def on_draw(p: "Player", _opts: dict) -> bool:
+        def on_draw(p: "Player", _opts: object) -> bool:
             if p is not player:
                 return True
             alive = [pl for pl in gm.players if pl.is_alive()]

--- a/bang_py/characters/jesse_jones.py
+++ b/bang_py/characters/jesse_jones.py
@@ -1,4 +1,5 @@
 """Steal a card instead of drawing the first. Core set."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -21,13 +22,14 @@ class JesseJones(BaseCharacter):
     def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
         player.metadata.abilities.add(JesseJones)
 
-        def on_draw(p: "Player", opts: dict) -> bool:
+        def on_draw(p: "Player", opts: object) -> bool:
             if p is not player:
                 return True
             opponents = [t for t in gm.players if t is not player and t.hand]
             if opponents:
-                target = opts.get("jesse_target")
-                idx = opts.get("jesse_card", 0)
+                options: dict[str, object] = opts if isinstance(opts, dict) else {}
+                target = options.get("jesse_target")
+                idx = options.get("jesse_card", 0)
                 if target in opponents:
                     if idx is None or idx < 0 or idx >= len(target.hand):
                         idx = 0

--- a/bang_py/characters/jose_delgado.py
+++ b/bang_py/characters/jose_delgado.py
@@ -1,4 +1,5 @@
 """Discard a blue card to draw two more. Dodge City expansion."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -18,12 +19,13 @@ class JoseDelgado(BaseCharacter):
     def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
         player.metadata.abilities.add(JoseDelgado)
 
-        def on_draw(p: "Player", opts: dict) -> bool:
+        def on_draw(p: "Player", opts: object) -> bool:
             if p is not player:
                 return True
             equips = [c for c in player.hand if hasattr(c, "slot")]
             equip = None
-            sel = opts.get("jose_equipment")
+            options: dict[str, object] = opts if isinstance(opts, dict) else {}
+            sel = options.get("jose_equipment")
             if sel is not None and 0 <= sel < len(equips):
                 equip = equips[sel]
             elif equips:

--- a/bang_py/characters/pat_brennan.py
+++ b/bang_py/characters/pat_brennan.py
@@ -1,4 +1,5 @@
 """Draw a card from play instead of the deck. Dodge City expansion."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -20,11 +21,12 @@ class PatBrennan(BaseCharacter):
     def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
         player.metadata.abilities.add(PatBrennan)
 
-        def on_draw(p: "Player", opts: dict) -> bool:
+        def on_draw(p: "Player", opts: object) -> bool:
             if p is not player:
                 return True
-            target = opts.get("pat_target")
-            card_name = opts.get("pat_card")
+            options: dict[str, object] = opts if isinstance(opts, dict) else {}
+            target = options.get("pat_target")
+            card_name = options.get("pat_card")
             if not gm.pat_brennan_draw(player, target, card_name):
                 gm.draw_card(player)
             gm.draw_card(player)

--- a/bang_py/characters/pedro_ramirez.py
+++ b/bang_py/characters/pedro_ramirez.py
@@ -1,4 +1,5 @@
 """May draw the top discard instead of from the deck. Core set."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -21,10 +22,11 @@ class PedroRamirez(BaseCharacter):
     def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
         player.metadata.abilities.add(PedroRamirez)
 
-        def on_draw(p: "Player", opts: dict) -> bool:
+        def on_draw(p: "Player", opts: object) -> bool:
             if p is not player or not gm.discard_pile:
                 return True
-            use_discard = opts.get("pedro_use_discard", True)
+            options: dict[str, object] = opts if isinstance(opts, dict) else {}
+            use_discard = bool(options.get("pedro_use_discard", True))
             if use_discard:
                 player.hand.append(gm.discard_pile.pop())
                 gm.draw_card(player)

--- a/bang_py/characters/pixie_pete.py
+++ b/bang_py/characters/pixie_pete.py
@@ -1,4 +1,5 @@
 """Draw three cards during phase 1. Dodge City expansion."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -18,7 +19,7 @@ class PixiePete(BaseCharacter):
     def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
         player.metadata.abilities.add(PixiePete)
 
-        def on_draw(p: "Player", _opts: dict) -> bool:
+        def on_draw(p: "Player", _opts: object) -> bool:
             if p is not player:
                 return True
             gm.draw_card(player, 3)


### PR DESCRIPTION
## Summary
- type listener closures in character abilities to accept generic `object` options
- cast option objects to dictionaries when options are consumed

## Testing
- `pre-commit run --files bang_py/characters/pixie_pete.py bang_py/characters/claus_the_saint.py bang_py/characters/bill_noface.py bang_py/characters/pedro_ramirez.py bang_py/characters/pat_brennan.py bang_py/characters/jose_delgado.py bang_py/characters/jesse_jones.py` *(fails: mypy reports missing attributes)*
- `pytest` *(fails: NameError: name 'cards' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_689676ee1844832380505c2d93b8acca