### PR TITLE
Use GameManagerProtocol in character abilities

### DIFF
--- a/bang_py/characters/apache_kid.py
+++ b/bang_py/characters/apache_kid.py
@@ -1,4 +1,5 @@
 """Diamonds cannot affect you. Dodge City expansion."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -6,7 +7,7 @@ from typing import TYPE_CHECKING
 from .base import BaseCharacter
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
-    from ..game_manager import GameManager
+    from ..game_manager_protocol import GameManagerProtocol
     from ..player import Player
     from ..cards.card import BaseCard
     from ..cards.duel import DuelCard
@@ -17,15 +18,11 @@ class ApacheKid(BaseCharacter):
     description = "You are unaffected by Diamond suited cards."
     starting_health = 4
 
-    def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
+    def ability(self, gm: "GameManagerProtocol", player: "Player", **_: object) -> bool:
         player.metadata.abilities.add(ApacheKid)
 
         def check(p: "Player", card: "BaseCard", target: "Player | None") -> bool:
-            if (
-                p is not player
-                and target is player
-                and getattr(card, "suit", None) == "Diamonds"
-            ):
+            if p is not player and target is player and getattr(card, "suit", None) == "Diamonds":
                 if gm._duel_counts is not None and not isinstance(card, DuelCard):
                     return True
                 if card in getattr(p, "hand", []):

--- a/bang_py/characters/chuck_wengam.py
+++ b/bang_py/characters/chuck_wengam.py
@@ -1,4 +1,5 @@
 """Lose 1 life to draw 2 cards during your turn. Dodge City expansion."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -6,22 +7,20 @@ from typing import TYPE_CHECKING
 from .base import BaseCharacter
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
-    from ..game_manager import GameManager
+    from ..game_manager_protocol import GameManagerProtocol
     from ..player import Player
 
 
 class ChuckWengam(BaseCharacter):
     name = "Chuck Wengam"
-    description = (
-        "During your turn, you may lose 1 life point to draw 2 cards."
-    )
+    description = "During your turn, you may lose 1 life point to draw 2 cards."
     starting_health = 4
 
-    def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
+    def ability(self, gm: "GameManagerProtocol", player: "Player", **_: object) -> bool:
         player.metadata.abilities.add(ChuckWengam)
         return True
 
-    def use_ability(self, gm: "GameManager", player: "Player") -> bool:
+    def use_ability(self, gm: "GameManagerProtocol", player: "Player") -> bool:
         if player.health <= 1:
             return True
         player.take_damage(1)

--- a/bang_py/characters/doc_holyday.py
+++ b/bang_py/characters/doc_holyday.py
@@ -1,4 +1,5 @@
 """Discard 2 cards for a free Bang once per turn. Dodge City expansion."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -6,7 +7,7 @@ from typing import TYPE_CHECKING
 from .base import BaseCharacter
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
-    from ..game_manager import GameManager
+    from ..game_manager_protocol import GameManagerProtocol
     from ..player import Player
 
 
@@ -18,13 +19,13 @@ class DocHolyday(BaseCharacter):
     )
     starting_health = 4
 
-    def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
+    def ability(self, gm: "GameManagerProtocol", player: "Player", **_: object) -> bool:
         player.metadata.abilities.add(DocHolyday)
         return True
 
     def use_ability(
         self,
-        gm: "GameManager",
+        gm: "GameManagerProtocol",
         player: "Player",
         indices: list[int] | None = None,
     ) -> bool:

--- a/bang_py/characters/greg_digger.py
+++ b/bang_py/characters/greg_digger.py
@@ -1,4 +1,5 @@
 """Gain 2 life when another player dies. Dodge City expansion."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -6,7 +7,7 @@ from typing import TYPE_CHECKING
 from .base import BaseCharacter
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
-    from ..game_manager import GameManager
+    from ..game_manager_protocol import GameManagerProtocol
     from ..player import Player
 
 
@@ -15,7 +16,7 @@ class GregDigger(BaseCharacter):
     description = "Each time a player is eliminated, regain two life points."
     starting_health = 4
 
-    def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
+    def ability(self, gm: "GameManagerProtocol", player: "Player", **_: object) -> bool:
         player.metadata.abilities.add(GregDigger)
 
         def on_death(victim: "Player", _src: "Player | None") -> None:

