### PR TITLE
Adopt GameManagerProtocol in card play routines

### DIFF
--- a/bang_py/card_handlers/bang_handlers.py
+++ b/bang_py/card_handlers/bang_handlers.py
@@ -18,7 +18,7 @@ class BangHandlersMixin:
     """Mixin providing Bang-specific card resolution helpers."""
 
     def _play_bang_card(
-        self,
+        self: GameManagerProtocol,
         player: "Player",
         card: BangCard,
         target: "Player" | None,
@@ -67,7 +67,7 @@ class BangHandlersMixin:
         if not self.event_flags.get("river"):
             handle_out_of_turn_discard(self, player, card)
 
-    def _auto_miss(self, target: "Player") -> bool:
+    def _auto_miss(self: GameManagerProtocol, target: "Player") -> bool:
         """Attempt to satisfy a Bang! with automatic Missed! effects."""
         if not self._should_use_auto_miss(target):
             return False
@@ -85,7 +85,7 @@ class BangHandlersMixin:
             return False
         return target.metadata.auto_miss is not False
 
-    def _use_miss_card(self, target: "Player") -> bool:
+    def _use_miss_card(self: GameManagerProtocol, target: "Player") -> bool:
         """Use a Missed! card from ``target`` if available."""
         miss = next((c for c in target.hand if isinstance(c, MissedCard)), None)
         if miss:
@@ -95,7 +95,7 @@ class BangHandlersMixin:
             return True
         return False
 
-    def _use_bang_as_miss(self, target: "Player") -> bool:
+    def _use_bang_as_miss(self: GameManagerProtocol, target: "Player") -> bool:
         """Use a Bang! card as a Missed! if allowed."""
         if target.metadata.bang_as_missed:
             bang = next((c for c in target.hand if isinstance(c, BangCard)), None)
@@ -106,7 +106,7 @@ class BangHandlersMixin:
                 return True
         return False
 
-    def _use_any_card_as_miss(self, target: "Player") -> bool:
+    def _use_any_card_as_miss(self: GameManagerProtocol, target: "Player") -> bool:
         """Use any card as a Missed! if permitted by effects."""
         if target.metadata.any_card_as_missed and target.hand:
             card = target.hand.pop()

--- a/bang_py/cards/beer.py
+++ b/bang_py/cards/beer.py
@@ -6,7 +6,7 @@ from ..player import Player
 from typing import Any, TYPE_CHECKING, override
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
-    from ..game_manager import GameManager
+    from ..game_manager_protocol import GameManagerProtocol
 
 
 class BeerCard(BaseCard):
@@ -20,7 +20,7 @@ class BeerCard(BaseCard):
         self,
         target: Player | None,
         player: Player | None = None,
-        game: "GameManager" | None = None,
+        game: "GameManagerProtocol" | None = None,
         **kwargs: Any,
     ) -> None:
         """Heal the target if allowed by game state and abilities."""

--- a/bang_py/cards/bible.py
+++ b/bang_py/cards/bible.py
@@ -6,7 +6,7 @@ from ..player import Player
 from typing import Any, TYPE_CHECKING, override
 
 if TYPE_CHECKING:
-    from ..game_manager import GameManager
+    from ..game_manager_protocol import GameManagerProtocol
 
 
 class BibleCard(BaseCard):
@@ -22,7 +22,7 @@ class BibleCard(BaseCard):
         self,
         target: Player | None,
         player: Player | None = None,
-        game: GameManager | None = None,
+        game: GameManagerProtocol | None = None,
         **kwargs: Any,
     ) -> None:
         if not target:

--- a/bang_py/cards/brawl.py
+++ b/bang_py/cards/brawl.py
@@ -6,7 +6,7 @@ from ..player import Player
 from typing import Any, TYPE_CHECKING, override
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
-    from ..game_manager import GameManager
+    from ..game_manager_protocol import GameManagerProtocol
 
 from ..helpers import handle_out_of_turn_discard
 
@@ -24,7 +24,7 @@ class BrawlCard(BaseCard):
         self,
         target: Player | None = None,
         player: Player | None = None,
-        game: GameManager | None = None,
+        game: GameManagerProtocol | None = None,
         *,
         discard_idx: int = 0,
         victim_indices: dict[int, int] | None = None,

--- a/bang_py/cards/buffalo_rifle.py
+++ b/bang_py/cards/buffalo_rifle.py
@@ -6,7 +6,7 @@ from ..player import Player
 from typing import Any, TYPE_CHECKING, override
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
-    from ..game_manager import GameManager
+    from ..game_manager_protocol import GameManagerProtocol
 
 from .bang import BangCard
 
@@ -24,7 +24,7 @@ class BuffaloRifleCard(BaseCard):
         self,
         target: Player | None,
         player: Player | None = None,
-        game: GameManager | None = None,
+        game: GameManagerProtocol | None = None,
         **kwargs: Any,
     ) -> None:
         if not target:

--- a/bang_py/cards/can_can.py
+++ b/bang_py/cards/can_can.py
@@ -7,7 +7,7 @@ from typing import Any, TYPE_CHECKING, override
 from ..helpers import handle_out_of_turn_discard
 
 if TYPE_CHECKING:
