### PR TITLE
feat: import deck for discard phase

### DIFF
--- a/bang_py/turn_phases/discard_phase.py
+++ b/bang_py/turn_phases/discard_phase.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from bang_py.deck import Deck
 from ..cards.card import BaseCard
 from ..event_flags import EventFlags
 from ..game_manager_protocol import GameManagerProtocol


### PR DESCRIPTION
## Summary
- add Deck import to discard phase mixin
- keep deck attribute type consistent with draw phase mixin

## Testing
- `SKIP=mypy pre-commit run --files bang_py/turn_phases/discard_phase.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896b412f30c83238eef0e77e1b4258e