### PR TITLE
Add GameManager hooks for turn start checks

### DIFF
--- a/bang_py/cards/bang.py
+++ b/bang_py/cards/bang.py
@@ -9,6 +9,7 @@ from ..characters.jourdonnais import Jourdonnais
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from ..deck import Deck
+    from ..game_manager_protocol import GameManagerProtocol
 
 
 class BangCard(BaseCard):
@@ -23,18 +24,20 @@ class BangCard(BaseCard):
         target: Player | None,
         deck: Deck | None = None,
         *,
+        game: "GameManagerProtocol" | None = None,
         ignore_equipment: bool = False,
         **kwargs: Any,
     ) -> None:
         if not target:
             return
-        if deck and not ignore_equipment:
+        gm = game or target.metadata.game if target else None
+        if gm and not ignore_equipment:
             barrel = target.equipment.get("Barrel")
-            if isinstance(barrel, BarrelCard) and barrel.draw_check(deck, target):
+            if isinstance(barrel, BarrelCard) and barrel.draw_check(gm, target):
                 target.metadata.dodged = True
                 return
             if isinstance(target.character, Jourdonnais) or target.metadata.virtual_barrel:
-                if BarrelCard().draw_check(deck, target):
+                if BarrelCard().draw_check(gm, target):
                     target.metadata.dodged = True
                     return
         target.take_damage(1)

--- a/bang_py/cards/barrel.py
+++ b/bang_py/cards/barrel.py
@@ -10,6 +10,7 @@ from ..helpers import is_heart
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from ..deck import Deck
+    from ..game_manager_protocol import GameManagerProtocol
 
 
 class BarrelCard(BaseCard):
@@ -27,20 +28,19 @@ class BarrelCard(BaseCard):
             return
         target.equip(self, active=self.active)
 
-    def draw_check(self, deck: Deck, player: Player | None = None) -> bool:
+    @override
+    def draw_check(self, gm: "GameManagerProtocol", player: Player) -> bool:
         """Perform the Barrel draw! check, returning True if Bang! is dodged."""
-        gm = player.metadata.game if player else None
-        if player and player.metadata.lucky_duke:
-            card1 = deck.draw()
-            card2 = deck.draw()
+        if player.metadata.lucky_duke:
+            card1 = gm._draw_from_deck()
+            card2 = gm._draw_from_deck()
             chosen = card1 if is_heart(card1) or not is_heart(card2) else card2
-            if gm:
-                if card1:
-                    gm.discard_pile.append(card1)
-                if card2:
-                    gm.discard_pile.append(card2)
+            if card1:
+                gm.discard_pile.append(card1)
+            if card2:
+                gm.discard_pile.append(card2)
             return is_heart(chosen)
-        card = deck.draw()
-        if gm and card:
+        card = gm._draw_from_deck()
+        if card:
             gm.discard_pile.append(card)
         return is_heart(card)

--- a/bang_py/cards/buffalo_rifle.py
+++ b/bang_py/cards/buffalo_rifle.py
@@ -7,7 +7,6 @@ from typing import Any, TYPE_CHECKING, override
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from ..game_manager import GameManager
-    from ..deck import Deck
 
 from .bang import BangCard
 
@@ -26,18 +25,16 @@ class BuffaloRifleCard(BaseCard):
         target: Player | None,
         player: Player | None = None,
         game: GameManager | None = None,
-        deck: Deck | None = None,
         **kwargs: Any,
     ) -> None:
         if not target:
             return
-        d = deck or (game.deck if game else None)
         if game and game._auto_miss(target):
             return
         before = target.health
         BangCard().play(
             target,
-            d,
+            game=game,
             ignore_equipment=player.metadata.ignore_others_equipment if player else False,
         )
         if game and player and target.health < before:

--- a/bang_py/cards/card.py
+++ b/bang_py/cards/card.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - import for type checking only
     from ..player import Player
-    from ..deck import Deck
+    from ..game_manager_protocol import GameManagerProtocol
 
 
 class BaseCard(ABC):
@@ -35,6 +35,14 @@ class BaseCard(ABC):
         # changing the base class signature.
         raise NotImplementedError
 