-    from ..game_manager import GameManager
+    from ..game_manager_protocol import GameManagerProtocol
 
 
 class CanCanCard(BaseCard):
@@ -23,7 +23,7 @@ class CanCanCard(BaseCard):
         self,
         target: Player | None,
         player: Player | None = None,
-        game: GameManager | None = None,
+        game: GameManagerProtocol | None = None,
         *,
         hand_idx: int | None = None,
         equip_name: str | None = None,

--- a/bang_py/cards/canteen.py
+++ b/bang_py/cards/canteen.py
@@ -6,7 +6,7 @@ from ..player import Player
 from typing import Any, TYPE_CHECKING, override
 
 if TYPE_CHECKING:
-    from ..game_manager import GameManager
+    from ..game_manager_protocol import GameManagerProtocol
 
 
 class CanteenCard(BaseCard):
@@ -22,7 +22,7 @@ class CanteenCard(BaseCard):
         self,
         target: Player | None,
         player: Player | None = None,
-        game: GameManager | None = None,
+        game: GameManagerProtocol | None = None,
         **kwargs: Any,
     ) -> None:
         if not target:

--- a/bang_py/cards/cat_balou.py
+++ b/bang_py/cards/cat_balou.py
@@ -9,7 +9,7 @@ from typing import Any, TYPE_CHECKING, override
 from ..helpers import handle_out_of_turn_discard
 
 if TYPE_CHECKING:
-    from ..game_manager import GameManager
+    from ..game_manager_protocol import GameManagerProtocol
 
 
 class CatBalouCard(BaseCard):
@@ -22,7 +22,7 @@ class CatBalouCard(BaseCard):
     def play(
         self,
         target: Player | None,
-        game: GameManager | None = None,
+        game: GameManagerProtocol | None = None,
         *,
         hand_idx: int | None = None,
         equip_name: str | None = None,

--- a/bang_py/cards/conestoga.py
+++ b/bang_py/cards/conestoga.py
@@ -6,7 +6,7 @@ from ..player import Player
 from typing import Any, TYPE_CHECKING, override
 
 if TYPE_CHECKING:
-    from ..game_manager import GameManager
+    from ..game_manager_protocol import GameManagerProtocol
 
 
 class ConestogaCard(BaseCard):
@@ -22,7 +22,7 @@ class ConestogaCard(BaseCard):
         self,
         target: Player | None,
         player: Player | None = None,
-        game: GameManager | None = None,
+        game: GameManagerProtocol | None = None,
         *,
         hand_idx: int | None = None,
         equip_name: str | None = None,

--- a/bang_py/cards/derringer.py
+++ b/bang_py/cards/derringer.py
@@ -6,7 +6,7 @@ from ..player import Player
 from typing import Any, TYPE_CHECKING, override
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
-    from ..game_manager import GameManager
+    from ..game_manager_protocol import GameManagerProtocol
 
 from .bang import BangCard
 
@@ -24,7 +24,7 @@ class DerringerCard(BaseCard):
         self,
         target: Player | None,
         player: Player | None = None,
-        game: GameManager | None = None,
+        game: GameManagerProtocol | None = None,
         **kwargs: Any,
     ) -> None:
         if not target or not player:

--- a/bang_py/cards/duel.py
+++ b/bang_py/cards/duel.py
@@ -7,7 +7,7 @@ from ..helpers import handle_out_of_turn_discard
 from typing import Any, TYPE_CHECKING, override
 
 if TYPE_CHECKING:
-    from ..game_manager import GameManager
+    from ..game_manager_protocol import GameManagerProtocol
 
 
 class DuelCard(BaseCard):
@@ -21,7 +21,7 @@ class DuelCard(BaseCard):
         self,
         target: Player | None,
         player: Player | None = None,
-        game: GameManager | None = None,
+        game: GameManagerProtocol | None = None,
         **kwargs: Any,
     ) -> None:
         if not target or not player or not game:

--- a/bang_py/cards/events/abandoned_mine.py
+++ b/bang_py/cards/events/abandoned_mine.py
@@ -8,7 +8,7 @@ from ...player import Player
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from ...game_manager import GameManager
+    from ...game_manager_protocol import GameManagerProtocol
 
 
 class AbandonedMineEventCard(BaseEventCard):
@@ -25,7 +25,7 @@ class AbandonedMineEventCard(BaseEventCard):
         self,
         target: Player | None = None,
         player: Player | None = None,
-        game: GameManager | None = None,
+        game: GameManagerProtocol | None = None,
     ) -> None:
         """Activate the Abandoned Mine event."""
         if game:

--- a/bang_py/cards/events/ambush.py
+++ b/bang_py/cards/events/ambush.py
@@ -8,7 +8,7 @@ from ...player import Player
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from ...game_manager import GameManager
+    from ...game_manager_protocol import GameManagerProtocol
 
 
 class AmbushEventCard(BaseEventCard):
