### PR TITLE
chore: enable mypy for ui and event logic

### DIFF
--- a/bang_py/ui/components/network_threads.py
+++ b/bang_py/ui/components/network_threads.py
@@ -1,18 +1,20 @@
 from __future__ import annotations
 
 """Qt threads for running the Bang server and client in the background."""
-# mypy: ignore-errors
 
 import asyncio
 import json
 import logging
 import ssl
-from typing import override
+from typing import TYPE_CHECKING, override
 
-from PySide6 import QtCore
-from typing import TYPE_CHECKING
+from PySide6 import QtCore  # type: ignore[import-not-found]
 
-from websockets import ClientConnection, WebSocketException, connect
+from websockets import (
+    ClientConnection,
+    WebSocketException,
+    connect,
+)  # type: ignore[import-not-found]
 
 from ...network.server import BangServer
 
@@ -110,7 +112,7 @@ class ClientThread(_QThread):
 
     async def _run(self) -> None:
         try:
-            ssl_ctx = None
+            ssl_ctx: ssl.SSLContext | None = None
             if self.uri.startswith("wss://") or self.cafile:
                 ssl_ctx = ssl.create_default_context()
                 if self.cafile:
@@ -140,7 +142,7 @@ class ClientThread(_QThread):
         if self.loop.is_running():
             asyncio.run_coroutine_threadsafe(self._send("end_turn"), self.loop)
 
-    def send_json(self, payload: dict) -> None:
+    def send_json(self, payload: dict[str, object]) -> None:
         """Serialize ``payload`` and send it to the server."""
         if self.loop.is_running():
             msg = json.dumps(payload)

--- a/bang_py/ui/components/network_threads.py
+++ b/bang_py/ui/components/network_threads.py
@@ -15,6 +15,7 @@ from websockets import (
     WebSocketException,
     connect,
 )  # type: ignore[import-not-found]
+from websockets.protocol import State  # type: ignore[import-not-found]
 
 from ...network.server import BangServer
 
@@ -101,7 +102,7 @@ class ClientThread(_QThread):
         self.loop.close()
 
     def stop(self) -> None:
-        if self.websocket and not self.websocket.closed:
+        if self.websocket and self.websocket.state is State.OPEN:
             fut = asyncio.run_coroutine_threadsafe(self.websocket.close(), self.loop)
             try:
                 fut.result(timeout=1)
@@ -149,7 +150,7 @@ class ClientThread(_QThread):
             asyncio.run_coroutine_threadsafe(self._send(msg), self.loop)
 
     async def _send(self, msg: str) -> None:
-        if not self.websocket or self.websocket.closed:
+        if not self.websocket or self.websocket.state is not State.OPEN:
             self.message_received.emit("Send error: not connected")
             return
         try:


### PR DESCRIPTION
## Summary
- add explicit typing and casting to Qt UI code
- refine event deck helpers and test utilities

## Testing
- `uv run pre-commit run --files bang_py/ui/main.py bang_py/ui/components/network_threads.py bang_py/events/event_logic.py tests/test_ui_prompts.py`
- `uv run mypy --ignore-missing-imports bang_py tests`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68995bf896d48323afb09c9f3119542f