### PR TITLE
Restrict checksum generation to bang.exe

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -37,28 +37,15 @@ jobs:
         run: |
           cd dist
           sha256sum -c SHA256SUMS
-      - name: Prepare release notes
-        if: startsWith(github.ref, 'refs/tags/')
-        shell: bash
-        run: |
-          {
-            echo '### SHA256 Checksums';
-            echo '```';
-            cat dist/SHA256SUMS;
-            echo '```';
-          } > dist/RELEASE_NOTES.md
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: bang-exe
           path: |
             dist/bang.exe
-            dist/SHA256SUMS
       - name: Attach to release
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v1
         with:
           files: |
             dist/bang.exe
-            dist/SHA256SUMS
-          body_path: dist/RELEASE_NOTES.md


### PR DESCRIPTION
## Summary
- produce SHA256SUMS with just dist/bang.exe
- keep checksum for verification but only upload bang.exe in Windows workflow

## Testing
- `sha256sum dist/bang.exe > dist/SHA256SUMS`
- `sha256sum -c dist/SHA256SUMS`
- `uv run pre-commit run --files scripts/generate_checksums.py .github/workflows/windows-build.yml`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a5857cabc832395e8d2f1b7e2e59f