### PR TITLE
Log join token via logging in CLI

### DIFF
--- a/bang_py/network/cli.py
+++ b/bang_py/network/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import logging
 from collections.abc import Sequence
 
 from .server import BangServer
@@ -38,7 +39,7 @@ def main(argv: Sequence[str] | None = None) -> None:
     )
 
     if args.show_token:
-        print(server.generate_join_token())
+        logging.info(server.generate_join_token())
         return
 
     asyncio.run(server.start())


### PR DESCRIPTION
## Summary
- import logging in CLI and log join token instead of printing

## Testing
- `pre-commit run --files bang_py/network/cli.py` *(fails: mypy errors in unrelated files)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896c91f929483238b829a38cbfff87b