--- a/bang_py/characters/johnny_kisch.py
+++ b/bang_py/characters/johnny_kisch.py
@@ -1,4 +1,5 @@
 """Play a card and discard all copies in play. Bullet expansion exclusive."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -6,7 +7,7 @@ from typing import TYPE_CHECKING
 from .base import BaseCharacter
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
-    from ..game_manager import GameManager
+    from ..game_manager_protocol import GameManagerProtocol
     from ..player import Player
     from ..cards.card import BaseCard
 
@@ -18,7 +19,7 @@ class JohnnyKisch(BaseCharacter):
     )
     starting_health = 4
 
-    def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
+    def ability(self, gm: "GameManagerProtocol", player: "Player", **_: object) -> bool:
         player.metadata.abilities.add(JohnnyKisch)
 
         def on_play(p: "Player", card: "BaseCard", _t: "Player | None") -> None:

--- a/bang_py/characters/pat_brennan.py
+++ b/bang_py/characters/pat_brennan.py
@@ -8,7 +8,7 @@ from ..player import Player
 from .base import BaseCharacter
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
-    from ..game_manager import GameManager
+    from ..game_manager_protocol import GameManagerProtocol
 
 
 class PatBrennan(BaseCharacter):
@@ -18,7 +18,7 @@ class PatBrennan(BaseCharacter):
     )
     starting_health = 4
 
-    def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
+    def ability(self, gm: "GameManagerProtocol", player: "Player", **_: object) -> bool:
         player.metadata.abilities.add(PatBrennan)
 
         def on_draw(p: "Player", opts: object) -> bool:

--- a/bang_py/characters/sid_ketchum.py
+++ b/bang_py/characters/sid_ketchum.py
@@ -1,4 +1,5 @@
 """Discard two cards to heal one life. Core set."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -6,7 +7,7 @@ from typing import TYPE_CHECKING
 from .base import BaseCharacter
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
-    from ..game_manager import GameManager
+    from ..game_manager_protocol import GameManagerProtocol
     from ..player import Player
 
 
@@ -15,13 +16,13 @@ class SidKetchum(BaseCharacter):
     description = "You may discard two cards to regain one life point."
     starting_health = 4
 
-    def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
+    def ability(self, gm: "GameManagerProtocol", player: "Player", **_: object) -> bool:
         player.metadata.abilities.add(SidKetchum)
         return True
 
     def use_ability(
         self,
-        gm: "GameManager",
+        gm: "GameManagerProtocol",
         player: "Player",
         indices: list[int] | None = None,
     ) -> bool:

--- a/bang_py/characters/uncle_will.py
+++ b/bang_py/characters/uncle_will.py
@@ -1,4 +1,5 @@
 """Once per turn, any card becomes a General Store. Bullet expansion exclusive."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -6,24 +7,22 @@ from typing import TYPE_CHECKING
 from .base import BaseCharacter
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
-    from ..game_manager import GameManager
+    from ..game_manager_protocol import GameManagerProtocol
     from ..player import Player
 
 
 class UncleWill(BaseCharacter):
     name = "Uncle Will"
-    description = (
-        "Once during your turn, you may play any card from your hand as a General Store."
-    )
+    description = "Once during your turn, you may play any card from your hand as a General Store."
     starting_health = 4
 
-    def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
+    def ability(self, gm: "GameManagerProtocol", player: "Player", **_: object) -> bool:
         player.metadata.abilities.add(UncleWill)
         return True
 
     def use_ability(
         self,
-        gm: "GameManager",
+        gm: "GameManagerProtocol",
         player: "Player",
         card,
     ) -> bool:


### PR DESCRIPTION
## Summary
- use GameManagerProtocol instead of GameManager for affected character abilities
- clean up type-checking imports accordingly

## Testing
- `pre-commit run --files bang_py/characters/sid_ketchum.py bang_py/characters/johnny_kisch.py bang_py/characters/greg_digger.py bang_py/characters/chuck_wengam.py bang_py/characters/apache_kid.py bang_py/characters/pat_brennan.py bang_py/characters/doc_holyday.py bang_py/characters/uncle_will.py` *(fails: Invalid self argument "GameManager" to attribute function...)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689698b285708323bb45a1629f9096cc