### PR TITLE
Ensure Molly Stark metadata safe

### DIFF
--- a/bang_py/characters/molly_stark.py
+++ b/bang_py/characters/molly_stark.py
@@ -22,8 +22,7 @@ class MollyStark(BaseCharacter):
 
     def ability(self, gm: "GameManager", player: "Player", **_: object) -> bool:
         player.metadata.abilities.add(MollyStark)
-        if player.metadata.molly_choices is None:
-            player.metadata.molly_choices = {}
+        player.metadata.molly_choices = player.metadata.molly_choices or {}
         return True
 
     def on_out_of_turn_discard(self, gm: "GameManager", player: "Player", card: "BaseCard") -> None:

--- a/bang_py/player.py
+++ b/bang_py/player.py
@@ -33,7 +33,7 @@ class PlayerMetadata:
     kit_cards: list["BaseCard"] | None = None
     lucky_cards: list["BaseCard"] | None = None
     gringo_index: int | None = None
-    molly_choices: dict[int, bool] | None = None
+    molly_choices: dict[int, bool] = field(default_factory=dict)
     uncle_used: bool = False
     vera_copy: type["BaseCharacter"] | None = None
     unused_character: "BaseCharacter | None" = None


### PR DESCRIPTION
## Summary
- guarantee a dictionary exists for Molly Stark's choice tracking
- store Molly Stark choices directly on `PlayerMetadata`

## Testing
- `pre-commit run --files bang_py/player.py bang_py/characters/molly_stark.py` *(fails: mypy - 94 errors)*
- `SKIP=mypy pre-commit run --files bang_py/player.py bang_py/characters/molly_stark.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68969e3571a08323a0f06ebc0d1246f2