-    def draw_check(self, deck: "Deck", player: "Player" | None = None) -> bool:
+    def check_dynamite(self, gm: "GameManagerProtocol", player: "Player") -> bool:
+        """Hook for start-of-turn Dynamite checks. Default implementation."""
+        return False
+
+    def check_turn(self, gm: "GameManagerProtocol", player: "Player") -> bool:
+        """Hook for start-of-turn Jail checks. Default implementation."""
+        return False
+
+    def draw_check(self, gm: "GameManagerProtocol", player: "Player") -> bool:
         """Hook for cards that perform a draw! check. Default implementation."""
         return False

--- a/bang_py/cards/derringer.py
+++ b/bang_py/cards/derringer.py
@@ -7,7 +7,6 @@ from typing import Any, TYPE_CHECKING, override
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from ..game_manager import GameManager
-    from ..deck import Deck
 
 from .bang import BangCard
 
@@ -26,21 +25,19 @@ class DerringerCard(BaseCard):
         target: Player | None,
         player: Player | None = None,
         game: GameManager | None = None,
-        deck: Deck | None = None,
         **kwargs: Any,
     ) -> None:
         if not target or not player:
             return
         if player.distance_to(target) > 1:
             return
-        d = deck or (game.deck if game else None)
         if game and game._auto_miss(target):
             game.draw_card(player)
             return
         before = target.health
         BangCard().play(
             target,
-            d,
+            game=game,
             ignore_equipment=player.metadata.ignore_others_equipment if game else False,
         )
         if game and target.health < before:

--- a/bang_py/cards/gatling.py
+++ b/bang_py/cards/gatling.py
@@ -7,7 +7,6 @@ from typing import Any, TYPE_CHECKING, override
 
 if TYPE_CHECKING:
     from ..game_manager import GameManager
-    from ..deck import Deck
 
 
 class GatlingCard(BaseCard):
@@ -22,7 +21,6 @@ class GatlingCard(BaseCard):
         target: Player | None,
         player: Player | None = None,
         game: GameManager | None = None,
-        deck: Deck | None = None,
         **kwargs: Any,
     ) -> None:
         if not game or not player:
@@ -35,7 +33,7 @@ class GatlingCard(BaseCard):
 
             BangCard().play(
                 p,
-                deck or game.deck,
+                game=game,
                 ignore_equipment=player.metadata.ignore_others_equipment,
             )
             if p.health < before:

--- a/bang_py/cards/howitzer.py
+++ b/bang_py/cards/howitzer.py
@@ -7,7 +7,6 @@ from typing import Any, TYPE_CHECKING, override
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from ..game_manager import GameManager
-    from ..deck import Deck
 
 from .bang import BangCard
 
@@ -26,7 +25,6 @@ class HowitzerCard(BaseCard):
         target: Player | None,
         player: Player | None = None,
         game: GameManager | None = None,
-        deck: Deck | None = None,
         **kwargs: Any,
     ) -> None:
         if not game or not player:
@@ -37,7 +35,7 @@ class HowitzerCard(BaseCard):
             before = p.health
             BangCard().play(
                 p,
-                deck or game.deck,
+                game=game,
                 ignore_equipment=player.metadata.ignore_others_equipment,
             )
             if p.health < before:

--- a/bang_py/cards/jail.py
+++ b/bang_py/cards/jail.py
@@ -8,6 +8,7 @@ from ..helpers import is_heart
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from ..deck import Deck
+    from ..game_manager_protocol import GameManagerProtocol
 
 
 class JailCard(BaseCard):
@@ -25,25 +26,24 @@ class JailCard(BaseCard):
             return
         target.equip(self, active=self.active)
 
-    def check_turn(self, player: Player, deck: Deck) -> bool:
+    @override
+    def check_turn(self, gm: "GameManagerProtocol", player: Player) -> bool:
         """Handle start-of-turn Jail check.
 
         Returns True if the player's turn is skipped.
         """
-        gm = player.metadata.game
         if player.metadata.lucky_duke:
-            card1 = deck.draw()
-            card2 = deck.draw()
+            card1 = gm._draw_from_deck()
+            card2 = gm._draw_from_deck()
             chosen = card1 if is_heart(card1) or not is_heart(card2) else card2
-            if gm:
-                if card1:
-                    gm.discard_pile.append(card1)
-                if card2:
-                    gm.discard_pile.append(card2)
+            if card1:
+                gm.discard_pile.append(card1)
+            if card2:
+                gm.discard_pile.append(card2)
             result = is_heart(chosen)
         else:
