### PR TITLE
Annotate event flags and remove redundant casts

### DIFF
--- a/bang_py/ability_dispatch.py
+++ b/bang_py/ability_dispatch.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 from .cards.bang import BangCard
-from .cards.missed import MissedCard
-from .cards.general_store import GeneralStoreCard
-from .characters.vera_custer import VeraCuster
 from .cards.card import BaseCard
+from .cards.general_store import GeneralStoreCard
+from .cards.missed import MissedCard
+from .characters.vera_custer import VeraCuster
+from .event_flags import EventFlags
 from .game_manager_protocol import GameManagerProtocol
 from .helpers import handle_out_of_turn_discard
 from .player import Player
@@ -15,7 +16,7 @@ from .player import Player
 class AbilityDispatchMixin:
     """Implement miscellaneous character abilities."""
 
-    event_flags: dict
+    event_flags: EventFlags
     discard_pile: list[BaseCard]
 
     def chuck_wengam_ability(self: GameManagerProtocol, player: "Player") -> None:

--- a/bang_py/card_handlers/dispatch.py
+++ b/bang_py/card_handlers/dispatch.py
@@ -11,13 +11,14 @@ from collections.abc import Iterable
 from typing import TYPE_CHECKING, cast
 
 from ..cards.bang import BangCard
-from ..cards.missed import MissedCard
 from ..cards.card import BaseCard
-from ..cards.panic import PanicCard
 from ..cards.jail import JailCard
+from ..cards.missed import MissedCard
+from ..cards.panic import PanicCard
 from ..cards.roles import SheriffRoleCard
-from ..helpers import handle_out_of_turn_discard
+from ..event_flags import EventFlags
 from ..game_manager_protocol import GameManagerProtocol
+from ..helpers import handle_out_of_turn_discard
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from ..player import Player
@@ -43,7 +44,7 @@ class DispatchMixin:
     card_played_listeners: list
     card_play_checks: list
     discard_pile: list
-    event_flags: dict
+    event_flags: EventFlags
     _card_handlers: dict
     _players: list["Player"]
     turn_order: list[int]

--- a/bang_py/cards/beer.py
+++ b/bang_py/cards/beer.py
@@ -38,7 +38,7 @@ class BeerCard(BaseCard):
             alive = [p for p in game.players if p.is_alive()]
             if len(alive) <= 2:
                 return
-            heal_amt = int(game.event_flags.get("beer_heal", 1))
+            heal_amt = game.event_flags.get("beer_heal", 1)
         else:
             heal_amt = 1
 

--- a/bang_py/cards/events/the_reverend.py
+++ b/bang_py/cards/events/the_reverend.py
@@ -1,22 +1,24 @@
-"""The Reverend card from the High Noon expansion. Beer cannot be played"""
+"""The Reverend card from the High Noon expansion. Beer cannot be played and
+hand limit is 2."""
 
 from __future__ import annotations
 
 from .base import BaseEventCard
 from ...player import Player
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, override
 
 if TYPE_CHECKING:
     from ...game_manager import GameManager
 
 
 class TheReverendEventCard(BaseEventCard):
-    """Beer cards cannot be played."""
+    """Beer cards cannot be played and hands are limited to two cards."""
 
     card_name = "The Reverend"
     card_set = "high_noon"
-    description = "Beer cannot be played"
+    description = "Beer cannot be played and hand limit is 2"
 
