### PR TITLE
Add release checksum generation and verification

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -29,13 +29,36 @@ jobs:
       - name: Build executable
         shell: bash
         run: uv run pyinstaller scripts/bang.spec
+      - name: Generate checksums
+        shell: bash
+        run: uv run python scripts/generate_checksums.py
+      - name: Verify checksums
+        shell: bash
+        run: |
+          cd dist
+          sha256sum -c SHA256SUMS
+      - name: Prepare release notes
+        if: startsWith(github.ref, 'refs/tags/')
+        shell: bash
+        run: |
+          {
+            echo '### SHA256 Checksums';
+            echo '```';
+            cat dist/SHA256SUMS;
+            echo '```';
+          } > dist/RELEASE_NOTES.md
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: bang-exe
-          path: dist/bang.exe
+          path: |
+            dist/bang.exe
+            dist/SHA256SUMS
       - name: Attach to release
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v1
         with:
-          files: dist/bang.exe
+          files: |
+            dist/bang.exe
+            dist/SHA256SUMS
+          body_path: dist/RELEASE_NOTES.md

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ build-exe:
 >mkdir -p build/bang
 >echo "[Paths]\nPrefix=." > build/bang/qt.conf
 >uv run pyinstaller scripts/bang.spec
+>uv run python scripts/generate_checksums.py
 
 lint:
 >@uv run pre-commit run --files $(if $(FILES),$(FILES),$(shell git ls-files '*.py'))

--- a/README.md
+++ b/README.md
@@ -7,6 +7,16 @@ Example screenshots of the Qt interface are available under `docs/images` and sh
 ![Bang main menu screenshot](docs/images/example-bang-menu-ui.jpg)
 ![Bang gameplay screenshot](docs/images/example_bang_ui.jpg)
 
+## Verifying downloads
+
+Releases include a `SHA256SUMS` file alongside the build artifacts and list the
+checksums in the release notes. After downloading a release, run the following
+from the directory containing the files:
+
+```bash
+sha256sum -c SHA256SUMS
+```
+
 ## Development
 
 Use [uv](https://astral.sh/uv) to manage the development environment. Install dependencies and set up the hooks:

--- a/scripts/generate_checksums.py
+++ b/scripts/generate_checksums.py
@@ -1,0 +1,36 @@
+"""Generate SHA256 checksums for build artifacts.
+
+This script scans the ``dist`` directory for files and writes their SHA256 hashes to
+``dist/SHA256SUMS``. It should be executed after the build process creates the final
+artifacts.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+
+def compute_sha256(path: Path) -> str:
+    """Return the SHA256 hash for ``path``."""
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(8192), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def main() -> None:
+    """Write ``SHA256SUMS`` for all files in ``dist``."""
+    dist_dir = Path("dist")
+    sums_path = dist_dir / "SHA256SUMS"
+    entries: list[str] = []
+    for artifact in sorted(dist_dir.iterdir()):
+        if artifact.name == "SHA256SUMS" or not artifact.is_file():
+            continue
+        entries.append(f"{compute_sha256(artifact)}  {artifact.name}")
+    sums_path.write_text("\n".join(entries) + "\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `scripts/generate_checksums.py` to write SHA256 hashes for build artifacts
- run checksum generation during `build-exe` and Windows release workflow, verifying hashes in CI
- include checksums in release notes and document verifying downloads

## Testing
- `uv run pre-commit run --files README.md .github/workflows/windows-build.yml`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899b1bf5e5083239d62ed6672be4f60