### PR TITLE
Initialize Molly Stark metadata dictionary

### DIFF
--- a/bang_py/characters/molly_stark.py
+++ b/bang_py/characters/molly_stark.py
@@ -22,7 +22,8 @@ class MollyStark(BaseCharacter):
 
     def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
         player.metadata.abilities.add(MollyStark)
-        player.metadata.molly_choices = {}
+        if player.metadata.molly_choices is None:
+            player.metadata.molly_choices = {}
         return True
 
     def on_out_of_turn_discard(self, gm: "GameManager", player: "Player", card: "BaseCard") -> None:


### PR DESCRIPTION
## Summary
- Guard against missing `molly_choices` metadata by initializing the dictionary if absent

## Testing
- `SKIP=mypy pre-commit run --files bang_py/characters/molly_stark.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896930f57808323989d90d317967267