### PR TITLE
test: merge CardHandlersMixin checks

### DIFF
--- a/tests/test_handler_registry.py
+++ b/tests/test_handler_registry.py
@@ -10,6 +10,9 @@ from bang_py.card_handlers import (
 
 
 def test_register_specific_handler_groups():
+    assert hasattr(CardHandlersMixin, "_dispatch_play")
+    assert hasattr(CardHandlersMixin, "_play_bang_card")
+
     deck = Deck([BangCard(), BangCard(), BangCard()])
     gm = GameManager(deck=deck)
     gm._card_handlers = {}
@@ -26,9 +29,3 @@ def test_register_specific_handler_groups():
     register_handler_groups(gm, ["basic", "green"])
     gm.play_card(p1, p1.hand[0])
     assert len(p1.hand) == 3
-
-
-def test_card_handlers_mixin_includes_methods() -> None:
-    """CardHandlersMixin should expose combined dispatch helpers."""
-    assert hasattr(CardHandlersMixin, "_dispatch_play")
-    assert hasattr(CardHandlersMixin, "_play_bang_card")


### PR DESCRIPTION
## Summary
- merge CardHandlersMixin helper assertions into existing handler registry test

## Testing
- `pre-commit run --files tests/test_handler_registry.py` *(fails: bang_py/card_handlers/dispatch.py:293: Invalid self argument "DispatchMixin" to attribute function "_pass_left_or_discard")*
- `pytest tests/test_handler_registry.py`


------
https://chatgpt.com/codex/tasks/task_e_6896c93704e48323909f3fe15afadce6