### PR TITLE
Add ricochet event ability and tests

### DIFF
--- a/bang_py/game_manager.py
+++ b/bang_py/game_manager.py
@@ -142,6 +142,10 @@ class GameManager(
         """Handle Pat Brennan's draw ability."""
         return super(GameManager, self).pat_brennan_draw(player, target, card)
 
+    def ricochet_shoot(self, player: Player, target: Player, card_name: str) -> bool:
+        """Discard a Bang! to shoot at ``card_name`` in front of ``target``."""
+        return super(GameManager, self).ricochet_shoot(player, target, card_name)
+
     # ------------------------------------------------------------------
     # Hook stubs
     def _hand_limit(self, player: Player) -> int:

--- a/bang_py/game_manager_protocol.py
+++ b/bang_py/game_manager_protocol.py
@@ -177,6 +177,9 @@ class GameManagerProtocol(Protocol):
     def uncle_will_ability(self, player: Player, card: BaseCard) -> bool:
         """Play ``card`` as a General Store once per turn."""
 
+    def ricochet_shoot(self, player: Player, target: Player, card_name: str) -> bool:
+        """Discard a Bang! to shoot at ``card_name`` in front of ``target``."""
+
     def reset_turn_flags(self, player: Player) -> None:
         """Reset per-turn ability flags on ``player``."""
 

--- a/tests/test_card_effects.py
+++ b/tests/test_card_effects.py
@@ -1,0 +1,42 @@
+import random
+
+from bang_py.cards.bang import BangCard
+from bang_py.cards.barrel import BarrelCard
+from bang_py.cards.missed import MissedCard
+from bang_py.game_manager import GameManager
+from bang_py.player import Player
+
+
+def test_ricochet_shoot_discards_equipment() -> None:
+    random.seed(0)
+    gm = GameManager()
+    shooter = Player("Shooter")
+    target = Player("Target")
+    gm.add_player(shooter)
+    gm.add_player(target)
+    gm.event_flags["ricochet"] = True
+    shooter.hand.append(BangCard())
+    barrel = BarrelCard()
+    barrel.play(target)
+    assert gm.ricochet_shoot(shooter, target, "Barrel")
+    assert "Barrel" not in target.equipment
+    assert any(c.card_name == "Barrel" for c in gm.discard_pile)
+    assert all(not isinstance(c, BangCard) for c in shooter.hand)
+
+
+def test_ricochet_shoot_blocked_by_miss() -> None:
+    random.seed(0)
+    gm = GameManager()
+    shooter = Player("Shooter")
+    target = Player("Target")
+    gm.add_player(shooter)
+    gm.add_player(target)
+    gm.event_flags["ricochet"] = True
+    shooter.hand.append(BangCard())
+    barrel = BarrelCard()
+    barrel.play(target)
+    target.hand.append(MissedCard())
+    assert not gm.ricochet_shoot(shooter, target, "Barrel")
+    assert "Barrel" in target.equipment
+    assert any(isinstance(c, MissedCard) for c in gm.discard_pile)
+    assert all(not isinstance(c, BangCard) for c in shooter.hand)

--- a/tests/test_character_abilities.py
+++ b/tests/test_character_abilities.py
@@ -7,6 +7,7 @@ from bang_py.deck import Deck
 from bang_py.game_manager import GameManager
 from bang_py.player import Player
 from bang_py.characters.sid_ketchum import SidKetchum
+from bang_py.characters.uncle_will import UncleWill
 
 
 def test_sid_ketchum_heal_ability() -> None:
@@ -42,3 +43,21 @@ def test_general_store_pick_sequence() -> None:
     assert p1.hand[0].card_name == "Beer"
     assert p2.hand[0].card_name == "Bang!"
     assert p3.hand[0].card_name == "Missed!"
+
+
+def test_uncle_will_general_store_ability() -> None:
+    random.seed(0)
+    deck = Deck([])
+    deck.push_top(BeerCard())
+    deck.push_top(BangCard())
+    gm = GameManager(deck=deck)
+    will = Player("Will", character=UncleWill())
+    other = Player("Other")
+    for p in (will, other):
+        gm.add_player(p)
+    will.hand.append(MissedCard())
+    assert gm.uncle_will_ability(will, will.hand[0])
+    assert will.metadata.uncle_used
+    assert will.hand[0].card_name == "Bang!"
+    assert other.hand[0].card_name == "Beer"
+    assert gm.discard_pile[-1].card_name == "Missed!"


### PR DESCRIPTION
## Summary
- expose `ricochet_shoot` in the game manager protocol and implementation
- cover Uncle Will's General Store ability and Ricochet event interactions with new tests

## Testing
- `uv run pre-commit run --files bang_py/game_manager_protocol.py bang_py/game_manager.py tests/test_character_abilities.py tests/test_card_effects.py`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_689880a81cc0832392bc0d02a54735ff