### PR TITLE
Add ability hooks and tests for character mechanics

### DIFF
--- a/bang_py/characters/sid_ketchum.py
+++ b/bang_py/characters/sid_ketchum.py
@@ -27,7 +27,7 @@ class SidKetchum(BaseCharacter):
         indices: list[int] | None = None,
     ) -> bool:
         if len(player.hand) < 2 or player.health >= player.max_health:
-            return True
+            return False
         discard_indices = sorted(indices or list(range(2)), reverse=True)[:2]
         for idx in discard_indices:
             if 0 <= idx < len(player.hand):

--- a/bang_py/game_manager.py
+++ b/bang_py/game_manager.py
@@ -130,17 +130,17 @@ class GameManager(
 
     def _handle_missed_as_bang(self, player: Player, card: BaseCard, target: Player | None) -> bool:
         """Treat Missed! cards as Bang."""
-        return super()._handle_missed_as_bang(player, card, target)
+        return super(GameManager, self)._handle_missed_as_bang(player, card, target)
 
     def _advance_turn(self) -> None:
         """Advance to the next player's turn."""
-        super()._advance_turn()
+        super(GameManager, self)._advance_turn()
 
     def pat_brennan_draw(
         self, player: Player, target: Player | None = None, card: str | None = None
     ) -> bool:
         """Handle Pat Brennan's draw ability."""
-        return super().pat_brennan_draw(player, target, card)
+        return super(GameManager, self).pat_brennan_draw(player, target, card)
 
     def __post_init__(self) -> None:
         """Initialize decks and register card handlers."""

--- a/bang_py/game_manager.py
+++ b/bang_py/game_manager.py
@@ -128,6 +128,20 @@ class GameManager(
             gm._cleanup_general_store_leftovers()
         return True
 
+    def _handle_missed_as_bang(self, player: Player, card: BaseCard, target: Player | None) -> bool:
+        """Treat Missed! cards as Bang."""
+        return super()._handle_missed_as_bang(player, card, target)
+
+    def _advance_turn(self) -> None:
+        """Advance to the next player's turn."""
+        super()._advance_turn()
+
+    def pat_brennan_draw(
+        self, player: Player, target: Player | None = None, card: str | None = None
+    ) -> bool:
+        """Handle Pat Brennan's draw ability."""
+        return super().pat_brennan_draw(player, target, card)
+
     def __post_init__(self) -> None:
         """Initialize decks and register card handlers."""
         self.initialize_main_deck()

--- a/bang_py/game_manager_protocol.py
+++ b/bang_py/game_manager_protocol.py
@@ -153,7 +153,9 @@ class GameManagerProtocol(Protocol):
     def _cleanup_general_store_leftovers(self) -> None:
         """Discard any remaining General Store cards and reset state."""
 
-    def pat_brennan_draw(self, player: Player, target: Player | None, card: str | None) -> bool:
+    def pat_brennan_draw(
+        self, player: Player, target: Player | None = None, card: str | None = None
+    ) -> bool:
         """Draw a card in play for Pat Brennan's ability."""
         ...
 
@@ -235,6 +237,7 @@ class GameManagerProtocol(Protocol):
 
     def _advance_turn(self) -> None:
         """Move the turn pointer and start the next turn."""
+        ...
 
     def prompt_new_identity(self, player: Player) -> bool:
         """Prompt ``player`` to swap characters during New Identity."""
@@ -279,6 +282,7 @@ class GameManagerProtocol(Protocol):
 
     def _handle_missed_as_bang(self, player: Player, card: BaseCard, target: Player | None) -> bool:
         """Treat Missed! cards as Bang! when allowed."""
+        ...
 
     def _can_play_bang(self, player: Player) -> bool:
         """Return ``True`` if ``player`` may play a Bang!."""

--- a/tests/test_character_abilities.py
+++ b/tests/test_character_abilities.py
@@ -1,0 +1,44 @@
+import random
+
+from bang_py.cards.bang import BangCard
+from bang_py.cards.beer import BeerCard
+from bang_py.cards.missed import MissedCard
+from bang_py.deck import Deck
+from bang_py.game_manager import GameManager
+from bang_py.player import Player
+from bang_py.characters.sid_ketchum import SidKetchum
+
+
+def test_sid_ketchum_heal_ability() -> None:
+    random.seed(0)
+    gm = GameManager()
+    sid = Player("Sid", character=SidKetchum())
+    gm.add_player(sid)
+    assert isinstance(sid.character, SidKetchum)
+    sid.hand.extend([BangCard(), BeerCard()])
+    sid.health -= 1
+    assert sid.character.use_ability(gm, sid, [0, 1])
+    assert sid.health == sid.max_health
+    assert not sid.hand
+
+
+def test_general_store_pick_sequence() -> None:
+    random.seed(0)
+    deck = Deck([])
+    deck.push_top(MissedCard())
+    deck.push_top(BeerCard())
+    deck.push_top(BangCard())
+    gm = GameManager(deck=deck)
+    p1, p2, p3 = Player("A"), Player("B"), Player("C")
+    for p in (p1, p2, p3):
+        gm.add_player(p)
+    revealed = gm.start_general_store(p1)
+    assert revealed == ["Bang!", "Beer", "Missed!"]
+    assert not gm.general_store_pick(p2, 0)
+    assert gm.general_store_pick(p1, 1)
+    assert gm.general_store_pick(p2, 0)
+    assert gm.general_store_pick(p3, 0)
+    assert gm.general_store_cards is None
+    assert p1.hand[0].card_name == "Beer"
+    assert p2.hand[0].card_name == "Bang!"
+    assert p3.hand[0].card_name == "Missed!"


### PR DESCRIPTION
## Summary
- expose Pat Brennan draw, turn advancement, and Missed-as-Bang hooks on GameManager
- tighten Sid Ketchum heal ability and add coverage for General Store sequence

## Testing
- `uv run pre-commit run --files bang_py/game_manager.py bang_py/characters/sid_ketchum.py bang_py/game_manager_protocol.py tests/test_character_abilities.py`
- `uv run pytest tests/test_character_abilities.py`
- `uv run pytest` *(fails: ModuleNotFoundError: No module named 'websockets')*


------
https://chatgpt.com/codex/tasks/task_e_68979d7c16a8832394fbde5a36602669