### PR TITLE
Add auto-miss helpers to GameManager protocol

### DIFF
--- a/bang_py/card_handlers/bang_handlers.py
+++ b/bang_py/card_handlers/bang_handlers.py
@@ -48,16 +48,16 @@ class BangHandlersMixin:
                 return True
         return False
 
-    def _attempt_double_dodge(self: GameManagerProtocol, target: "Player") -> bool:
-        """Let ``target`` discard two Missed! cards to dodge a Bang!."""
-        misses = [c for c in target.hand if isinstance(c, MissedCard)]
+    def _attempt_double_dodge(self: GameManagerProtocol, player: "Player") -> bool:
+        """Let ``player`` discard two Missed! cards to dodge a Bang!."""
+        misses = [c for c in player.hand if isinstance(c, MissedCard)]
         if len(misses) >= 2:
             for _ in range(2):
                 mcard = misses.pop()
-                target.hand.remove(mcard)
+                player.hand.remove(mcard)
                 self.discard_pile.append(mcard)
-                handle_out_of_turn_discard(self, target, mcard)
-            target.metadata.dodged = True
+                handle_out_of_turn_discard(self, player, mcard)
+            player.metadata.dodged = True
             return True
         return False
 
@@ -85,33 +85,33 @@ class BangHandlersMixin:
             return False
         return target.metadata.auto_miss is not False
 
-    def _use_miss_card(self: GameManagerProtocol, target: "Player") -> bool:
-        """Use a Missed! card from ``target`` if available."""
-        miss = next((c for c in target.hand if isinstance(c, MissedCard)), None)
+    def _use_miss_card(self: GameManagerProtocol, player: "Player") -> bool:
+        """Use a Missed! card from ``player`` if available."""
+        miss = next((c for c in player.hand if isinstance(c, MissedCard)), None)
         if miss:
-            target.hand.remove(miss)
-            self._discard_and_record(target, miss)
-            target.metadata.dodged = True
+            player.hand.remove(miss)
+            self._discard_and_record(player, miss)
+            player.metadata.dodged = True
             return True
         return False
 
-    def _use_bang_as_miss(self: GameManagerProtocol, target: "Player") -> bool:
+    def _use_bang_as_miss(self: GameManagerProtocol, player: "Player") -> bool:
         """Use a Bang! card as a Missed! if allowed."""
-        if target.metadata.bang_as_missed:
-            bang = next((c for c in target.hand if isinstance(c, BangCard)), None)
+        if player.metadata.bang_as_missed:
+            bang = next((c for c in player.hand if isinstance(c, BangCard)), None)
             if bang:
-                target.hand.remove(bang)
-                self._discard_and_record(target, bang)
-                target.metadata.dodged = True
+                player.hand.remove(bang)
+                self._discard_and_record(player, bang)
+                player.metadata.dodged = True
                 return True
         return False
 
-    def _use_any_card_as_miss(self: GameManagerProtocol, target: "Player") -> bool:
+    def _use_any_card_as_miss(self: GameManagerProtocol, player: "Player") -> bool:
         """Use any card as a Missed! if permitted by effects."""
-        if target.metadata.any_card_as_missed and target.hand:
-            card = target.hand.pop()
-            self._discard_and_record(target, card)
-            target.metadata.dodged = True
+        if player.metadata.any_card_as_missed and player.hand:
+            card = player.hand.pop()
+            self._discard_and_record(player, card)
+            player.metadata.dodged = True
             return True
         return False
 

--- a/bang_py/game_manager_protocol.py
+++ b/bang_py/game_manager_protocol.py
@@ -10,6 +10,7 @@ from .event_flags import EventFlags
 
 if TYPE_CHECKING:  # pragma: no cover - imported for type checking
     from .cards.card import BaseCard
+    from .cards.bang import BangCard
     from .cards.roles import BaseRole
     from .characters.base import BaseCharacter
     from .deck import Deck
@@ -269,11 +270,29 @@ class GameManagerProtocol(Protocol):
     def _draw_if_empty(self, player: Player) -> None:
         """Draw a card if ``player`` has an empty hand and may draw."""
 
+    def _consume_sniper_extra(self, player: Player, card: BangCard) -> bool:
+        """Discard an extra Bang! for Sniper and return ``True`` if used."""
+
+    def _attempt_double_dodge(self, player: Player) -> bool:
+        """Let ``player`` discard two Missed! cards to dodge a Bang!."""
+
     def _discard_and_record(self, player: Player, card: BaseCard) -> None:
         """Discard ``card`` from ``player`` and record out-of-turn discard."""
 
+    def _auto_miss(self, player: Player) -> bool:
+        """Attempt to satisfy a Bang! with automatic Missed! effects."""
+
     def _should_use_auto_miss(self, target: Player) -> bool:
         """Return ``True`` if automatic Missed! effects may apply."""
+
+    def _use_miss_card(self, player: Player) -> bool:
+        """Use a Missed! card from ``player`` if available."""
+
+    def _use_bang_as_miss(self, player: Player) -> bool:
+        """Use a Bang! card as a Missed! if allowed."""
+
+    def _use_any_card_as_miss(self, player: Player) -> bool:
+        """Use any card as a Missed! when permitted."""
 
     def _update_bang_counters(self, player: Player) -> None:
         """Update per-turn Bang! counters for ``player``."""


### PR DESCRIPTION
## Summary
- declare sniper and auto-miss helpers in `GameManagerProtocol`
- standardize Bang! handler helper parameters on `player`

## Testing
- `pre-commit run --files bang_py/game_manager_protocol.py bang_py/card_handlers/bang_handlers.py` *(fails: mypy errors in unrelated files)*
- `SKIP=mypy pre-commit run --files bang_py/game_manager_protocol.py bang_py/card_handlers/bang_handlers.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896b987c1c48323956bbcdd21d24283