@@ -17,15 +17,14 @@ class AmbushEventCard(BaseEventCard):
     card_name = "Ambush"
     card_set = "fistful_of_cards"
     description = (
-        "The distance between any two players is 1. "
-        "Only other cards in play may modify this."
+        "The distance between any two players is 1. " "Only other cards in play may modify this."
     )
 
     def play(
         self,
         target: Player | None = None,
         player: Player | None = None,
-        game: GameManager | None = None,
+        game: GameManagerProtocol | None = None,
     ) -> None:
         """Activate the Ambush event."""
         if game:

--- a/bang_py/cards/events/base.py
+++ b/bang_py/cards/events/base.py
@@ -6,7 +6,7 @@ from ...player import Player
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints
-    from ...game_manager import GameManager
+    from ...game_manager_protocol import GameManagerProtocol
 
 
 class BaseEventCard:
@@ -26,10 +26,10 @@ class BaseEventCard:
         self,
         target: Player | None = None,
         player: Player | None = None,
-        game: GameManager | None = None,
+        game: GameManagerProtocol | None = None,
     ) -> None:
         raise NotImplementedError
 
-    def apply(self, game: GameManager) -> None:
+    def apply(self, game: GameManagerProtocol) -> None:
         """Execute this event's effect."""
         self.play(game=game)

--- a/bang_py/cards/events/blessing.py
+++ b/bang_py/cards/events/blessing.py
@@ -7,7 +7,7 @@ from ...player import Player
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from ...game_manager import GameManager
+    from ...game_manager_protocol import GameManagerProtocol
 
 
 class BlessingEventCard(BaseEventCard):
@@ -21,7 +21,7 @@ class BlessingEventCard(BaseEventCard):
         self,
         target: Player | None = None,
         player: Player | None = None,
-        game: GameManager | None = None,
+        game: GameManagerProtocol | None = None,
     ) -> None:
         """Activate the Blessing event."""
         if game:

--- a/bang_py/cards/events/blood_brothers.py
+++ b/bang_py/cards/events/blood_brothers.py
@@ -8,7 +8,7 @@ from ...player import Player
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from ...game_manager import GameManager
+    from ...game_manager_protocol import GameManagerProtocol
 
 
 class BloodBrothersEventCard(BaseEventCard):
@@ -25,7 +25,7 @@ class BloodBrothersEventCard(BaseEventCard):
         self,
         target: Player | None = None,
         player: Player | None = None,
-        game: GameManager | None = None,
+        game: GameManagerProtocol | None = None,
     ) -> None:
         """Activate the Blood Brothers event."""
         if game:

--- a/bang_py/cards/events/curse.py
+++ b/bang_py/cards/events/curse.py
@@ -7,7 +7,7 @@ from ...player import Player
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from ...game_manager import GameManager
+    from ...game_manager_protocol import GameManagerProtocol
 
 
 class CurseEventCard(BaseEventCard):
@@ -21,7 +21,7 @@ class CurseEventCard(BaseEventCard):
         self,
         target: Player | None = None,
         player: Player | None = None,
-        game: GameManager | None = None,
+        game: GameManagerProtocol | None = None,
     ) -> None:
         """Activate the Curse event."""
         if game:

--- a/bang_py/cards/events/dead_man.py
+++ b/bang_py/cards/events/dead_man.py
@@ -8,7 +8,7 @@ from ...player import Player
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from ...game_manager import GameManager
+    from ...game_manager_protocol import GameManagerProtocol
 
 
 class DeadManEventCard(BaseEventCard):
@@ -25,7 +25,7 @@ class DeadManEventCard(BaseEventCard):
         self,
         target: Player | None = None,
         player: Player | None = None,
-        game: GameManager | None = None,
+        game: GameManagerProtocol | None = None,
     ) -> None:
         """Activate the Dead Man event."""
         if game:

--- a/bang_py/cards/events/fistful_of_cards.py
+++ b/bang_py/cards/events/fistful_of_cards.py
@@ -11,7 +11,7 @@ from ...player import Player
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from ...game_manager import GameManager
+    from ...game_manager_protocol import GameManagerProtocol
 
 
 class FistfulOfCardsEventCard(BaseEventCard):
@@ -28,7 +28,7 @@ class FistfulOfCardsEventCard(BaseEventCard):
         self,
         target: Player | None = None,
         player: Player | None = None,
-        game: GameManager | None = None,
+        game: GameManagerProtocol | None = None,
     ) -> None:
         """Activate the Fistful of Cards event."""
         if game:

--- a/bang_py/cards/events/ghost_town.py
+++ b/bang_py/cards/events/ghost_town.py
@@ -8,7 +8,7 @@ from ...player import Player
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from ...game_manager import GameManager
+    from ...game_manager_protocol import GameManagerProtocol
 
 
 class GhostTownEventCard(BaseEventCard):
@@ -25,7 +25,7 @@ class GhostTownEventCard(BaseEventCard):
         self,
         target: Player | None = None,
         player: Player | None = None,
-        game: GameManager | None = None,
+        game: GameManagerProtocol | None = None,
     ) -> None:
         """Activate the Ghost Town event."""
         if game:

