### PR TITLE
Expand game manager hooks and refine card dispatch

### DIFF
--- a/bang_py/card_handlers/bang_handlers.py
+++ b/bang_py/card_handlers/bang_handlers.py
@@ -18,7 +18,7 @@ class BangHandlersMixin:
     """Mixin providing Bang-specific card resolution helpers."""
 
     def _play_bang_card(
-        self,
+        self: GameManagerProtocol,
         player: "Player",
         card: BangCard,
         target: "Player" | None,
@@ -67,7 +67,7 @@ class BangHandlersMixin:
         if not self.event_flags.get("river"):
             handle_out_of_turn_discard(self, player, card)
 
-    def _auto_miss(self, target: "Player") -> bool:
+    def _auto_miss(self: GameManagerProtocol, target: "Player") -> bool:
         """Attempt to satisfy a Bang! with automatic Missed! effects."""
         if not self._should_use_auto_miss(target):
             return False
@@ -85,7 +85,7 @@ class BangHandlersMixin:
             return False
         return target.metadata.auto_miss is not False
 
-    def _use_miss_card(self, target: "Player") -> bool:
+    def _use_miss_card(self: GameManagerProtocol, target: "Player") -> bool:
         """Use a Missed! card from ``target`` if available."""
         miss = next((c for c in target.hand if isinstance(c, MissedCard)), None)
         if miss:
@@ -95,7 +95,7 @@ class BangHandlersMixin:
             return True
         return False
 
-    def _use_bang_as_miss(self, target: "Player") -> bool:
+    def _use_bang_as_miss(self: GameManagerProtocol, target: "Player") -> bool:
         """Use a Bang! card as a Missed! if allowed."""
         if target.metadata.bang_as_missed:
             bang = next((c for c in target.hand if isinstance(c, BangCard)), None)
@@ -106,7 +106,7 @@ class BangHandlersMixin:
                 return True
         return False
 
-    def _use_any_card_as_miss(self, target: "Player") -> bool:
+    def _use_any_card_as_miss(self: GameManagerProtocol, target: "Player") -> bool:
         """Use any card as a Missed! if permitted by effects."""
         if target.metadata.any_card_as_missed and target.hand:
             card = target.hand.pop()

--- a/bang_py/card_handlers/dispatch.py
+++ b/bang_py/card_handlers/dispatch.py
@@ -74,7 +74,7 @@ class DispatchMixin:
         target: "Player" | None,
     ) -> None:
         if target:
-            card.play(target, player, game=self)
+            card.play(target, player=player, game=self)
 
     def _handler_self_player_game(
         self: GameManagerProtocol,
@@ -82,7 +82,7 @@ class DispatchMixin:
         card: BaseCard,
         target: "Player" | None,
     ) -> None:
-        card.play(player, player, game=self)
+        card.play(player, player=player, game=self)
 
     def _handler_target_or_self_player_game(
         self: GameManagerProtocol,
@@ -90,7 +90,7 @@ class DispatchMixin:
         card: BaseCard,
         target: "Player" | None,
     ) -> None:
-        card.play(target or player, player, game=self)
+        card.play(target or player, player=player, game=self)
 
     def _handler_target_player(
         self: GameManagerProtocol,
@@ -99,7 +99,7 @@ class DispatchMixin:
         target: "Player" | None,
     ) -> None:
         if target:
-            card.play(target, player)
+            card.play(target, player=player)
 
     def _register_card_handlers(
         self: GameManagerProtocol, groups: Iterable[str] | None = None

--- a/bang_py/game_manager.py
+++ b/bang_py/game_manager.py
@@ -99,3 +99,11 @@ class GameManager(
         self.initialize_main_deck()
         self.initialize_event_deck()
         self.register_card_handlers()
+
+    def on_player_damaged(self, player: Player, source: Player | None = None) -> None:
+        """Hook fired when a player takes damage."""
+        super().on_player_damaged(player, source)
+
+    def on_player_healed(self, player: Player) -> None:
+        """Hook fired when a player regains health."""
+        super().on_player_healed(player)


### PR DESCRIPTION
## Summary
- declare new player and event hooks on GameManagerProtocol
- stub damage and heal hooks on GameManager
- tighten card handler dispatch calls and typing

## Testing
- `pre-commit run --files bang_py/card_handlers/bang_handlers.py bang_py/card_handlers/dispatch.py bang_py/game_manager.py bang_py/game_manager_protocol.py` *(fails: "GameManagerProtocol" has no attribute "_consume_sniper_extra", etc.)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'websockets')*
- `mypy bang_py` *(fails: "GameManager" has no attribute "sid_ketchum_ability", etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68969e41424883239715172cc211824c