### PR TITLE
refactor: centralize join token helpers

### DIFF
--- a/bang_py/network/cli.py
+++ b/bang_py/network/cli.py
@@ -8,6 +8,7 @@ import logging
 from collections.abc import Sequence
 
 from .server import BangServer
+from .token_utils import generate_join_token
 
 
 def main(argv: Sequence[str] | None = None) -> None:
@@ -39,7 +40,14 @@ def main(argv: Sequence[str] | None = None) -> None:
     )
 
     if args.show_token:
-        logging.info(server.generate_join_token())
+        logging.info(
+            generate_join_token(
+                server.host,
+                server.port,
+                server.room_code,
+                server.token_key,
+            )
+        )
         return
 
     asyncio.run(server.start())

--- a/bang_py/network/server.py
+++ b/bang_py/network/server.py
@@ -27,7 +27,7 @@ from .messages import (
     SetAutoMissPayload,
     UseAbilityPayload,
 )
-from .token_utils import _token_key_bytes, generate_join_token
+from .token_utils import _token_key_bytes
 from .validation import validate_player_name
 
 logger = logging.getLogger(__name__)
@@ -94,11 +94,6 @@ class BangServer:
         self.game.player_healed_listeners.append(self._on_player_healed)
         self.game.game_over_listeners.append(self._on_game_over)
         self.game.turn_started_listeners.append(self._on_turn_started)
-
-    def generate_join_token(self) -> str:
-        """Return an encoded join token for this server."""
-
-        return generate_join_token(self.host, self.port, self.room_code, self.token_key)
 
     def _create_send_task(self, conn: Connection, payload: str | Mapping[str, object]) -> None:
         """Create a supervised task to send ``payload``.

--- a/bang_py/network/token_utils.py
+++ b/bang_py/network/token_utils.py
@@ -11,6 +11,8 @@ DEFAULT_TOKEN_KEY = b"xPv7Sx0hWCLo5A9HhF_zvg87gdRSB8OYBjWM7lV-H2I="
 
 ENV_TOKEN_KEY = "BANG_TOKEN_KEY"
 
+__all__ = ["generate_join_token", "parse_join_token", "DEFAULT_TOKEN_KEY"]
+
 
 def _token_key_bytes(key: bytes | str | None) -> bytes:
     """Return ``key`` as bytes or read it from ``BANG_TOKEN_KEY``.


### PR DESCRIPTION
## Summary
- export join token helpers from `token_utils`
- drop redundant `generate_join_token` method from `BangServer`
- call `generate_join_token` directly in the CLI

## Testing
- `uv run pre-commit run --files bang_py/network/token_utils.py bang_py/network/server.py bang_py/network/cli.py`
- `BANG_AUTO_CLOSE=1 uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899a15c2ddc8323b5f2f36a29f4e9cd