--- a/bang_py/cards/events/gold_rush.py
+++ b/bang_py/cards/events/gold_rush.py
@@ -8,7 +8,7 @@ from ...player import Player
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from ...game_manager import GameManager
+    from ...game_manager_protocol import GameManagerProtocol
 
 
 class GoldRushEventCard(BaseEventCard):
@@ -22,7 +22,7 @@ class GoldRushEventCard(BaseEventCard):
         self,
         target: Player | None = None,
         player: Player | None = None,
-        game: GameManager | None = None,
+        game: GameManagerProtocol | None = None,
     ) -> None:
         """Activate the Gold Rush event."""
         if game:

--- a/bang_py/cards/events/handcuffs.py
+++ b/bang_py/cards/events/handcuffs.py
@@ -8,7 +8,7 @@ from ...player import Player
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from ...game_manager import GameManager
+    from ...game_manager_protocol import GameManagerProtocol
 
 
 class HandcuffsEventCard(BaseEventCard):
@@ -25,7 +25,7 @@ class HandcuffsEventCard(BaseEventCard):
         self,
         target: Player | None = None,
         player: Player | None = None,
-        game: GameManager | None = None,
+        game: GameManagerProtocol | None = None,
     ) -> None:
         """Activate the Handcuffs event."""
         if game:

--- a/bang_py/cards/events/hangover.py
+++ b/bang_py/cards/events/hangover.py
@@ -7,7 +7,7 @@ from ...player import Player
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from ...game_manager import GameManager
+    from ...game_manager_protocol import GameManagerProtocol
 
 
 class HangoverEventCard(BaseEventCard):
@@ -21,7 +21,7 @@ class HangoverEventCard(BaseEventCard):
         self,
         target: Player | None = None,
         player: Player | None = None,
-        game: GameManager | None = None,
+        game: GameManagerProtocol | None = None,
     ) -> None:
         """Activate the Hangover event."""
         if game:

--- a/bang_py/cards/events/hard_liquor.py
+++ b/bang_py/cards/events/hard_liquor.py
@@ -7,7 +7,7 @@ from ...player import Player
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from ...game_manager import GameManager
+    from ...game_manager_protocol import GameManagerProtocol
 
 
 class HardLiquorEventCard(BaseEventCard):
@@ -21,7 +21,7 @@ class HardLiquorEventCard(BaseEventCard):
         self,
         target: Player | None = None,
         player: Player | None = None,
-        game: GameManager | None = None,
+        game: GameManagerProtocol | None = None,
     ) -> None:
         """Activate the Hard Liquor event."""
         if game:

--- a/bang_py/cards/events/high_noon.py
+++ b/bang_py/cards/events/high_noon.py
@@ -7,7 +7,7 @@ from ...player import Player
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from ...game_manager import GameManager
+    from ...game_manager_protocol import GameManagerProtocol
 
 
 class HighNoonEventCard(BaseEventCard):
@@ -21,7 +21,7 @@ class HighNoonEventCard(BaseEventCard):
         self,
         target: Player | None = None,
         player: Player | None = None,
-        game: GameManager | None = None,
+        game: GameManagerProtocol | None = None,
     ) -> None:
         """Activate the High Noon event."""
         if game:

--- a/bang_py/cards/events/lasso.py
+++ b/bang_py/cards/events/lasso.py
@@ -8,7 +8,7 @@ from ...player import Player
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from ...game_manager import GameManager
+    from ...game_manager_protocol import GameManagerProtocol
 
 
 class LassoEventCard(BaseEventCard):
@@ -22,7 +22,7 @@ class LassoEventCard(BaseEventCard):
         self,
         target: Player | None = None,
         player: Player | None = None,
-        game: GameManager | None = None,
+        game: GameManagerProtocol | None = None,
     ) -> None:
         """Activate the Lasso event."""
         if game:

--- a/bang_py/cards/events/law_of_the_west.py
+++ b/bang_py/cards/events/law_of_the_west.py
@@ -8,7 +8,7 @@ from ...player import Player
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from ...game_manager import GameManager
+    from ...game_manager_protocol import GameManagerProtocol
 
 
 class LawOfTheWestEventCard(BaseEventCard):
@@ -25,7 +25,7 @@ class LawOfTheWestEventCard(BaseEventCard):
         self,
         target: Player | None = None,
         player: Player | None = None,
-        game: GameManager | None = None,
+        game: GameManagerProtocol | None = None,
     ) -> None:
         """Activate the Law of the West event."""
         if game:

--- a/bang_py/cards/events/new_identity.py
+++ b/bang_py/cards/events/new_identity.py
@@ -8,7 +8,7 @@ from ...player import Player
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from ...game_manager import GameManager
+    from ...game_manager_protocol import GameManagerProtocol
 
 
 class NewIdentityEventCard(BaseEventCard):
@@ -25,7 +25,7 @@ class NewIdentityEventCard(BaseEventCard):
         self,
         target: Player | None = None,
         player: Player | None = None,
-        game: GameManager | None = None,
+        game: GameManagerProtocol | None = None,
     ) -> None:
         """Activate the New Identity event."""
         if game:

