### PR TITLE
Declare additional mixin hooks in GameManager protocol

### DIFF
--- a/bang_py/card_handlers/dispatch.py
+++ b/bang_py/card_handlers/dispatch.py
@@ -20,7 +20,6 @@ from ..helpers import handle_out_of_turn_discard
 from ..game_manager_protocol import GameManagerProtocol
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
-    from ..game_manager import GameManager
     from ..player import Player
 
 HANDLER_MODULES = {
@@ -31,7 +30,7 @@ HANDLER_MODULES = {
 }
 
 
-def register_handler_groups(game: "GameManager", groups: Iterable[str]) -> None:
+def register_handler_groups(game: GameManagerProtocol, groups: Iterable[str]) -> None:
     """Import handler modules for ``groups`` and register them on ``game``."""
     for group in groups:
         module = import_module(HANDLER_MODULES[group])
@@ -109,7 +108,7 @@ class DispatchMixin:
         register_handler_groups(self, groups or HANDLER_MODULES.keys())
 
     def _dispatch_play(
-        self,
+        self: GameManagerProtocol,
         player: "Player",
         card: BaseCard,
         target: "Player" | None,
@@ -137,7 +136,9 @@ class DispatchMixin:
 
     # ------------------------------------------------------------------
     # Card play utilities
-    def _pre_card_checks(self, player: "Player", card: BaseCard, target: "Player" | None) -> bool:
+    def _pre_card_checks(
+        self: GameManagerProtocol, player: "Player", card: BaseCard, target: "Player" | None
+    ) -> bool:
         return (
             self._card_in_hand(player, card)
             and self._run_card_play_checks(player, card, target)
@@ -228,7 +229,9 @@ class DispatchMixin:
         active = self._players[idx]
         return player is active and getattr(card, "suit", None) != self.event_flags["turn_suit"]
 
-    def _is_bang(self, player: "Player", card: BaseCard, target: "Player" | None) -> bool:
+    def _is_bang(
+        self: GameManagerProtocol, player: "Player", card: BaseCard, target: "Player" | None
+    ) -> bool:
         return bool(
             isinstance(card, BangCard)
             or (player.metadata.play_missed_as_bang and isinstance(card, MissedCard) and target)

--- a/bang_py/game_manager_protocol.py
+++ b/bang_py/game_manager_protocol.py
@@ -47,6 +47,12 @@ class GameManagerProtocol(Protocol):
     def _pass_left_or_discard(self, player: Player, card: BaseCard) -> None:
         """Discard ``card`` or pass it left based on active events."""
 
+    def _hand_limit(self, player: Player) -> int:
+        """Return the maximum hand size for ``player``."""
+
+    def _discard_to_limit(self, player: Player, limit: int) -> None:
+        """Discard cards from ``player`` until ``limit`` is met."""
+
     def discard_card(self, player: Player, card: BaseCard) -> None:
         """Remove ``card`` from ``player``'s hand and discard it."""
 
@@ -65,6 +71,12 @@ class GameManagerProtocol(Protocol):
     def _check_win_conditions(self) -> None:
         """Verify whether the game has ended."""
 
+    def _deal_general_store_cards(self) -> list[BaseCard]:
+        """Deal cards for the General Store."""
+
+    def _set_general_store_order(self, player: Player) -> None:
+        """Initialize General Store pick order starting with ``player``."""
+
     def reset_turn_flags(self, player: Player) -> None:
         """Reset per-turn ability flags on ``player``."""
 
@@ -80,6 +92,15 @@ class GameManagerProtocol(Protocol):
     def _apply_event_start_effects(self, player: Player) -> Player | None:
         """Apply start-of-turn event effects returning the acting player."""
 
+    def _reactivate_green_equipment(self, player: Player) -> None:
+        """Reactivate green equipment on ``player``."""
+
+    def _resolve_dynamite(self, player: Player) -> bool:
+        """Return ``False`` if Dynamite eliminates ``player``."""
+
+    def _run_start_turn_checks(self, player: Player) -> Player | None:
+        """Run start-of-turn checks returning the acting player or ``None``."""
+
     def _maybe_revive_ghost_town(self, player: Player) -> bool:
         """Return True if Ghost Town revives ``player``."""
 
@@ -91,6 +112,33 @@ class GameManagerProtocol(Protocol):
 
     def prompt_new_identity(self, player: Player) -> bool:
         """Prompt ``player`` to swap characters during New Identity."""
+
+    def _pre_card_checks(self, player: Player, card: BaseCard, target: Player | None) -> bool:
+        """Return ``True`` if ``player`` may play ``card`` on ``target``."""
+
+    def _is_bang(self, player: Player, card: BaseCard, target: Player | None) -> bool:
+        """Return ``True`` if playing ``card`` counts as a Bang!."""
+
+    def _dispatch_play(self, player: Player, card: BaseCard, target: Player | None) -> None:
+        """Dispatch ``card`` to its handler."""
+
+    def _update_bang_counters(self, player: Player) -> None:
+        """Update per-turn Bang! counters for ``player``."""
+
+    def _current_player_obj(self) -> Player | None:
+        """Return the player whose turn it currently is."""
+
+    def _reindex_turn_order(self, removed_idx: int) -> None:
+        """Rebuild turn order after removing ``removed_idx``."""
+
+    def _deal_roles_and_characters(self) -> None:
+        """Assign roles and characters to all players."""
+
+    def _next_alive_player(self, player: Player) -> Player | None:
+        """Return the next living player to the left of ``player``."""
+
+    def _get_player_by_index(self, idx: int) -> Player | None:
+        """Return the player at ``idx`` if it exists."""
 
 
 __all__ = ["GameManagerProtocol"]

--- a/bang_py/general_store.py
+++ b/bang_py/general_store.py
@@ -31,7 +31,6 @@ class GeneralStoreMixin:
         self._set_general_store_order(player)
         return [c.card_name for c in self.general_store_cards or []]
 
-
     def _deal_general_store_cards(self: GameManagerProtocol) -> list[BaseCard]:
         alive = [p for p in self._players if p.is_alive()]
         cards: list[BaseCard] = []
@@ -64,6 +63,8 @@ class GeneralStoreMixin:
         return True
 
     def _valid_general_store_pick(self: GameManagerProtocol, player: "Player", index: int) -> bool:
+        cards = self.general_store_cards
+        order = self.general_store_order
         if (
             not cards
             or not order

--- a/bang_py/turn_phases/discard_phase.py
+++ b/bang_py/turn_phases/discard_phase.py
@@ -22,7 +22,7 @@ class DiscardPhaseMixin:
         limit = self._hand_limit(player)
         self._discard_to_limit(player, limit)
 
-    def _hand_limit(self, player: "Player") -> int:
+    def _hand_limit(self: GameManagerProtocol, player: "Player") -> int:
         limit = player.health
         if player.metadata.hand_limit is not None:
             limit = max(limit, player.metadata.hand_limit)
@@ -32,7 +32,7 @@ class DiscardPhaseMixin:
             limit = min(limit, int(self.event_flags["reverend_limit"]))
         return limit
 
-    def _discard_to_limit(self, player: "Player", limit: int) -> None:
+    def _discard_to_limit(self: GameManagerProtocol, player: "Player", limit: int) -> None:
         while len(player.hand) > limit:
             card = player.hand.pop()
             if self.event_flags.get("abandoned_mine"):


### PR DESCRIPTION
## Summary
- extend `GameManagerProtocol` with mixin hooks for discard limits, general store handling, turn start effects, card dispatch, and turn order helpers
- switch mixins like `EventHooksMixin` and `DispatchMixin` to import and use `GameManagerProtocol`
- repair general store pick validation to reference stored cards

## Testing
- `pre-commit run --files bang_py/game_manager_protocol.py bang_py/events/event_hooks.py bang_py/card_handlers/dispatch.py bang_py/turn_phases/discard_phase.py bang_py/general_store.py` *(mypy skipped: repository has existing type errors)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68967e296eac8323b5c5f8dbba607529