### PR TITLE
Handle missing character when copying ability

### DIFF
--- a/bang_py/ability_dispatch.py
+++ b/bang_py/ability_dispatch.py
@@ -82,7 +82,7 @@ class AbilityDispatchMixin:
         """Copy another living character's ability for the turn."""
         if not isinstance(player.character, VeraCuster):
             return
-        if not target.is_alive() or target is player:
+        if not target.is_alive() or target is player or target.character is None:
             return
         player.metadata.vera_copy = target.character.__class__
         player.metadata.abilities.add(target.character.__class__)

--- a/bang_py/characters/vera_custer.py
+++ b/bang_py/characters/vera_custer.py
@@ -1,4 +1,5 @@
 """Copy another living character's ability each turn. Dodge City expansion."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -19,10 +20,8 @@ class VeraCuster(BaseCharacter):
         player.metadata.abilities.add(VeraCuster)
         return True
 
-    def copy_ability(
-        self, gm: "GameManager", player: "Player", target: "Player"
-    ) -> bool:
-        if not target.is_alive() or target is player:
+    def copy_ability(self, gm: "GameManager", player: "Player", target: "Player") -> bool:
+        if not target.is_alive() or target is player or target.character is None:
             return True
         player.metadata.vera_copy = target.character.__class__
         player.metadata.abilities.add(target.character.__class__)


### PR DESCRIPTION
## Summary
- Avoid copying abilities from players without a character
- Skip Vera Custer's copy action if the target has no character

## Testing
- `pre-commit run --files bang_py/characters/vera_custer.py bang_py/ability_dispatch.py` *(fails: mypy errors in unrelated files)*
- `pre-commit run black --files bang_py/characters/vera_custer.py bang_py/ability_dispatch.py`
- `pre-commit run flake8 --files bang_py/characters/vera_custer.py bang_py/ability_dispatch.py`
- `pytest` *(fails: NameError: name 'cards' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68967a03185c8323a0d4ed10155a6456