### PR TITLE
Add reusable QML prompts and integrate with Bang UI

### DIFF
--- a/bang_py/ui/qml/ConfirmPrompt.qml
+++ b/bang_py/ui/qml/ConfirmPrompt.qml
@@ -1,0 +1,19 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+Dialog {
+    id: root
+    modal: true
+    property string titleText: qsTr("Confirm")
+    property string message: ""
+    title: titleText
+    standardButtons: Dialog.Ok | Dialog.Cancel
+
+    contentItem: Column {
+        spacing: 8
+        Label {
+            text: root.message
+            wrapMode: Text.Wrap
+        }
+    }
+}

--- a/bang_py/ui/qml/ConfirmPrompt.qml
+++ b/bang_py/ui/qml/ConfirmPrompt.qml
@@ -1,5 +1,6 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
 
 Dialog {
     id: root
@@ -9,9 +10,10 @@ Dialog {
     title: titleText
     standardButtons: Dialog.Ok | Dialog.Cancel
 
-    contentItem: Column {
+    contentItem: ColumnLayout {
         spacing: 8
         Label {
+            Layout.fillWidth: true
             text: root.message
             wrapMode: Text.Wrap
         }

--- a/bang_py/ui/qml/Main.qml
+++ b/bang_py/ui/qml/Main.qml
@@ -69,6 +69,7 @@ Item {
                 id: portField
                 placeholderText: qsTr("Port (1-65535)")
                 text: qsTr("8765")
+                maximumLength: 5
                 validator: IntValidator { bottom: 1; top: 65535 }
             }
             Label {
@@ -141,6 +142,7 @@ Item {
                 id: portJoinField
                 placeholderText: qsTr("Port (1-65535)")
                 text: qsTr("8765")
+                maximumLength: 5
                 validator: IntValidator { bottom: 1; top: 65535 }
             }
             Label {

--- a/bang_py/ui/qml/MainMenu.qml
+++ b/bang_py/ui/qml/MainMenu.qml
@@ -30,6 +30,7 @@ Rectangle {
             id: nameField
             placeholderText: qsTr("Name (1-20 printable chars)")
             width: 200 * scale
+            maximumLength: 20
             color: theme === "dark" ? "white" : "black"
             background: Rectangle {
                 color: theme === "dark" ? "#3c3c3c" : "#fff8dc"

--- a/bang_py/ui/qml/MessageDialog.qml
+++ b/bang_py/ui/qml/MessageDialog.qml
@@ -1,0 +1,21 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+Dialog {
+    id: root
+    modal: true
+    property string titleText: qsTr("Message")
+    property string message: ""
+    property bool error: false
+    title: titleText
+    standardButtons: Dialog.Ok
+
+    contentItem: Column {
+        spacing: 8
+        Label {
+            text: root.message
+            wrapMode: Text.Wrap
+            color: root.error ? "red" : "black"
+        }
+    }
+}

--- a/bang_py/ui/qml/OptionPrompt.qml
+++ b/bang_py/ui/qml/OptionPrompt.qml
@@ -1,0 +1,41 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+Dialog {
+    id: root
+    modal: true
+    property string titleText: qsTr("Choose")
+    property var options: []
+    property int selectedIndex: -1
+    title: titleText
+    standardButtons: Dialog.Ok | Dialog.Cancel
+    signal acceptedIndex(int index)
+
+    contentItem: Column {
+        spacing: 8
+        ListView {
+            width: parent.width
+            height: Math.min(contentHeight, 200)
+            model: root.options
+            delegate: ItemDelegate {
+                text: modelData
+                width: parent.width
+                onClicked: root.selectedIndex = index
+                highlighted: root.selectedIndex === index
+            }
+        }
+        Label {
+            text: qsTr("Please select an option")
+            color: "red"
+            visible: root.selectedIndex === -1
+        }
+    }
+
+    onAccepted: {
+        if (selectedIndex === -1) {
+            root.open()
+            return
+        }
+        acceptedIndex(selectedIndex)
+    }
+}

--- a/bang_py/ui/qml/OptionPrompt.qml
+++ b/bang_py/ui/qml/OptionPrompt.qml
@@ -1,5 +1,6 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
 
 Dialog {
     id: root
@@ -11,20 +12,22 @@ Dialog {
     standardButtons: Dialog.Ok | Dialog.Cancel
     signal acceptedIndex(int index)
 
-    contentItem: Column {
+    contentItem: ColumnLayout {
         spacing: 8
         ListView {
-            width: parent.width
-            height: Math.min(contentHeight, 200)
+            id: optionList
+            Layout.fillWidth: true
+            Layout.preferredHeight: Math.min(contentHeight, 200)
             model: root.options
             delegate: ItemDelegate {
                 text: modelData
-                width: parent.width
+                width: optionList.width
                 onClicked: root.selectedIndex = index
                 highlighted: root.selectedIndex === index
             }
         }
         Label {
+            Layout.fillWidth: true
             text: qsTr("Please select an option")
             color: "red"
             visible: root.selectedIndex === -1

--- a/tests/test_ui_prompts.py
+++ b/tests/test_ui_prompts.py
@@ -1,0 +1,75 @@
+import pytest
+
+pytest.importorskip(
+    "PySide6", reason="PySide6 not installed; skipping GUI tests", exc_type=ImportError
+)
+pytest.importorskip(
+    "PySide6.QtCore",
+    reason="QtCore unavailable; skipping GUI tests",
+    exc_type=ImportError,
+)
+pytest.importorskip(
+    "PySide6.QtWidgets",
+    reason="QtWidgets unavailable; skipping GUI tests",
+    exc_type=ImportError,
+)
+pytest.importorskip(
+    "PySide6.QtQml",
+    reason="QtQml unavailable; skipping GUI tests",
+    exc_type=ImportError,
+)
+
+from PySide6 import QtQml  # noqa: E402
+
+
+def _load_component(name: str) -> QtQml.QQmlComponent:
+    from importlib import resources
+
+    qml_dir = resources.files("bang_py.ui") / "qml"
+    with resources.as_file(qml_dir / name) as path:
+        engine = QtQml.QQmlEngine()
+        return QtQml.QQmlComponent(engine, str(path))
+
+
+def test_option_prompt_emits_index(qt_app):
+    comp = _load_component("OptionPrompt.qml")
+    dialog = comp.create()
+    dialog.setProperty("options", ["a", "b"])
+    captured = {}
+
+    def _got(i: int) -> None:
+        captured["index"] = i
+
+    dialog.acceptedIndex.connect(_got)
+    dialog.setProperty("selectedIndex", 1)
+    dialog.accept()
+    qt_app.processEvents()
+    assert captured["index"] == 1
+    dialog.deleteLater()
+
+
+def test_confirm_prompt_accepts(qt_app):
+    comp = _load_component("ConfirmPrompt.qml")
+    dialog = comp.create()
+    result = {"ok": False}
+    dialog.accepted.connect(lambda: result.__setitem__("ok", True))
+    dialog.accept()
+    qt_app.processEvents()
+    assert result["ok"]
+    dialog.deleteLater()
+
+
+def test_show_prompt_general_store_sends_action(qt_app, monkeypatch):
+    from bang_py.ui import BangUI
+
+    ui = BangUI()
+    called = {}
+
+    def fake_send(payload: dict) -> None:
+        called["payload"] = payload
+
+    monkeypatch.setattr(ui, "_send_action", fake_send)
+    monkeypatch.setattr(ui, "_option_prompt", lambda title, opts: 1)
+    ui._show_prompt("general_store", {"cards": ["Bang", "Missed"]})
+    assert called["payload"] == {"action": "general_store_pick", "index": 1}
+    ui.close()

--- a/tests/test_ui_prompts.py
+++ b/tests/test_ui_prompts.py
@@ -28,7 +28,9 @@ def _load_component(name: str) -> QtQml.QQmlComponent:
     qml_dir = resources.files("bang_py.ui") / "qml"
     with resources.as_file(qml_dir / name) as path:
         engine = QtQml.QQmlEngine()
-        return QtQml.QQmlComponent(engine, str(path))
+        comp = QtQml.QQmlComponent(engine, str(path))
+        comp._engine = engine  # prevent engine from being garbage-collected
+        return comp
 
 
 def test_option_prompt_emits_index(qt_app):


### PR DESCRIPTION
## Summary
- add reusable QML dialogs for option selection, confirmation, and messages
- update BangUI to await server prompts and surface results or errors
- enforce input validation on name and port fields
- test prompt flows with new Qt-based integration tests

## Testing
- `uv run pre-commit run --files bang_py/ui/main.py bang_py/ui/qml/Main.qml bang_py/ui/qml/MainMenu.qml bang_py/ui/qml/OptionPrompt.qml bang_py/ui/qml/ConfirmPrompt.qml bang_py/ui/qml/MessageDialog.qml tests/test_ui_prompts.py`
- `uv run pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897b52c66f08323b3dba8500799712c