### PR TITLE
Document asset testing guidelines and expand AGENTS instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,19 @@ Run the checks on changed files before committing:
 uv run pre-commit run --files <path> [<path> ...]
 ```
 
+Run the test suite:
+
+```bash
+uv run pytest
+```
+
+If you modify assets, update `bang_py/assets/ATTRIBUTION.md` with the source and
+license and run the asset tests:
+
+```bash
+uv run pytest tests/test_icon_usage.py tests/test_audio_usage.py tests/test_root_asset_usage.py
+```
+
 Run the type checker directly with:
 
 ```bash

--- a/bang_py/assets/AGENTS.md
+++ b/bang_py/assets/AGENTS.md
@@ -16,4 +16,9 @@ Do not add other formats without a compelling reason.
 - Record the origin and license for every asset in `ATTRIBUTION.md` whenever assets change.
 
 ## Tests
-- `tests/test_audio_usage.py`, `tests/test_icon_usage.py`, and `tests/test_root_asset_usage.py` check that assets referenced by the code exist and that unused files are avoided. Run `pytest` after modifying assets to ensure they pass.
+- `tests/test_audio_usage.py`, `tests/test_icon_usage.py`, and
+  `tests/test_root_asset_usage.py` check that assets referenced by the code
+  exist and that unused files are avoided.
+- After changing assets, run `uv run pre-commit run --files <file> [<file> ...]`
+  and `uv run pytest tests/test_audio_usage.py tests/test_icon_usage.py
+  tests/test_root_asset_usage.py`.

--- a/bang_py/events/AGENTS.md
+++ b/bang_py/events/AGENTS.md
@@ -1,5 +1,11 @@
 # Agent Guidelines for events
 
+## Style
 - All modules in this directory must include a module-level docstring.
-- Use built-in collection generics such as `list[int]` and `dict[str, str]` rather than `typing.List` or `typing.Dict`.
+- Use built-in collection generics such as `list[int]` and `dict[str, str]`
+  rather than `typing.List` or `typing.Dict`.
 - Apply the `@override` decorator from `typing` when overriding methods.
+
+## Testing
+- Run `uv run pre-commit run --files <file> [<file> ...]` after editing.
+- Execute `uv run pytest` to ensure event tests pass.

--- a/bang_py/network/AGENTS.md
+++ b/bang_py/network/AGENTS.md
@@ -1,5 +1,10 @@
 # Agent Guidelines
 
+## Style
 - Use `asyncio` APIs with `TaskGroup` for managing concurrency when suitable.
 - Decorate methods that override base class implementations with `@override`.
 - Keep lines at or below 100 characters and write docstrings for public functions.
+
+## Testing
+- Run `uv run pre-commit run --files <file> [<file> ...]` on changes.
+- Execute `uv run pytest` after modifying this package.

--- a/bang_py/ui/AGENTS.md
+++ b/bang_py/ui/AGENTS.md
@@ -1,5 +1,10 @@
 # UI Module Guidelines
 
+## Style
 - Require module docstrings and type hints.
 - Use built-in generics and annotate overrides with `@override`.
 - Keep lines ≤100 characters.
+
+## Testing
+- Run `uv run pre-commit run --files <file> [<file> ...]` on changed files.
+- Execute `uv run pytest` after modifying this module.

--- a/bang_py/ui/qml/AGENTS.md
+++ b/bang_py/ui/qml/AGENTS.md
@@ -1,5 +1,10 @@
 # QML Guidelines
 
+## Style
 - Wrap all user-facing text in `qsTr()` for translation.
 - Provide input validators for user-editable fields whenever possible.
 - Use four spaces for indentation and keep lines under 100 characters.
+
+## Testing
+- Run `uv run pre-commit run --files <file> [<file> ...]` after editing QML files.
+- Execute `uv run pytest` to ensure tests pass.

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -3,4 +3,7 @@
 - Use Python 3.13+.
 - Provide descriptive module and function docstrings.
 - Limit lines to 100 characters.
-- After modifying these scripts, run `pre-commit run --files <files>`.
+
+## Testing
+- After modifying these scripts, run `uv run pre-commit run --files <file> [<file> ...]`
+  and `uv run pytest`.


### PR DESCRIPTION
## Summary
- add style and testing guidance in AGENTS files for UI, QML, network, events, assets, and scripts
- document pre-commit, pytest, and asset attribution steps in the README, including required asset usage tests

## Testing
- `uv run pre-commit run --files README.md bang_py/assets/AGENTS.md bang_py/events/AGENTS.md bang_py/network/AGENTS.md bang_py/ui/AGENTS.md bang_py/ui/qml/AGENTS.md scripts/AGENTS.md`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68990646ed708323a46de0f679a23643