### PR TITLE
Align deck attribute typing across mixins

### DIFF
--- a/bang_py/events/event_logic.py
+++ b/bang_py/events/event_logic.py
@@ -10,9 +10,10 @@ from typing import Any
 
 from .event_decks import EventCard, create_high_noon_deck, create_fistful_deck
 from ..cards.roles import SheriffRoleCard
-from ..player import Player
-from ..game_manager_protocol import GameManagerProtocol
+from ..deck import Deck
 from ..event_flags import EventFlags
+from ..game_manager_protocol import GameManagerProtocol
+from ..player import Player
 
 
 class EventLogicMixin:
@@ -22,7 +23,7 @@ class EventLogicMixin:
     current_event: EventCard | None
     event_flags: EventFlags
     expansions: list[str]
-    deck: object
+    deck: Deck | None
     discard_pile: list[Any]
     _players: list[Any]
     turn_order: list[int]

--- a/bang_py/general_store.py
+++ b/bang_py/general_store.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from .cards.card import BaseCard
+from .deck import Deck
 from .game_manager_protocol import GameManagerProtocol
 
 if TYPE_CHECKING:
@@ -17,7 +18,7 @@ class GeneralStoreMixin:
     general_store_cards: list[BaseCard] | None
     general_store_order: list["Player"] | None
     general_store_index: int
-    deck: object
+    deck: Deck | None
     discard_pile: list[BaseCard]
     _players: list["Player"]
 

--- a/bang_py/turn_phases/turn_flow.py
+++ b/bang_py/turn_phases/turn_flow.py
@@ -9,6 +9,7 @@ from ..characters.jose_delgado import JoseDelgado
 from ..characters.kit_carlson import KitCarlson
 from ..characters.pat_brennan import PatBrennan
 from ..characters.pedro_ramirez import PedroRamirez
+from ..deck import Deck
 from ..event_flags import EventFlags
 from ..game_manager_protocol import GameManagerProtocol
 
@@ -27,7 +28,7 @@ class TurnFlowMixin:
     play_phase_listeners: list
     turn_started_listeners: list
     discard_pile: list
-    deck: object
+    deck: Deck | None
     event_flags: EventFlags
 
     def play_phase(self: GameManagerProtocol, player: "Player") -> None:


### PR DESCRIPTION
## Summary
- type `deck` as `Deck | None` in turn flow, general store, and event logic helpers to match draw phase

## Testing
- `python -m pre_commit run --files bang_py/events/event_logic.py bang_py/general_store.py bang_py/turn_phases/turn_flow.py` *(fails: mypy error in bang_py/characters/molly_stark.py)*
- `SKIP=mypy python -m pre_commit run --files bang_py/events/event_logic.py bang_py/general_store.py bang_py/turn_phases/turn_flow.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896c151c67c832396ac9da462798e00