--- a/bang_py/cards/events/peyote.py
+++ b/bang_py/cards/events/peyote.py
@@ -8,7 +8,7 @@ from ...player import Player
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from ...game_manager import GameManager
+    from ...game_manager_protocol import GameManagerProtocol
 
 
 class PeyoteEventCard(BaseEventCard):
@@ -25,7 +25,7 @@ class PeyoteEventCard(BaseEventCard):
         self,
         target: Player | None = None,
         player: Player | None = None,
-        game: GameManager | None = None,
+        game: GameManagerProtocol | None = None,
     ) -> None:
         """Activate the Peyote event."""
         if game:

--- a/bang_py/cards/events/ranch.py
+++ b/bang_py/cards/events/ranch.py
@@ -7,7 +7,7 @@ from ...player import Player
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from ...game_manager import GameManager
+    from ...game_manager_protocol import GameManagerProtocol
 
 
 class RanchEventCard(BaseEventCard):
@@ -21,7 +21,7 @@ class RanchEventCard(BaseEventCard):
         self,
         target: Player | None = None,
         player: Player | None = None,
-        game: GameManager | None = None,
+        game: GameManagerProtocol | None = None,
     ) -> None:
         """Activate the Ranch event."""
         if game:

--- a/bang_py/cards/events/ricochet.py
+++ b/bang_py/cards/events/ricochet.py
@@ -7,7 +7,7 @@ from ...player import Player
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from ...game_manager import GameManager
+    from ...game_manager_protocol import GameManagerProtocol
 
 
 class RicochetEventCard(BaseEventCard):
@@ -21,7 +21,7 @@ class RicochetEventCard(BaseEventCard):
         self,
         target: Player | None = None,
         player: Player | None = None,
-        game: GameManager | None = None,
+        game: GameManagerProtocol | None = None,
     ) -> None:
         """Activate the Ricochet event."""
         if game:

--- a/bang_py/cards/events/russian_roulette.py
+++ b/bang_py/cards/events/russian_roulette.py
@@ -11,7 +11,7 @@ from ..missed import MissedCard
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from ...game_manager import GameManager
+    from ...game_manager_protocol import GameManagerProtocol
 
 
 class RussianRouletteEventCard(BaseEventCard):
@@ -28,7 +28,7 @@ class RussianRouletteEventCard(BaseEventCard):
         self,
         target: Player | None = None,
         player: Player | None = None,
-        game: GameManager | None = None,
+        game: GameManagerProtocol | None = None,
     ) -> None:
         """Activate the Russian Roulette event."""
         if not game:

--- a/bang_py/cards/events/shootout.py
+++ b/bang_py/cards/events/shootout.py
@@ -8,7 +8,7 @@ from ...player import Player
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from ...game_manager import GameManager
+    from ...game_manager_protocol import GameManagerProtocol
 
 
 class ShootoutEventCard(BaseEventCard):
@@ -22,7 +22,7 @@ class ShootoutEventCard(BaseEventCard):
         self,
         target: Player | None = None,
         player: Player | None = None,
-        game: GameManager | None = None,
+        game: GameManagerProtocol | None = None,
     ) -> None:
         """Activate the Shootout event."""
         if game:

--- a/bang_py/cards/events/sniper.py
+++ b/bang_py/cards/events/sniper.py
@@ -9,7 +9,7 @@ from ...player import Player
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from ...game_manager import GameManager
+    from ...game_manager_protocol import GameManagerProtocol
 
 
 class SniperEventCard(BaseEventCard):
@@ -26,7 +26,7 @@ class SniperEventCard(BaseEventCard):
         self,
         target: Player | None = None,
         player: Player | None = None,
-        game: GameManager | None = None,
+        game: GameManagerProtocol | None = None,
     ) -> None:
         """Activate the Sniper event."""
         if game:

--- a/bang_py/cards/events/the_daltons.py
+++ b/bang_py/cards/events/the_daltons.py
@@ -8,7 +8,7 @@ from ...player import Player
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from ...game_manager import GameManager
+    from ...game_manager_protocol import GameManagerProtocol
 
 
 class TheDaltonsEventCard(BaseEventCard):
@@ -25,7 +25,7 @@ class TheDaltonsEventCard(BaseEventCard):
         self,
         target: Player | None = None,
         player: Player | None = None,
-        game: GameManager | None = None,
+        game: GameManagerProtocol | None = None,
     ) -> None:
         """Activate the The Daltons event."""
         if not game:

--- a/bang_py/cards/events/the_doctor.py
+++ b/bang_py/cards/events/the_doctor.py
@@ -8,7 +8,7 @@ from ...player import Player
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from ...game_manager import GameManager
+    from ...game_manager_protocol import GameManagerProtocol
 
 
 class TheDoctorEventCard(BaseEventCard):
@@ -25,7 +25,7 @@ class TheDoctorEventCard(BaseEventCard):
         self,
         target: Player | None = None,
         player: Player | None = None,
-        game: GameManager | None = None,
+        game: GameManagerProtocol | None = None,
     ) -> None:
         """Activate the The Doctor event."""
         if not game:

