### PR TITLE
Check target character before ability copy

### DIFF
--- a/bang_py/ability_dispatch.py
+++ b/bang_py/ability_dispatch.py
@@ -85,8 +85,10 @@ class AbilityDispatchMixin:
             return
         if not isinstance(target, Player):
             return
-        if not target.is_alive() or target is player or target.character is None:
+        if not target.is_alive() or target is player:
             return
+        if target.character is None:
+            raise ValueError("Target has no character to copy")
         player.metadata.vera_copy = target.character.__class__
         player.metadata.abilities.add(target.character.__class__)
         target.character.ability(self, player)

--- a/bang_py/characters/vera_custer.py
+++ b/bang_py/characters/vera_custer.py
@@ -21,8 +21,10 @@ class VeraCuster(BaseCharacter):
         return True
 
     def copy_ability(self, gm: "GameManager", player: "Player", target: "Player") -> bool:
-        if not target.is_alive() or target is player or target.character is None:
+        if not target.is_alive() or target is player:
             return True
+        if target.character is None:
+            raise ValueError("Target has no character to copy")
         player.metadata.vera_copy = target.character.__class__
         player.metadata.abilities.add(target.character.__class__)
         target.character.ability(gm, player)


### PR DESCRIPTION
## Summary
- ensure target character exists before copying abilities
- raise ValueError when copying from a player without a character

## Testing
- `pre-commit run --files bang_py/ability_dispatch.py bang_py/characters/vera_custer.py` *(fails: mypy reports 101 errors)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896930b2d7083238ccf482ee435948b