### PR TITLE
Add event hooks to GameManagerProtocol and expand ability tests

### DIFF
--- a/bang_py/game_manager_protocol.py
+++ b/bang_py/game_manager_protocol.py
@@ -69,6 +69,15 @@ class GameManagerProtocol(Protocol):
     def _initialize_event_deck(self) -> None:
         """Build and shuffle the event deck based on active expansions."""
 
+    def draw_event_card(self) -> None:
+        """Draw and apply the next event card."""
+
+    def _prepare_high_noon_deck(self) -> deque[EventCard] | None:
+        """Create and shuffle the High Noon event deck."""
+
+    def _prepare_fistful_deck(self) -> deque[EventCard] | None:
+        """Create and shuffle the Fistful of Cards event deck."""
+
     def _register_card_handlers(self, groups: Iterable[str] | None = None) -> None:
         """Populate the card handler registry."""
 
@@ -210,6 +219,33 @@ class GameManagerProtocol(Protocol):
 
     def _apply_event_start_effects(self, player: Player) -> Player | None:
         """Apply start-of-turn event effects returning the acting player."""
+
+    def _sheriff_event_updates(self, player: Player, pre_ghost: bool) -> Player:
+        """Update sheriff counters and handle Ghost Town revivals."""
+
+    def _process_new_identity(self, player: Player) -> None:
+        """Handle the New Identity event for ``player``."""
+
+    def apply_new_identity(self, player: Player) -> None:
+        """Swap ``player`` to their unused character if the event is active."""
+
+    def _skip_turn_if_needed(self) -> bool:
+        """Skip the current turn if required by active events."""
+
+    def _apply_start_damage(self, player: Player) -> bool:
+        """Apply start-of-turn damage to ``player`` and return True if they survive."""
+
+    def _apply_fistful_of_cards(self, player: Player) -> bool:
+        """Resolve Fistful of Cards effects for ``player`` and return True if they survive."""
+
+    def _handle_dead_man(self, player: Player) -> None:
+        """Apply Dead Man event revival if conditions are met."""
+
+    def _increment_sheriff_turns(self) -> None:
+        """Increment sheriff turn count and draw events when eligible."""
+
+    def _ghost_town_cleanup(self, player: Player) -> Player:
+        """Remove revived ghosts after two sheriff turns."""
 
     def _reactivate_green_equipment(self, player: Player) -> None:
         """Reactivate green equipment on ``player``."""

--- a/tests/test_card_effects.py
+++ b/tests/test_card_effects.py
@@ -2,7 +2,10 @@ import random
 
 from bang_py.cards.bang import BangCard
 from bang_py.cards.barrel import BarrelCard
+from bang_py.cards.beer import BeerCard
+from bang_py.cards.general_store import GeneralStoreCard
 from bang_py.cards.missed import MissedCard
+from bang_py.deck import Deck
 from bang_py.game_manager import GameManager
 from bang_py.player import Player
 
@@ -40,3 +43,36 @@ def test_ricochet_shoot_blocked_by_miss() -> None:
     assert "Barrel" in target.equipment
     assert any(isinstance(c, MissedCard) for c in gm.discard_pile)
     assert all(not isinstance(c, BangCard) for c in shooter.hand)
+
+
+def test_general_store_card_allows_picks() -> None:
+    random.seed(0)
+    deck = Deck([])
+    deck.push_top(MissedCard())
+    deck.push_top(BeerCard())
+    deck.push_top(BangCard())
+    gm = GameManager(deck=deck)
+    p1, p2, p3 = Player("A"), Player("B"), Player("C")
+    for p in (p1, p2, p3):
+        gm.add_player(p)
+    card = GeneralStoreCard()
+    card.play(None, player=p1, game=gm, choices=[1, 1, 0])
+    assert gm.general_store_cards is None
+    assert p1.hand[0].card_name == "Beer"
+    assert p2.hand[0].card_name == "Missed!"
+    assert p3.hand[0].card_name == "Bang!"
+
+
+def test_bang_triggers_damage_listeners() -> None:
+    random.seed(0)
+    gm = GameManager()
+    shooter = Player("Shooter")
+    target = Player("Target")
+    gm.add_player(shooter)
+    gm.add_player(target)
+    events: list[tuple[Player, Player | None]] = []
+    gm.player_damaged_listeners.append(lambda p, s: events.append((p, s)))
+    shooter.hand.append(BangCard())
+    gm.play_card(shooter, shooter.hand[0], target)
+    assert events == [(target, shooter)]
+    assert target.health == target.max_health - 1

--- a/tests/test_character_abilities.py
+++ b/tests/test_character_abilities.py
@@ -8,6 +8,7 @@ from bang_py.game_manager import GameManager
 from bang_py.player import Player
 from bang_py.characters.sid_ketchum import SidKetchum
 from bang_py.characters.uncle_will import UncleWill
+from bang_py.characters.calamity_janet import CalamityJanet
 
 
 def test_sid_ketchum_heal_ability() -> None:
@@ -61,3 +62,18 @@ def test_uncle_will_general_store_ability() -> None:
     assert will.hand[0].card_name == "Bang!"
     assert other.hand[0].card_name == "Beer"
     assert gm.discard_pile[-1].card_name == "Missed!"
+
+
+def test_calamity_janet_bang_as_miss() -> None:
+    random.seed(0)
+    gm = GameManager()
+    attacker = Player("A")
+    janet = Player("Janet", character=CalamityJanet())
+    gm.add_player(attacker)
+    gm.add_player(janet)
+    attacker.hand.append(BangCard())
+    janet.hand.append(BangCard())
+    gm.play_card(attacker, attacker.hand[0], janet)
+    assert janet.health == janet.max_health
+    assert not janet.hand
+    assert any(isinstance(c, BangCard) for c in gm.discard_pile)


### PR DESCRIPTION
## Summary
- declare missing event and turn hooks in `GameManagerProtocol`
- test Calamity Janet's Bang-as-Missed ability
- test General Store card play and damage listener notifications

## Testing
- `pre-commit run --files bang_py/game_manager_protocol.py tests/test_card_effects.py tests/test_character_abilities.py`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68990f599ac483239894e59513de3c69