-            card = deck.draw()
-            if gm and card:
+            card = gm._draw_from_deck()
+            if card:
                 gm.discard_pile.append(card)
             result = is_heart(card)
         player.unequip(self.card_name)

--- a/bang_py/cards/knife.py
+++ b/bang_py/cards/knife.py
@@ -31,12 +31,11 @@ class KnifeCard(BaseCard):
             return
         if player.distance_to(target) > 1:
             return
-        deck = game.deck if game else None
         if game and game._auto_miss(target):
             return
         BangCard().play(
             target,
-            deck,
+            game=game,
             ignore_equipment=player.metadata.ignore_others_equipment if game else False,
         )
         if game and target.health < target.max_health:

--- a/bang_py/cards/pepperbox.py
+++ b/bang_py/cards/pepperbox.py
@@ -7,7 +7,6 @@ from typing import Any, TYPE_CHECKING, override
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from ..game_manager import GameManager
-    from ..deck import Deck
 
 from .bang import BangCard
 
@@ -26,20 +25,18 @@ class PepperboxCard(BaseCard):
         target: Player | None,
         player: Player | None = None,
         game: GameManager | None = None,
-        deck: Deck | None = None,
         **kwargs: Any,
     ) -> None:
         if not target or not player:
             return
         if player.distance_to(target) > player.attack_range:
             return
-        d = deck or (game.deck if game else None)
         if game and game._auto_miss(target):
             return
         before = target.health
         BangCard().play(
             target,
-            d,
+            game=game,
             ignore_equipment=player.metadata.ignore_others_equipment if game else False,
         )
         if game and target.health < before:

--- a/bang_py/cards/springfield.py
+++ b/bang_py/cards/springfield.py
@@ -41,7 +41,7 @@ class SpringfieldCard(BaseCard):
         if not game._auto_miss(target):
             BangCard().play(
                 target,
-                game.deck,
+                game=game,
                 ignore_equipment=player.metadata.ignore_others_equipment,
             )
             if target.health < target.max_health:

--- a/bang_py/turn_phases/turn_flow.py
+++ b/bang_py/turn_phases/turn_flow.py
@@ -55,10 +55,8 @@ class TurnFlowMixin:
     def _resolve_dynamite(self: GameManagerProtocol, player: "Player") -> bool:
         """Handle Dynamite at turn start. Returns ``False`` if the player dies."""
         dyn = player.equipment.get("Dynamite")
-        if dyn and getattr(dyn, "check_dynamite", None):
-            next_idx = self.turn_order[(self.current_turn + 1) % len(self.turn_order)]
-            next_player = self._players[next_idx]
-            exploded = dyn.check_dynamite(player, next_player, self.deck)
+        if dyn and hasattr(dyn, "check_dynamite"):
+            exploded = dyn.check_dynamite(self, player)
             if exploded:
                 self.discard_pile.append(dyn)
                 self.on_player_damaged(player)
@@ -76,8 +74,8 @@ class TurnFlowMixin:
             player.unequip("Jail")
             self.discard_pile.append(jail)
             return True
-        if getattr(jail, "check_turn", None):
-            skipped = jail.check_turn(player, self.deck)
+        if hasattr(jail, "check_turn"):
+            skipped = jail.check_turn(self, player)
             self.discard_pile.append(jail)
             if skipped:
                 self.current_turn = (self.current_turn + 1) % len(self.turn_order)

--- a/tests/test_cards.py
+++ b/tests/test_cards.py
@@ -9,6 +9,7 @@ from bang_py.cards.mustang import MustangCard
 from bang_py.cards.jail import JailCard
 from bang_py.cards.dynamite import DynamiteCard
 from bang_py.deck_factory import create_standard_deck
+from bang_py.game_manager import GameManager
 from bang_py.player import Player
 
 
@@ -74,7 +75,9 @@ def test_barrel_dodges_bang_on_heart():
     BarrelCard().play(target)
     deck = create_standard_deck()
     deck.push_top(BeerCard(suit="Hearts"))
-    BangCard().play(target, deck)
+    gm = GameManager(deck=deck)
+    gm.add_player(target)
+    BangCard().play(target, game=gm)
     assert target.health == target.max_health
     assert target.metadata.dodged is True
 
@@ -84,7 +87,9 @@ def test_barrel_fails_on_non_heart():
     BarrelCard().play(target)
     deck = create_standard_deck()
     deck.push_top(BeerCard(suit="Clubs"))