--- a/bang_py/cards/events/the_judge.py
+++ b/bang_py/cards/events/the_judge.py
@@ -10,7 +10,7 @@ from ...player import Player
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from ...game_manager import GameManager
+    from ...game_manager_protocol import GameManagerProtocol
 
 
 class TheJudgeEventCard(BaseEventCard):
@@ -24,7 +24,7 @@ class TheJudgeEventCard(BaseEventCard):
         self,
         target: Player | None = None,
         player: Player | None = None,
-        game: GameManager | None = None,
+        game: GameManagerProtocol | None = None,
     ) -> None:
         """Activate the Judge event."""
         if game:

--- a/bang_py/cards/events/the_reverend.py
+++ b/bang_py/cards/events/the_reverend.py
@@ -8,7 +8,7 @@ from ...player import Player
 from typing import TYPE_CHECKING, override
 
 if TYPE_CHECKING:
-    from ...game_manager import GameManager
+    from ...game_manager_protocol import GameManagerProtocol
 
 
 class TheReverendEventCard(BaseEventCard):
@@ -23,7 +23,7 @@ class TheReverendEventCard(BaseEventCard):
         self,
         target: Player | None = None,
         player: Player | None = None,
-        game: GameManager | None = None,
+        game: GameManagerProtocol | None = None,
     ) -> None:
         """Activate the Reverend event."""
         if game:

--- a/bang_py/cards/events/the_sermon.py
+++ b/bang_py/cards/events/the_sermon.py
@@ -7,7 +7,7 @@ from ...player import Player
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from ...game_manager import GameManager
+    from ...game_manager_protocol import GameManagerProtocol
 
 
 class TheSermonEventCard(BaseEventCard):
@@ -21,7 +21,7 @@ class TheSermonEventCard(BaseEventCard):
         self,
         target: Player | None = None,
         player: Player | None = None,
-        game: GameManager | None = None,
+        game: GameManagerProtocol | None = None,
     ) -> None:
         """Activate the Sermon event."""
         if game:

--- a/bang_py/cards/events/thirst.py
+++ b/bang_py/cards/events/thirst.py
@@ -7,7 +7,7 @@ from ...player import Player
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from ...game_manager import GameManager
+    from ...game_manager_protocol import GameManagerProtocol
 
 
 class ThirstEventCard(BaseEventCard):
@@ -21,7 +21,7 @@ class ThirstEventCard(BaseEventCard):
         self,
         target: Player | None = None,
         player: Player | None = None,
-        game: GameManager | None = None,
+        game: GameManagerProtocol | None = None,
     ) -> None:
         """Activate the Thirst event."""
         if game:

--- a/bang_py/cards/events/train_arrival.py
+++ b/bang_py/cards/events/train_arrival.py
@@ -8,7 +8,7 @@ from ...player import Player
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from ...game_manager import GameManager
+    from ...game_manager_protocol import GameManagerProtocol
 
 
 class TrainArrivalEventCard(BaseEventCard):
@@ -22,7 +22,7 @@ class TrainArrivalEventCard(BaseEventCard):
         self,
         target: Player | None = None,
         player: Player | None = None,
-        game: GameManager | None = None,
+        game: GameManagerProtocol | None = None,
     ) -> None:
         """Activate the Train Arrival event."""
         if game:

--- a/bang_py/cards/events/vendetta.py
+++ b/bang_py/cards/events/vendetta.py
@@ -8,7 +8,7 @@ from ...player import Player
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from ...game_manager import GameManager
+    from ...game_manager_protocol import GameManagerProtocol
 
 
 class VendettaEventCard(BaseEventCard):
@@ -25,7 +25,7 @@ class VendettaEventCard(BaseEventCard):
         self,
         target: Player | None = None,
         player: Player | None = None,
-        game: GameManager | None = None,
+        game: GameManagerProtocol | None = None,
     ) -> None:
         """Activate the Vendetta event."""
         if game:

--- a/bang_py/cards/gatling.py
+++ b/bang_py/cards/gatling.py
@@ -6,7 +6,7 @@ from ..player import Player
 from typing import Any, TYPE_CHECKING, override
 
 if TYPE_CHECKING:
-    from ..game_manager import GameManager
+    from ..game_manager_protocol import GameManagerProtocol
 
 
 class GatlingCard(BaseCard):
@@ -20,7 +20,7 @@ class GatlingCard(BaseCard):
         self,
         target: Player | None,
         player: Player | None = None,
-        game: GameManager | None = None,
+        game: GameManagerProtocol | None = None,
         **kwargs: Any,
     ) -> None:
         if not game or not player:

--- a/bang_py/cards/general_store.py
+++ b/bang_py/cards/general_store.py
@@ -7,7 +7,7 @@ from ..player import Player
 from typing import Any, TYPE_CHECKING, override
 
 if TYPE_CHECKING:
-    from ..game_manager import GameManager
+    from ..game_manager_protocol import GameManagerProtocol
 
 
 class GeneralStoreCard(BaseCard):
@@ -21,7 +21,7 @@ class GeneralStoreCard(BaseCard):
         self,
         target: Player | None,
         player: Player | None = None,
