### PR TITLE
Wrap Makefile targets with uv run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,10 @@
 build-exe:
 >mkdir -p build/bang
 >echo "[Paths]\nPrefix=." > build/bang/qt.conf
->pyinstaller scripts/bang.spec
+>uv run pyinstaller scripts/bang.spec
 
 lint:
->@pre-commit run --files $(if $(FILES),$(FILES),$(shell git ls-files '*.py'))
+>@uv run pre-commit run --files $(if $(FILES),$(FILES),$(shell git ls-files '*.py'))
 
 test:
->@pytest
+>@uv run pytest


### PR DESCRIPTION
## Summary
- ensure Makefile targets execute tools in uv-managed environment

## Testing
- `uv run --extra dev pre-commit run --files Makefile`
- `uv run --extra dev pytest`


------
https://chatgpt.com/codex/tasks/task_e_689703dd9a688323b328e9c42e9f2a3a