-    BangCard().play(target, deck)
+    gm = GameManager(deck=deck)
+    gm.add_player(target)
+    BangCard().play(target, game=gm)
     assert target.health == target.max_health - 1
 
 
@@ -94,7 +99,9 @@ def test_jail_skip_turn():
     jail.play(player)
     deck = create_standard_deck()
     deck.push_top(BangCard(suit="Clubs"))
-    skipped = jail.check_turn(player, deck)
+    gm = GameManager(deck=deck)
+    gm.add_player(player)
+    skipped = jail.check_turn(gm, player)
     assert skipped is True
     assert "Jail" not in player.equipment
 
@@ -105,7 +112,9 @@ def test_jail_freed_on_heart():
     jail.play(player)
     deck = create_standard_deck()
     deck.push_top(BangCard(suit="Hearts"))
-    skipped = jail.check_turn(player, deck)
+    gm = GameManager(deck=deck)
+    gm.add_player(player)
+    skipped = jail.check_turn(gm, player)
     assert skipped is False
     assert "Jail" not in player.equipment
 
@@ -117,7 +126,10 @@ def test_dynamite_explodes():
     dyn.play(p1)
     deck = create_standard_deck()
     deck.push_top(BangCard(suit="Spades", rank=5))
-    exploded = dyn.check_dynamite(p1, p2, deck)
+    gm = GameManager(deck=deck)
+    gm.add_player(p1)
+    gm.add_player(p2)
+    exploded = dyn.check_dynamite(gm, p1)
     assert exploded is True
     assert p1.health == p1.max_health - 3
     assert "Dynamite" not in p1.equipment
@@ -130,7 +142,10 @@ def test_dynamite_passes():
     dyn.play(p1)
     deck = create_standard_deck()
     deck.push_top(BangCard(suit="Hearts", rank=1))
-    exploded = dyn.check_dynamite(p1, p2, deck)
+    gm = GameManager(deck=deck)
+    gm.add_player(p1)
+    gm.add_player(p2)
+    exploded = dyn.check_dynamite(gm, p1)
     assert exploded is False
     assert "Dynamite" not in p1.equipment
     assert "Dynamite" in p2.equipment

--- a/tests/test_characters.py
+++ b/tests/test_characters.py
@@ -174,8 +174,10 @@ def test_jesse_jones_selects_card_index():
 def test_jourdonnais_has_virtual_barrel():
     deck = create_standard_deck()
     deck.push_top(BeerCard(suit="Hearts"))
+    gm = GameManager(deck=deck)
     target = Player("Jour", character=Jourdonnais())
-    BangCard().play(target, deck)
+    gm.add_player(target)
+    BangCard().play(target, game=gm)
     assert target.metadata.dodged is True
 
 
@@ -198,7 +200,7 @@ def test_lucky_duke_draw_two_on_jail():
     gm.add_player(player)
     jail = JailCard()
     jail.play(player)
-    skipped = jail.check_turn(player, deck)
+    skipped = jail.check_turn(gm, player)
     assert skipped is False
     assert len(gm.discard_pile) == 2
 
@@ -210,7 +212,7 @@ def test_barrel_draw_card_discarded():
     gm.add_player(player)
     barrel = BarrelCard()
     barrel.play(player)
-    assert barrel.draw_check(deck, player) is False
+    assert barrel.draw_check(gm, player) is False
     assert len(gm.discard_pile) == 1
 
 


### PR DESCRIPTION
## Summary
- add default check hooks to `BaseCard` for dynamite, jail, and draw! checks
- update card implementations to use `GameManagerProtocol`
- ensure turn flow mixin and tests use new hooks

## Testing
- `pre-commit run --files bang_py/cards/barrel.py bang_py/cards/buffalo_rifle.py bang_py/cards/card.py bang_py/cards/derringer.py bang_py/cards/dynamite.py bang_py/cards/gatling.py bang_py/cards/howitzer.py bang_py/cards/jail.py bang_py/cards/knife.py bang_py/cards/pepperbox.py bang_py/cards/springfield.py bang_py/cards/bang.py bang_py/turn_phases/turn_flow.py tests/test_cards.py tests/test_characters.py` *(failed: mypy – numerous attribute and type errors)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68968b17ec4c8323bbbe8c960b7e1c97