### PR TITLE
Handle specific exceptions when stopping client thread

### DIFF
--- a/bang_py/ui/components/network_threads.py
+++ b/bang_py/ui/components/network_threads.py
@@ -105,9 +105,6 @@ class ClientThread(_QThread):
                 fut.result(timeout=1)
             except (asyncio.TimeoutError, WebSocketException) as exc:
                 logging.exception("Error while closing websocket: %s", exc)
-            except Exception as exc:
-                logging.exception("Unexpected error while closing websocket: %s", exc)
-                raise
         if self.loop.is_running():
             self.loop.call_soon_threadsafe(self.loop.stop)
 


### PR DESCRIPTION
## Summary
- Avoid swallowing unexpected errors when shutting down client connections
- Catch only `asyncio.TimeoutError` and `WebSocketException` during client thread shutdown

## Testing
- `pre-commit run --files bang_py/ui/components/network_threads.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896ebd8bdd88323b9b9782434fbdfb5