-        game: GameManager | None = None,
+        game: GameManagerProtocol | None = None,
         choices: list[int] | None = None,
         **kwargs: Any,
     ) -> None:

--- a/bang_py/cards/high_noon_card.py
+++ b/bang_py/cards/high_noon_card.py
@@ -6,7 +6,7 @@ from ..player import Player
 from typing import Any, TYPE_CHECKING, override
 
 if TYPE_CHECKING:
-    from ..game_manager import GameManager
+    from ..game_manager_protocol import GameManagerProtocol
 
 
 class HighNoonCard(BaseCard):
@@ -22,7 +22,7 @@ class HighNoonCard(BaseCard):
         self,
         target: Player | None = None,
         player: Player | None = None,
-        game: GameManager | None = None,
+        game: GameManagerProtocol | None = None,
         **kwargs: Any,
     ) -> None:
         if not game:

--- a/bang_py/cards/howitzer.py
+++ b/bang_py/cards/howitzer.py
@@ -6,7 +6,7 @@ from ..player import Player
 from typing import Any, TYPE_CHECKING, override
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
-    from ..game_manager import GameManager
+    from ..game_manager_protocol import GameManagerProtocol
 
 from .bang import BangCard
 
@@ -24,7 +24,7 @@ class HowitzerCard(BaseCard):
         self,
         target: Player | None,
         player: Player | None = None,
-        game: GameManager | None = None,
+        game: GameManagerProtocol | None = None,
         **kwargs: Any,
     ) -> None:
         if not game or not player:

--- a/bang_py/cards/indians.py
+++ b/bang_py/cards/indians.py
@@ -7,7 +7,7 @@ from ..helpers import handle_out_of_turn_discard
 from typing import Any, TYPE_CHECKING, override
 
 if TYPE_CHECKING:
-    from ..game_manager import GameManager
+    from ..game_manager_protocol import GameManagerProtocol
 
 
 class IndiansCard(BaseCard):
@@ -21,7 +21,7 @@ class IndiansCard(BaseCard):
         self,
         target: Player | None,
         player: Player | None = None,
-        game: GameManager | None = None,
+        game: GameManagerProtocol | None = None,
         **kwargs: Any,
     ) -> None:
         if not game or not player:

--- a/bang_py/cards/knife.py
+++ b/bang_py/cards/knife.py
@@ -6,7 +6,7 @@ from ..player import Player
 from typing import Any, TYPE_CHECKING, override
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
-    from ..game_manager import GameManager
+    from ..game_manager_protocol import GameManagerProtocol
 
 from .bang import BangCard
 
@@ -24,7 +24,7 @@ class KnifeCard(BaseCard):
         self,
         target: Player | None,
         player: Player | None = None,
-        game: GameManager | None = None,
+        game: GameManagerProtocol | None = None,
         **kwargs: Any,
     ) -> None:
         if not target or not player:

--- a/bang_py/cards/panic.py
+++ b/bang_py/cards/panic.py
@@ -8,7 +8,7 @@ from typing import Any, TYPE_CHECKING, override
 from ..helpers import handle_out_of_turn_discard
 
 if TYPE_CHECKING:
-    from ..game_manager import GameManager
+    from ..game_manager_protocol import GameManagerProtocol
 
 
 class PanicCard(BaseCard):
@@ -22,7 +22,7 @@ class PanicCard(BaseCard):
         self,
         target: Player | None,
         player: Player | None = None,
-        game: GameManager | None = None,
+        game: GameManagerProtocol | None = None,
         *,
         hand_idx: int | None = None,
         equip_name: str | None = None,

--- a/bang_py/cards/pepperbox.py
+++ b/bang_py/cards/pepperbox.py
@@ -6,7 +6,7 @@ from ..player import Player
 from typing import Any, TYPE_CHECKING, override
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
-    from ..game_manager import GameManager
+    from ..game_manager_protocol import GameManagerProtocol
 
 from .bang import BangCard
 
@@ -24,7 +24,7 @@ class PepperboxCard(BaseCard):
         self,
         target: Player | None,
         player: Player | None = None,
-        game: GameManager | None = None,
+        game: GameManagerProtocol | None = None,
         **kwargs: Any,
     ) -> None:
         if not target or not player:

--- a/bang_py/cards/pony_express.py
+++ b/bang_py/cards/pony_express.py
@@ -6,7 +6,7 @@ from ..player import Player
 from typing import Any, TYPE_CHECKING, override
 
 if TYPE_CHECKING:
-    from ..game_manager import GameManager
+    from ..game_manager_protocol import GameManagerProtocol
 
 
 class PonyExpressCard(BaseCard):
@@ -22,7 +22,7 @@ class PonyExpressCard(BaseCard):
         self,
         target: Player | None = None,
         player: Player | None = None,
-        game: GameManager | None = None,
+        game: GameManagerProtocol | None = None,
         **kwargs: Any,
     ) -> None:
         if player and game:

