### PR TITLE
Clarify websocket payload module documentation

### DIFF
--- a/bang_py/network/messages.py
+++ b/bang_py/network/messages.py
@@ -1,4 +1,4 @@
-"""Typed payload definitions for websocket communication."""
+"""Typed websocket payload structures shared by the server and client."""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary
- clarify module docstring summarizing typed websocket payload structures used by server and client

## Testing
- `uv run pre-commit run --files bang_py/network/messages.py`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68995bfd0b2c8323b8f7797495150230