### PR TITLE
Use built-in Mapping type in player module

### DIFF
--- a/bang_py/player.py
+++ b/bang_py/player.py
@@ -1,9 +1,11 @@
 """Player representation and related helper data for Bang."""
 
 from __future__ import annotations
+
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from types import MappingProxyType
-from typing import Mapping, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 from .cards.roles import (
     BaseRole,
@@ -72,7 +74,7 @@ class Player:
 
     @property
     def metadata(self) -> PlayerMetadata:
-        """Player metadata (read-only reference)."""
+        """Return player metadata as a read-only reference."""
         return self._metadata
 
     @property


### PR DESCRIPTION
## Summary
- use `collections.abc.Mapping` instead of `typing.Mapping` in player module
- clarify `metadata` property docstring

## Testing
- `uv run pre-commit run --files bang_py/deck.py bang_py/game_manager.py bang_py/player.py bang_py/general_store.py bang_py/turn_phases/draw_phase.py`
- `uv run mypy --install-types --non-interactive bang_py` (fails: missing PySide6, cryptography, websockets stubs)
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68978cfebcdc8323b421b4716f4c0f8c