### PR TITLE
Refactor deck management typing

### DIFF
--- a/bang_py/deck_manager.py
+++ b/bang_py/deck_manager.py
@@ -75,7 +75,8 @@ class DeckManagerMixin:
 
     # ------------------------------------------------------------------
     # Setup helpers
-    def _build_role_deck(self: GameManagerProtocol) -> list[BaseRole]:
+    def _build_role_deck(self: GameManagerProtocol) -> list[type[BaseRole]]:
+        """Return role classes for the current player count."""
         role_map = {
             3: [DeputyRoleCard, OutlawRoleCard, RenegadeRoleCard],
             4: [SheriffRoleCard, RenegadeRoleCard, OutlawRoleCard, OutlawRoleCard],
@@ -117,7 +118,7 @@ class DeckManagerMixin:
         classes = role_map.get(len(self._players))
         if not classes:
             raise ValueError("Unsupported player count")
-        return [cls() for cls in classes]
+        return list(classes)
 
     def _build_character_deck(self: GameManagerProtocol) -> list[type[BaseCharacter]]:
         from . import characters
@@ -131,12 +132,12 @@ class DeckManagerMixin:
         return options[0]
 
     def _deal_roles_and_characters(self: GameManagerProtocol) -> None:
-        role_deck = self._build_role_deck()
-        random.shuffle(role_deck)
+        role_classes = self._build_role_deck()
+        random.shuffle(role_classes)
         char_deck = [cls() for cls in self._build_character_deck()]
         random.shuffle(char_deck)
         for player in self._players:
-            player.role = role_deck.pop()
+            player.role = role_classes.pop()()
             choices = [char_deck.pop(), char_deck.pop()]
             chosen = self.choose_character(player, choices)
             player.character = chosen

--- a/bang_py/game_manager_protocol.py
+++ b/bang_py/game_manager_protocol.py
@@ -8,6 +8,8 @@ from typing import Protocol, TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - imported for type checking
     from .cards.card import BaseCard
+    from .cards.roles import BaseRole
+    from .characters.base import BaseCharacter
     from .deck import Deck
     from .events.event_decks import EventCard
     from .player import Player
@@ -136,6 +138,15 @@ class GameManagerProtocol(Protocol):
 
     def _reindex_turn_order(self, removed_idx: int) -> None:
         """Rebuild turn order after removing ``removed_idx``."""
+
+    def _build_role_deck(self) -> list[type[BaseRole]]:
+        """Return role classes for the current player count."""
+
+    def _build_character_deck(self) -> list[type[BaseCharacter]]:
+        """Return available character classes."""
+
+    def choose_character(self, player: Player, options: list[BaseCharacter]) -> BaseCharacter:
+        """Select the character for ``player`` from ``options``."""
 
     def _deal_roles_and_characters(self) -> None:
         """Assign roles and characters to all players."""


### PR DESCRIPTION
## Summary
- build role decks from concrete role classes and instantiate when dealing
- expose role and character deck builders and selection hooks on GameManagerProtocol

## Testing
- `SKIP=mypy pre-commit run --files bang_py/deck_manager.py bang_py/game_manager_protocol.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896851bfb2c8323a5caa22c1030abff