### PR TITLE
Guard deck operations in turn phases

### DIFF
--- a/bang_py/turn_phases/discard_phase.py
+++ b/bang_py/turn_phases/discard_phase.py
@@ -36,6 +36,8 @@ class DiscardPhaseMixin:
         while len(player.hand) > limit:
             card = player.hand.pop()
             if self.event_flags.get("abandoned_mine"):
+                if self.deck is None:
+                    raise RuntimeError("Deck is required for abandoned mine")
                 self.deck.push_top(card)
             else:
                 self._pass_left_or_discard(player, card)

--- a/bang_py/turn_phases/draw_phase.py
+++ b/bang_py/turn_phases/draw_phase.py
@@ -31,16 +31,17 @@ class DrawPhaseMixin:
     # Deck helpers
     def _draw_from_deck(self) -> BaseCard | None:
         """Draw a card reshuffling the discard pile if needed."""
-        if self.deck is None:
+        deck = self.deck
+        if deck is None:
             return None
-        card = self.deck.draw()
+        card = deck.draw()
         if card is None and self.discard_pile:
-            self.deck.cards.extend(self.discard_pile)
+            deck.cards.extend(self.discard_pile)
             self.discard_pile.clear()
-            cards = list(self.deck.cards)
+            cards = list(deck.cards)
             random.shuffle(cards)
-            self.deck.cards = deque(cards)
-            card = self.deck.draw()
+            deck.cards = deque(cards)
+            card = deck.draw()
         return card
 
     def draw_card(self, player: "Player", num: int = 1) -> None:


### PR DESCRIPTION
## Summary
- Safely draw from deck by caching and validating the deck object
- Prevent abandoned mine discard when no deck exists

## Testing
- `pre-commit run --files bang_py/turn_phases/draw_phase.py bang_py/turn_phases/discard_phase.py` *(failed: Argument 1 to "handle_out_of_turn_discard" has incompatible type "GameManagerProtocol")*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68968adb1cd08323981540cf1eae749f