### PR TITLE
Refactor Molly Stark metadata handling

### DIFF
--- a/bang_py/characters/molly_stark.py
+++ b/bang_py/characters/molly_stark.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from .base import BaseCharacter
 
@@ -21,11 +21,10 @@ class MollyStark(BaseCharacter):
     starting_health = 4
 
     def ability(self, gm: "GameManagerProtocol", player: "Player", **_: object) -> bool:
-        try:
-            player.metadata = player.metadata or {}  # type: ignore[misc, assignment]
-        except AttributeError:
-            pass
-        metadata: Any = player.metadata
+        player_any = cast(Any, player)
+        if player_any.metadata is None:
+            player_any.metadata = {}
+        metadata: Any = player_any.metadata
         if isinstance(metadata, dict):
             metadata.setdefault("abilities", set()).add(MollyStark)
             metadata.setdefault("molly_choices", {})


### PR DESCRIPTION
## Summary
- avoid blanket try/except in Molly Stark ability
- initialize player metadata only when missing

## Testing
- `pre-commit run --files bang_py/characters/molly_stark.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896f2456574832384e7276b47219a05