### PR TITLE
Validate ability callback payloads

### DIFF
--- a/bang_py/characters/bart_cassidy.py
+++ b/bang_py/characters/bart_cassidy.py
@@ -1,4 +1,5 @@
 """Draw a card whenever you lose a life point. Core set."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -12,15 +13,13 @@ if TYPE_CHECKING:  # pragma: no cover - for type hints only
 
 class BartCassidy(BaseCharacter):
     name = "Bart Cassidy"
-    description = (
-        "When you lose a life point, draw a card from the deck."
-    )
+    description = "When you lose a life point, draw a card from the deck."
     starting_health = 4
 
     def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
         player.metadata.abilities.add(BartCassidy)
 
-        def on_damaged(p: "Player", _src: "Player | None", *__: object) -> None:
+        def on_damaged(p: "Player", _src: "Player | None") -> None:
             if p is player:
                 gm.draw_card(player)
 

--- a/bang_py/characters/el_gringo.py
+++ b/bang_py/characters/el_gringo.py
@@ -1,4 +1,5 @@
 """Steal a card from your attacker when wounded. Core set."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -21,7 +22,7 @@ class ElGringo(BaseCharacter):
     def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
         player.metadata.abilities.add(ElGringo)
 
-        def on_damaged(p: "Player", src: "Player | None", *__: object) -> None:
+        def on_damaged(p: "Player", src: "Player | None") -> None:
             if p is player and src and src.hand:
                 idx = player.metadata.gringo_index or 0
                 if idx < 0 or idx >= len(src.hand):

--- a/bang_py/characters/jesse_jones.py
+++ b/bang_py/characters/jesse_jones.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from ..player import Player
 from .base import BaseCharacter
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from ..game_manager import GameManager
-    from ..player import Player
 
 
 class JesseJones(BaseCharacter):
@@ -28,12 +28,14 @@ class JesseJones(BaseCharacter):
             opponents = [t for t in gm.players if t is not player and t.hand]
             if opponents:
                 options: dict[str, object] = opts if isinstance(opts, dict) else {}
-                target = options.get("jesse_target")
-                idx = options.get("jesse_card", 0)
-                if target in opponents:
-                    if idx is None or idx < 0 or idx >= len(target.hand):
+                target_obj = options.get("jesse_target")
+                target_pl = target_obj if isinstance(target_obj, Player) else None
+                idx_obj = options.get("jesse_card", 0)
+                idx = idx_obj if isinstance(idx_obj, int) else 0
+                if target_pl in opponents:
+                    if idx < 0 or idx >= len(target_pl.hand):
                         idx = 0
-                    card = target.hand.pop(idx)
+                    card = target_pl.hand.pop(idx)
                     player.hand.append(card)
                     gm.draw_card(player)
                 else:

--- a/bang_py/characters/jose_delgado.py
+++ b/bang_py/characters/jose_delgado.py
@@ -26,7 +26,7 @@ class JoseDelgado(BaseCharacter):
             equip = None
             options: dict[str, object] = opts if isinstance(opts, dict) else {}
             sel = options.get("jose_equipment")
-            if sel is not None and 0 <= sel < len(equips):
+            if isinstance(sel, int) and 0 <= sel < len(equips):
                 equip = equips[sel]
             elif equips:
                 equip = equips[0]

--- a/bang_py/characters/pat_brennan.py
+++ b/bang_py/characters/pat_brennan.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from ..player import Player
 from .base import BaseCharacter
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from ..game_manager import GameManager
-    from ..player import Player
 
 
 class PatBrennan(BaseCharacter):
@@ -25,9 +25,11 @@ class PatBrennan(BaseCharacter):
             if p is not player:
                 return True
             options: dict[str, object] = opts if isinstance(opts, dict) else {}
-            target = options.get("pat_target")
-            card_name = options.get("pat_card")
-            if not gm.pat_brennan_draw(player, target, card_name):
+            target_obj = options.get("pat_target")
+            target_pl = target_obj if isinstance(target_obj, Player) else None
+            card_obj = options.get("pat_card")
+            card_name = card_obj if isinstance(card_obj, str) else None
+            if not gm.pat_brennan_draw(player, target_pl, card_name):
                 gm.draw_card(player)
             gm.draw_card(player)
             return True


### PR DESCRIPTION
## Summary
- validate player targets and card names in ability dispatch helpers
- cast or sanitize ability event payloads to concrete types
- simplify damage callbacks for Bart Cassidy and El Gringo

## Testing
- `SKIP=mypy pre-commit run --files bang_py/ability_dispatch.py bang_py/characters/bart_cassidy.py bang_py/characters/el_gringo.py bang_py/characters/jesse_jones.py bang_py/characters/jose_delgado.py bang_py/characters/pat_brennan.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689687f0ae7c832398de5032ba1f8dee