### PR TITLE
Ensure SHA256SUMS uses Unix newlines

### DIFF
--- a/scripts/generate_checksums.py
+++ b/scripts/generate_checksums.py
@@ -24,12 +24,16 @@ def main() -> None:
     """Write ``SHA256SUMS`` for all files in ``dist``."""
     dist_dir = Path("dist")
     sums_path = dist_dir / "SHA256SUMS"
-    entries: list[str] = []
-    for artifact in sorted(dist_dir.iterdir()):
-        if artifact.name == "SHA256SUMS" or not artifact.is_file():
-            continue
-        entries.append(f"{compute_sha256(artifact)}  {artifact.name}")
-    sums_path.write_text("\n".join(entries) + "\n")
+
+    with sums_path.open("w", newline="\n") as handle:
+        for artifact in sorted(dist_dir.iterdir()):
+            if artifact.name == "SHA256SUMS" or not artifact.is_file():
+                continue
+            entry = f"{compute_sha256(artifact)}  {artifact.name}"
+            if entry.count("  ") != 1 or "\n" in entry:
+                msg = f"Malformed checksum entry: {entry!r}"
+                raise ValueError(msg)
+            handle.write(f"{entry}\n")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Ensure checksum generator writes with Unix newlines and validates `<hash>  <filename>` format.

## Testing
- `uv run pre-commit run --files scripts/generate_checksums.py`
- `uv run pytest`
- `make build-exe`
- `uv run python scripts/generate_checksums.py`
- `cd dist && sha256sum -c SHA256SUMS`


------
https://chatgpt.com/codex/tasks/task_e_6899ba5969cc832380e6b5c0e04f2dd4