+    @override
     def play(
         self,
         target: Player | None = None,
@@ -26,3 +28,4 @@ class TheReverendEventCard(BaseEventCard):
         """Activate the Reverend event."""
         if game:
             game.event_flags["no_beer_play"] = True
+            game.event_flags["reverend_limit"] = 2

--- a/bang_py/deck_manager.py
+++ b/bang_py/deck_manager.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 import random
 
-from .deck import Deck
-from .deck_factory import create_standard_deck
 from .cards.card import BaseCard
 from .cards.roles import (
     BaseRole,
@@ -16,6 +14,9 @@ from .cards.roles import (
     SheriffRoleCard,
 )
 from .characters.base import BaseCharacter
+from .deck import Deck
+from .deck_factory import create_standard_deck
+from .event_flags import EventFlags
 from .game_manager_protocol import GameManagerProtocol
 
 if TYPE_CHECKING:  # pragma: no cover - imported for type checking
@@ -29,7 +30,7 @@ class DeckManagerMixin:
     expansions: list[str]
     _players: list["Player"]
     discard_pile: list[BaseCard]
-    event_flags: dict
+    event_flags: EventFlags
     current_turn: int
     turn_order: list[int]
 

--- a/bang_py/event_flags.py
+++ b/bang_py/event_flags.py
@@ -1,0 +1,53 @@
+"""Typed definitions for event flag entries used across the game."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, TypedDict
+
+if TYPE_CHECKING:  # pragma: no cover - imported for type checking
+    from .player import Player
+
+
+class EventFlags(TypedDict, total=False):
+    """Optional flags toggled by events and abilities."""
+
+    abandoned_mine: bool
+    ambush: bool
+    bang_limit: int
+    beer_heal: int
+    blood_brothers: bool
+    bounty: bool
+    dead_man: bool
+    dead_man_player: "Player"
+    dead_man_used: bool
+    draw_count: int
+    fistful_of_cards: bool
+    ghost_town: bool
+    handcuffs: bool
+    hard_liquor: bool
+    judge: bool
+    lasso: bool
+    law_of_the_west: bool
+    new_identity: bool
+    no_abilities: bool
+    no_bang: bool
+    no_beer: bool
+    no_beer_play: bool
+    no_draw: bool
+    no_jail: bool
+    no_missed: bool
+    peyote: bool
+    peyote_bonus: int
+    ranch: bool
+    reverend_limit: int
+    reverse_turn: bool
+    ricochet: bool
+    river: bool
+    sniper: bool
+    start_damage: int
+    suit_override: str
+    turn_suit: str
+    vendetta: bool
+    vendetta_used: set["Player"]
+    revealed_hands: bool
+    skip_turn: bool

--- a/bang_py/events/event_hooks.py
+++ b/bang_py/events/event_hooks.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 from ..cards.roles import SheriffRoleCard
 from ..cards.card import BaseCard
 from ..game_manager_protocol import GameManagerProtocol
+from ..event_flags import EventFlags
 
 if TYPE_CHECKING:  # pragma: no cover - imported for type checking
     from ..player import Player
@@ -18,7 +19,7 @@ class EventHooksMixin:
     _players: list[Player]
     turn_order: list[int]
     current_turn: int
-    event_flags: dict
+    event_flags: EventFlags
     discard_pile: list[BaseCard]
     first_eliminated: Player | None
     game_over_listeners: list

--- a/bang_py/events/event_logic.py
+++ b/bang_py/events/event_logic.py
@@ -4,14 +4,15 @@
 
 from __future__ import annotations
 
-from typing import Any
-import random
 from collections import deque
+import random
+from typing import Any
 
 from .event_decks import EventCard, create_high_noon_deck, create_fistful_deck
 from ..cards.roles import SheriffRoleCard
 from ..player import Player
 from ..game_manager_protocol import GameManagerProtocol
+from ..event_flags import EventFlags
 
 
 class EventLogicMixin:
@@ -19,7 +20,7 @@ class EventLogicMixin:
 
     event_deck: deque[EventCard] | None
     current_event: EventCard | None
-    event_flags: dict
+    event_flags: EventFlags
     expansions: list[str]
     deck: object
     discard_pile: list[Any]

--- a/bang_py/game_manager.py
+++ b/bang_py/game_manager.py
@@ -6,17 +6,18 @@ from dataclasses import dataclass, field
 from collections.abc import Callable, Iterable, Sequence
 from collections import deque
 
-from .deck import Deck
-from .cards.card import BaseCard
-from .player import Player
-from .events.event_decks import EventCard
-from .events.event_logic import EventLogicMixin
-from .card_handlers import CardHandlersMixin
-from .general_store import GeneralStoreMixin
-from .turn_phases import TurnPhasesMixin
-from .deck_manager import DeckManagerMixin
 from .ability_dispatch import AbilityDispatchMixin
+from .card_handlers import CardHandlersMixin
+from .cards.card import BaseCard
+from .deck import Deck
+from .deck_manager import DeckManagerMixin
+from .event_flags import EventFlags
+from .events.event_decks import EventCard
 from .events.event_hooks import EventHooksMixin
+from .events.event_logic import EventLogicMixin
+from .general_store import GeneralStoreMixin
+from .player import Player
+from .turn_phases import TurnPhasesMixin
 
 
 @dataclass(slots=True)
@@ -39,7 +40,7 @@ class GameManager(
     turn_order: list[int] = field(default_factory=list)
     event_deck: deque[EventCard] | None = None
     current_event: EventCard | None = None
-    event_flags: dict = field(default_factory=dict)
+    event_flags: EventFlags = field(default_factory=dict)
     first_eliminated: Player | None = None
     sheriff_turns: int = 0
     phase: str = "draw"

--- a/bang_py/game_manager_protocol.py
+++ b/bang_py/game_manager_protocol.py
@@ -6,6 +6,8 @@ from collections import deque
 from collections.abc import Callable, Iterable
 from typing import Protocol, TYPE_CHECKING
 
+from .event_flags import EventFlags
+
 if TYPE_CHECKING:  # pragma: no cover - imported for type checking
     from .cards.card import BaseCard
     from .cards.roles import BaseRole
@@ -20,7 +22,7 @@ class GameManagerProtocol(Protocol):
 
     deck: Deck | None
     discard_pile: list[BaseCard]
-    event_flags: dict[str, object]
+    event_flags: EventFlags
     expansions: list[str]
     _players: list[Player]
     turn_order: list[int]

--- a/bang_py/turn_phases/discard_phase.py
+++ b/bang_py/turn_phases/discard_phase.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from ..cards.card import BaseCard
+from ..event_flags import EventFlags
 from ..game_manager_protocol import GameManagerProtocol
 
 if TYPE_CHECKING:  # pragma: no cover - imported for type checking
@@ -16,7 +17,7 @@ class DiscardPhaseMixin:
 
     deck: object
     discard_pile: list[BaseCard]
-    event_flags: dict
+    event_flags: EventFlags
 
     def discard_phase(self: GameManagerProtocol, player: "Player") -> None:
         limit = self._hand_limit(player)
@@ -29,7 +30,7 @@ class DiscardPhaseMixin:
         if player.metadata.no_hand_limit:
             return 99
         if "reverend_limit" in self.event_flags:
-            limit = min(limit, int(self.event_flags["reverend_limit"]))
+            limit = min(limit, self.event_flags["reverend_limit"])
         return limit
 
     def _discard_to_limit(self: GameManagerProtocol, player: "Player", limit: int) -> None:

--- a/bang_py/turn_phases/draw_phase.py
+++ b/bang_py/turn_phases/draw_phase.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, cast
-import random
 from collections import deque
+import random
 
 from ..cards.card import BaseCard
 from ..game_manager_protocol import GameManagerProtocol
+from ..event_flags import EventFlags
 
 if TYPE_CHECKING:  # pragma: no cover - imported for type checking
     from ..player import Player
@@ -18,7 +19,7 @@ class DrawPhaseMixin:
 
     deck: object
     discard_pile: list[BaseCard]
-    event_flags: dict
+    event_flags: EventFlags
     _players: list["Player"]
     turn_order: list[int]
     current_turn: int
@@ -46,7 +47,7 @@ class DrawPhaseMixin:
 
     def draw_card(self, player: "Player", num: int = 1) -> None:
         """Draw ``num`` cards for ``player`` applying event modifiers."""
-        bonus = int(self.event_flags.get("peyote_bonus", 0))
+        bonus = self.event_flags.get("peyote_bonus", 0)
         for _ in range(num + bonus):
             card: BaseCard | None
             if self.event_flags.get("abandoned_mine") and self.discard_pile:

--- a/bang_py/turn_phases/turn_flow.py
+++ b/bang_py/turn_phases/turn_flow.py
@@ -9,6 +9,7 @@ from ..characters.jose_delgado import JoseDelgado
 from ..characters.kit_carlson import KitCarlson
 from ..characters.pat_brennan import PatBrennan
 from ..characters.pedro_ramirez import PedroRamirez
+from ..event_flags import EventFlags
 from ..game_manager_protocol import GameManagerProtocol
 
 if TYPE_CHECKING:  # pragma: no cover - imported for type checking
@@ -27,7 +28,7 @@ class TurnFlowMixin:
     turn_started_listeners: list
     discard_pile: list
     deck: object
-    event_flags: dict
+    event_flags: EventFlags
 
     def play_phase(self: GameManagerProtocol, player: "Player") -> None:
         self.phase = "play"


### PR DESCRIPTION
## Summary
- define `EventFlags` TypedDict and annotate mixins with it
- remove integer casts from event flag usage and set `reverend_limit` directly in The Reverend event
- handle beer healing and peyote bonuses without `int()` conversions

## Testing
- `SKIP=mypy pre-commit run --files bang_py/event_flags.py bang_py/game_manager_protocol.py bang_py/deck_manager.py bang_py/events/event_logic.py bang_py/ability_dispatch.py bang_py/game_manager.py bang_py/events/event_hooks.py bang_py/turn_phases/draw_phase.py bang_py/turn_phases/discard_phase.py bang_py/turn_phases/turn_flow.py bang_py/card_handlers/dispatch.py bang_py/cards/beer.py bang_py/cards/events/the_reverend.py`
- `BANG_AUTO_CLOSE=1 pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896989ea1588323a4d71af2db378bdc