### PR TITLE
Use deque for deck and centralize token helpers

### DIFF
--- a/bang_py/characters/kit_carlson.py
+++ b/bang_py/characters/kit_carlson.py
@@ -26,7 +26,7 @@ class KitCarlson(BaseCharacter):
             if p is not player:
                 return True
             options: dict[str, object] = opts if isinstance(opts, dict) else {}
-            cards = [gm._draw_from_deck(), gm._draw_from_deck(), gm._draw_from_deck()]
+            cards = [gm._draw_from_deck() for _ in range(3)]
             back_index = options.get("kit_back")
             if not isinstance(back_index, int) or not (0 <= back_index < len(cards)):
                 back_index = len(cards) - 1

--- a/bang_py/deck.py
+++ b/bang_py/deck.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from random import shuffle
+import random
 from collections import deque
 from collections.abc import Iterable
 
@@ -12,16 +12,14 @@ from .cards.card import BaseCard
 class Deck:
     """Simple deck of cards supporting drawing."""
 
-    def __init__(self, cards: list[BaseCard] | None = None) -> None:
-        card_list = cards[:] if cards else []
-        shuffle(card_list)
+    def __init__(self, cards: Iterable[BaseCard] | None = None) -> None:
+        card_list = list(cards) if cards else []
+        random.shuffle(card_list)
         self.cards: deque[BaseCard] = deque(card_list)
 
     def draw(self) -> BaseCard | None:
         """Draw a card from the deck if available."""
-        if self.cards:
-            return self.cards.popleft()
-        return None
+        return self.cards.popleft() if self.cards else None
 
     def add(self, card: BaseCard) -> None:
         self.cards.append(card)
@@ -44,7 +42,7 @@ class Deck:
     def shuffle(self) -> None:
         """Shuffle the deck in-place."""
         card_list = list(self.cards)
-        shuffle(card_list)
+        random.shuffle(card_list)
         self.cards = deque(card_list)
 
     def __len__(self) -> int:

--- a/bang_py/network/server.py
+++ b/bang_py/network/server.py
@@ -25,7 +25,7 @@ from .messages import (
     SetAutoMissPayload,
     UseAbilityPayload,
 )
-from .token_utils import _token_key_bytes, generate_join_token, parse_join_token
+from .token_utils import _token_key_bytes, generate_join_token
 from .validation import validate_player_name
 
 logger = logging.getLogger(__name__)
@@ -33,7 +33,7 @@ logger = logging.getLogger(__name__)
 # Maximum allowed size for incoming websocket messages
 MAX_MESSAGE_SIZE = 4096
 
-__all__ = ["BangServer", "generate_join_token", "parse_join_token", "validate_player_name"]
+__all__ = ["BangServer", "validate_player_name"]
 
 
 # Use slots to reduce memory footprint and prevent dynamic attribute assignment.

--- a/bang_py/turn_phases/discard_phase.py
+++ b/bang_py/turn_phases/discard_phase.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from bang_py.deck import Deck
+from ..deck import Deck
 from ..cards.card import BaseCard
 from ..event_flags import EventFlags
 from ..game_manager_protocol import GameManagerProtocol

--- a/bang_py/ui/components/card_images.py
+++ b/bang_py/ui/components/card_images.py
@@ -142,6 +142,8 @@ def load_sound(name: str, parent: QtCore.QObject | None = None) -> QtCore.QObjec
     base = name.lower().replace(" ", "_")
     cached = _sound_cache.get(base)
     if cached is not None:
+        if parent is not None:
+            cached.setParent(parent)
         return cached
 
     class _MediaPlayer(QtMultimedia.QMediaPlayer):  # type: ignore[name-defined]


### PR DESCRIPTION
## Summary
- use `collections.deque` for Deck and update callers
- cache UI sounds with parent reassignment
- centralize join-token helpers in `network.token_utils`

## Testing
- `uv run pre-commit run --files bang_py/characters/kit_carlson.py bang_py/deck.py bang_py/network/server.py bang_py/turn_phases/discard_phase.py bang_py/ui/components/card_images.py`
- `uv run python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899062f5230832390b54157d5b9ce93