### PR TITLE
Use deque for deck storage and refactor draw phase

### DIFF
--- a/bang_py/deck.py
+++ b/bang_py/deck.py
@@ -37,5 +37,15 @@ class Deck:
         """
         self.cards.extendleft(cards)
 
+    def extend(self, cards: Iterable[BaseCard]) -> None:
+        """Append multiple cards to the bottom of the deck."""
+        self.cards.extend(cards)
+
+    def shuffle(self) -> None:
+        """Shuffle the deck in-place."""
+        card_list = list(self.cards)
+        shuffle(card_list)
+        self.cards = deque(card_list)
+
     def __len__(self) -> int:
         return len(self.cards)

--- a/bang_py/turn_phases/draw_phase.py
+++ b/bang_py/turn_phases/draw_phase.py
@@ -3,8 +3,6 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, cast
-from collections import deque
-import random
 
 from ..cards.card import BaseCard
 from ..deck import Deck
@@ -38,11 +36,9 @@ class DrawPhaseMixin:
             raise RuntimeError("Deck required")
         card = deck.draw()
         if card is None and self.discard_pile:
-            deck.cards.extend(self.discard_pile)
+            deck.extend(self.discard_pile)
             self.discard_pile.clear()
-            cards = list(deck.cards)
-            random.shuffle(cards)
-            deck.cards = deque(cards)
+            deck.shuffle()
             card = deck.draw()
         return card
 


### PR DESCRIPTION
## Summary
- Switch `Deck` card storage to `collections.deque` and add helpers to extend and shuffle the deck
- Refactor draw phase logic to reshuffle using new deck API instead of manipulating `deck.cards`

## Testing
- `uv run pytest` *(fails: ModuleNotFoundError: No module named 'websockets')*
- `uv run pre-commit run --files bang_py/deck.py bang_py/turn_phases/discard_phase.py bang_py/turn_phases/draw_phase.py bang_py/characters/kit_carlson.py`

------
https://chatgpt.com/codex/tasks/task_e_6897106814608323a5857c5cfd284ce2