### PR TITLE
Add pydocstyle to pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,10 @@ repos:
     rev: 7.1.1
     hooks:
       - id: flake8
+  - repo: https://github.com/PyCQA/pydocstyle
+    rev: 6.3.0
+    hooks:
+      - id: pydocstyle
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.11.2
     hooks:


### PR DESCRIPTION
## Summary
- run pydocstyle via pre-commit to enforce docstring conventions

## Testing
- `pre-commit run --files .pre-commit-config.yaml README.md`
- `BANG_AUTO_CLOSE=1 pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896c9104f548323bb09045b9d5900a7