### PR TITLE
Improve input validation and asset references

### DIFF
--- a/bang_py/assets/ATTRIBUTION.md
+++ b/bang_py/assets/ATTRIBUTION.md
@@ -57,6 +57,6 @@ The following icon files are included:
 - `join.svg` – join button icon on the main menu.
 - `settings.svg` – settings button icon on the main menu.
 
-The `bullet.png` icon used for health markers and the `table.png` background
-are from the [Kenney Game Assets](https://kenney.nl/assets) collection and are
-released under the CC0 1.0 Universal license.
+The `bullet.png` icon displayed for player health and the `table.png` board
+background are from the [Kenney Game Assets](https://kenney.nl/assets)
+collection and are released under the CC0 1.0 Universal license.

--- a/bang_py/ui/main.py
+++ b/bang_py/ui/main.py
@@ -287,6 +287,7 @@ class BangUI(QtCore.QObject):
             dialog.open()
             loop.exec()
             dialog.deleteLater()
+            self._run_next_prompt()
             return
 
         def _accepted() -> None:

--- a/bang_py/ui/qml/Main.qml
+++ b/bang_py/ui/qml/Main.qml
@@ -93,10 +93,20 @@ Item {
                 placeholderText: qsTr("Certificate")
                 validator: RegExpValidator { regExp: /^[\x20-\x7E]{0,255}$/ }
             }
+            Label {
+                text: qsTr("Use printable characters only")
+                color: "red"
+                visible: certField.text !== "" && !certField.acceptableInput
+            }
             TextField {
                 id: keyField
                 placeholderText: qsTr("Key File")
                 validator: RegExpValidator { regExp: /^[\x20-\x7E]{0,255}$/ }
+            }
+            Label {
+                text: qsTr("Use printable characters only")
+                color: "red"
+                visible: keyField.text !== "" && !keyField.acceptableInput
             }
         }
         onAccepted: {
@@ -165,6 +175,11 @@ Item {
                 id: cafileField
                 placeholderText: qsTr("CA File")
                 validator: RegExpValidator { regExp: /^[\x20-\x7E]{0,255}$/ }
+            }
+            Label {
+                text: qsTr("Use printable characters only")
+                color: "red"
+                visible: cafileField.text !== "" && !cafileField.acceptableInput
             }
         }
         onAccepted: {


### PR DESCRIPTION
## Summary
- show validation errors for certificate and key paths
- ensure message dialogs advance queued prompts
- document bullet icon and table background sources

## Testing
- `uv run pre-commit run --files bang_py/assets/ATTRIBUTION.md bang_py/ui/main.py bang_py/ui/qml/Main.qml`
- `uv run pytest`
- `uv run pytest tests/test_audio_usage.py tests/test_icon_usage.py tests/test_root_asset_usage.py`


------
https://chatgpt.com/codex/tasks/task_e_6899470b572c8323b9e94b2d2b487718