--- a/bang_py/cards/rag_time.py
+++ b/bang_py/cards/rag_time.py
@@ -7,7 +7,7 @@ from ..player import Player
 from typing import Any, TYPE_CHECKING, override
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
-    from ..game_manager import GameManager
+    from ..game_manager_protocol import GameManagerProtocol
 
 from ..helpers import handle_out_of_turn_discard
 
@@ -25,7 +25,7 @@ class RagTimeCard(BaseCard):
         self,
         target: Player | None,
         player: Player | None = None,
-        game: GameManager | None = None,
+        game: GameManagerProtocol | None = None,
         *,
         discard_idx: int = 0,
         steal_idx: int = 0,

--- a/bang_py/cards/saloon.py
+++ b/bang_py/cards/saloon.py
@@ -6,7 +6,7 @@ from ..player import Player
 from typing import Any, TYPE_CHECKING, override
 
 if TYPE_CHECKING:
-    from ..game_manager import GameManager
+    from ..game_manager_protocol import GameManagerProtocol
 
 
 class SaloonCard(BaseCard):
@@ -20,7 +20,7 @@ class SaloonCard(BaseCard):
         self,
         target: Player | None,
         player: Player | None = None,
-        game: GameManager | None = None,
+        game: GameManagerProtocol | None = None,
         **kwargs: Any,
     ) -> None:
         if not game:

--- a/bang_py/cards/springfield.py
+++ b/bang_py/cards/springfield.py
@@ -6,7 +6,7 @@ from ..player import Player
 from typing import Any, TYPE_CHECKING, override
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
-    from ..game_manager import GameManager
+    from ..game_manager_protocol import GameManagerProtocol
 
 from .bang import BangCard
 from ..helpers import handle_out_of_turn_discard
@@ -25,7 +25,7 @@ class SpringfieldCard(BaseCard):
         self,
         target: Player | None,
         player: Player | None = None,
-        game: GameManager | None = None,
+        game: GameManagerProtocol | None = None,
         *,
         discard_idx: int = 0,
         **kwargs: Any,

--- a/bang_py/cards/stagecoach.py
+++ b/bang_py/cards/stagecoach.py
@@ -7,7 +7,7 @@ from typing import Any, TYPE_CHECKING, override
 
 if TYPE_CHECKING:
     from ..deck import Deck
-    from ..game_manager import GameManager
+    from ..game_manager_protocol import GameManagerProtocol
 
 
 class StagecoachCard(BaseCard):
@@ -20,7 +20,7 @@ class StagecoachCard(BaseCard):
     def play(
         self,
         target: Player | None,
-        game: GameManager | None = None,
+        game: GameManagerProtocol | None = None,
         deck: Deck | None = None,
         **kwargs: Any,
     ) -> None:

--- a/bang_py/cards/tequila.py
+++ b/bang_py/cards/tequila.py
@@ -8,7 +8,7 @@ from typing import Any, TYPE_CHECKING, override
 from ..helpers import handle_out_of_turn_discard
 
 if TYPE_CHECKING:
-    from ..game_manager import GameManager
+    from ..game_manager_protocol import GameManagerProtocol
 
 
 class TequilaCard(BaseCard):
@@ -24,7 +24,7 @@ class TequilaCard(BaseCard):
         self,
         target: Player | None,
         player: Player | None = None,
-        game: GameManager | None = None,
+        game: GameManagerProtocol | None = None,
         *,
         discard_idx: int = 0,
         **kwargs: Any,

--- a/bang_py/cards/wells_fargo.py
+++ b/bang_py/cards/wells_fargo.py
@@ -7,7 +7,7 @@ from typing import Any, TYPE_CHECKING, override
 
 if TYPE_CHECKING:
     from ..deck import Deck
-    from ..game_manager import GameManager
+    from ..game_manager_protocol import GameManagerProtocol
 
 
 class WellsFargoCard(BaseCard):
@@ -20,7 +20,7 @@ class WellsFargoCard(BaseCard):
     def play(
         self,
         target: Player | None,
-        game: GameManager | None = None,
+        game: GameManagerProtocol | None = None,
         deck: Deck | None = None,
         **kwargs: Any,
     ) -> None:

--- a/bang_py/cards/whisky.py
+++ b/bang_py/cards/whisky.py
@@ -8,7 +8,7 @@ from typing import Any, TYPE_CHECKING, override
 from ..helpers import handle_out_of_turn_discard
 
 if TYPE_CHECKING:
-    from ..game_manager import GameManager
+    from ..game_manager_protocol import GameManagerProtocol
 
 
 class WhiskyCard(BaseCard):
@@ -24,7 +24,7 @@ class WhiskyCard(BaseCard):
         self,
         target: Player | None,
         player: Player | None = None,
-        game: GameManager | None = None,
+        game: GameManagerProtocol | None = None,
         *,
         discard_idx: int = 0,
         **kwargs: Any,


### PR DESCRIPTION
## Summary
- swap GameManager annotations for GameManagerProtocol across card `play` methods
- annotate Bang handlers to accept `GameManagerProtocol`

## Testing
- `pre-commit run --files $(git status --short | awk '{print $2}' | tr '\n' ' ')` *(fails: mypy reports numerous type errors)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68969e2ad97c8323a66f6ef921476e1d