### PR TITLE
Refactor network message parsing with structured errors

### DIFF
--- a/bang_py/network/messages.py
+++ b/bang_py/network/messages.py
@@ -49,10 +49,25 @@ class SetAutoMissPayload(TypedDict):
     enabled: bool
 
 
+class ErrorInfo(TypedDict):
+    """Detail describing a payload validation error."""
+
+    code: str
+    message: str
+
+
+class ErrorPayload(TypedDict):
+    """Structured error response from the server."""
+
+    error: ErrorInfo
+
+
 __all__ = [
     "DrawPayload",
     "DiscardPayload",
     "PlayCardPayload",
     "UseAbilityPayload",
     "SetAutoMissPayload",
+    "ErrorInfo",
+    "ErrorPayload",
 ]


### PR DESCRIPTION
## Summary
- add explicit TypedDict payloads and error structures for networking
- refactor websocket server to validate payloads and report structured errors
- cover malformed payload scenarios with regression tests

## Testing
- `uv run pre-commit run --files bang_py/network/messages.py bang_py/network/server.py tests/test_network_messages.py`
- `uv run pytest` *(fails: ModuleNotFoundError: No module named 'websockets')*

------
https://chatgpt.com/codex/tasks/task_e_68990f316c188323954c8dc2a475786a