### PR TITLE
Fix equipment property typing

### DIFF
--- a/bang_py/player.py
+++ b/bang_py/player.py
@@ -63,7 +63,7 @@ class Player:
     max_health: int = 4
     _health: int = field(init=False, repr=False)
     _metadata: PlayerMetadata = field(default_factory=PlayerMetadata, init=False, repr=False)
-    _equipment: dict[str, "BaseCard"] = field(default_factory=dict, init=False, repr=False)
+    _equipment: dict[str, BaseCard] = field(default_factory=dict, init=False, repr=False)
     hand: list["BaseCard"] = field(default_factory=list)
 
     def __post_init__(self) -> None:
@@ -76,7 +76,7 @@ class Player:
         return self._metadata
 
     @property
-    def equipment(self) -> Mapping[str, "BaseCard"]:
+    def equipment(self) -> Mapping[str, BaseCard]:
         """Mapping of currently equipped cards (read-only)."""
         return MappingProxyType(self._equipment)
 


### PR DESCRIPTION
## Summary
- annotate Player.equipment as Mapping[str, BaseCard] and align _equipment type

## Testing
- `SKIP=mypy pre-commit run --files bang_py/player.py`
- `pytest` *(fails: NameError: name 'cards' is not defined in bang_py/general_store.py)*

------
https://chatgpt.com/codex/tasks/task_e_68967a03e68c8323b2ace47ffcdaa134