### PR TITLE
Handle async prompts and improve UI validation

### DIFF
--- a/bang_py/ui/qml/Main.qml
+++ b/bang_py/ui/qml/Main.qml
@@ -73,7 +73,7 @@ Item {
                 validator: IntValidator { bottom: 1; top: 65535 }
             }
             Label {
-                text: qsTr("Enter a valid port")
+                text: qsTr("Port must be 1-65535")
                 color: "red"
                 visible: portField.text !== "" && !portField.acceptableInput
             }
@@ -146,7 +146,7 @@ Item {
                 validator: IntValidator { bottom: 1; top: 65535 }
             }
             Label {
-                text: qsTr("Enter a valid port")
+                text: qsTr("Port must be 1-65535")
                 color: "red"
                 visible: portJoinField.text !== "" && !portJoinField.acceptableInput
             }

--- a/bang_py/ui/qml/MainMenu.qml
+++ b/bang_py/ui/qml/MainMenu.qml
@@ -35,7 +35,7 @@ Rectangle {
             background: Rectangle {
                 color: theme === "dark" ? "#3c3c3c" : "#fff8dc"
             }
-            validator: RegExpValidator { regExp: /^[ -~]{1,20}$/ }
+            validator: RegExpValidator { regExp: /^[\x20-\x7E]{1,20}$/ }
         }
 
         Label {

--- a/tests/test_ui_prompts.py
+++ b/tests/test_ui_prompts.py
@@ -73,7 +73,7 @@ def test_show_prompt_general_store_sends_action(qt_app, monkeypatch):
         called["payload"] = payload
 
     monkeypatch.setattr(ui, "_send_action", fake_send)
-    monkeypatch.setattr(ui, "_option_prompt", lambda title, opts: 1)
+    monkeypatch.setattr(ui, "_option_prompt", lambda title, opts, cb: cb(1))
     ui._show_prompt("general_store", {"cards": ["Bang", "Missed"]})
     assert called["payload"] == {"action": "general_store_pick", "index": 1}
     ui.close()


### PR DESCRIPTION
## Summary
- Queue and process game prompts asynchronously, surfacing server errors to players
- Validate player name and port entries with explicit error messaging in QML
- Document bullet and table assets used for game board styling

## Testing
- `uv run pre-commit run --files bang_py/ui/main.py bang_py/ui/qml/MainMenu.qml bang_py/ui/qml/Main.qml tests/test_ui_prompts.py`
- `uv run pytest`

------
https://chatgpt.com/codex/tasks/task_e_68990f5f686c83239f7b635f37945210