### PR TITLE
Type mixin helpers via GameManagerProtocol

### DIFF
--- a/bang_py/game_manager.py
+++ b/bang_py/game_manager.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from collections.abc import Callable, Iterable, Sequence
 from collections import deque
+from typing import cast
 
 from .ability_dispatch import AbilityDispatchMixin
 from .card_handlers import CardHandlersMixin
@@ -16,6 +17,7 @@ from .events.event_decks import EventCard
 from .events.event_hooks import EventHooksMixin
 from .events.event_logic import EventLogicMixin
 from .general_store import GeneralStoreMixin
+from .game_manager_protocol import GameManagerProtocol
 from .player import Player
 from .turn_phases import TurnPhasesMixin
 
@@ -40,7 +42,7 @@ class GameManager(
     turn_order: list[int] = field(default_factory=list)
     event_deck: deque[EventCard] | None = None
     current_event: EventCard | None = None
-    event_flags: EventFlags = field(default_factory=dict)
+    event_flags: EventFlags = field(default_factory=lambda: cast(EventFlags, {}))
     first_eliminated: Player | None = None
     sheriff_turns: int = 0
     phase: str = "draw"
@@ -84,15 +86,18 @@ class GameManager(
     # Protocol wrappers
     def initialize_main_deck(self) -> None:
         """Create the main deck and reset event flags."""
-        self._initialize_main_deck()
+        gm: GameManagerProtocol = cast(GameManagerProtocol, self)
+        gm._initialize_main_deck()
 
     def initialize_event_deck(self) -> None:
         """Build the event deck based on active expansions."""
-        self._initialize_event_deck()
+        gm: GameManagerProtocol = cast(GameManagerProtocol, self)
+        gm._initialize_event_deck()
 
     def register_card_handlers(self, groups: Iterable[str] | None = None) -> None:
         """Populate the card handler registry."""
-        self._register_card_handlers(groups)
+        gm: GameManagerProtocol = cast(GameManagerProtocol, self)
+        gm._register_card_handlers(groups)
 
     def __post_init__(self) -> None:
         """Initialize decks and register card handlers."""

--- a/bang_py/game_manager_protocol.py
+++ b/bang_py/game_manager_protocol.py
@@ -62,6 +62,15 @@ class GameManagerProtocol(Protocol):
     def register_card_handlers(self, groups: Iterable[str] | None = None) -> None:
         """Populate the card handler registry."""
 
+    def _initialize_main_deck(self) -> None:
+        """Create the main deck if needed and ensure event flags exist."""
+
+    def _initialize_event_deck(self) -> None:
+        """Build and shuffle the event deck based on active expansions."""
+
+    def _register_card_handlers(self, groups: Iterable[str] | None = None) -> None:
+        """Populate the card handler registry."""
+
     def draw_card(self, player: Player, num: int = 1) -> None:
         """Draw ``num`` cards for ``player``."""
 


### PR DESCRIPTION
## Summary
- Cast `GameManager` wrapper methods to `GameManagerProtocol` before invoking mixin helper functions
- Declare `_initialize_main_deck`, `_initialize_event_deck`, and `_register_card_handlers` in `GameManagerProtocol`

## Testing
- `pre-commit run --hook-stage manual --files bang_py/game_manager.py bang_py/game_manager_protocol.py` *(fails: mypy missing attributes in unrelated modules)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896b0969d8483238040faed121387cb