### PR TITLE
Add asset caching benchmark and refine error handling

### DIFF
--- a/bang_py/ui/components/card_images.py
+++ b/bang_py/ui/components/card_images.py
@@ -1,4 +1,4 @@
-"""Load card images, templates, action icons and audio used by the Bang UI."""
+"""Load and cache card assets and audio used by the Bang UI."""
 
 from __future__ import annotations
 
@@ -145,7 +145,7 @@ def load_sound(name: str, parent: QtCore.QObject | None = None) -> QtCore.QObjec
         """Small helper to ensure playback stops when deleted."""
 
         def __del__(self) -> None:  # pragma: no cover - best effort
-            with suppress(Exception):
+            with suppress(RuntimeError):
                 self.stop()
 
     path = None

--- a/scripts/profile_loading.py
+++ b/scripts/profile_loading.py
@@ -1,0 +1,41 @@
+"""Benchmark asset loading to verify cache effectiveness."""
+
+from __future__ import annotations
+
+from time import perf_counter
+
+from bang_py.ui.components import card_images
+from PySide6 import QtWidgets
+
+
+def main() -> None:
+    """Profile card composition and sound loading with and without caches."""
+    app = QtWidgets.QApplication([])
+    loader = card_images.get_loader()
+
+    start = perf_counter()
+    loader.compose_card("blue", 1, "Spades", name="bang")
+    first_compose = perf_counter() - start
+
+    start = perf_counter()
+    loader.compose_card("blue", 1, "Spades", name="bang")
+    second_compose = perf_counter() - start
+
+    print(f"First compose: {first_compose:.6f}s")
+    print(f"Second compose (cached): {second_compose:.6f}s")
+
+    start = perf_counter()
+    card_images.load_sound("bang")
+    first_sound = perf_counter() - start
+
+    start = perf_counter()
+    card_images.load_sound("bang")
+    second_sound = perf_counter() - start
+
+    print(f"First sound load: {first_sound:.6f}s")
+    print(f"Second sound load (cached): {second_sound:.6f}s")
+    app.quit()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- document and tighten asset caching while narrowing media player cleanup to `RuntimeError`
- include a benchmark script to time cached vs uncached asset loads

## Testing
- `pre-commit run --files bang_py/ui/components/card_images.py scripts/profile_loading.py`
- `uv run pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897bc3ff55c83238cc2e658a4308e02