### PR TITLE
Use Windows uv install script for Windows CI

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -21,8 +21,8 @@ jobs:
       - name: Install uv
         shell: bash
         run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          curl -LsSf https://astral.sh/uv/install.ps1 | powershell -noprofile -
+          echo "$HOME/AppData/Local/uv/bin" >> $GITHUB_PATH
       - name: Install dependencies
         shell: bash
         run: uv sync --extra dev


### PR DESCRIPTION
## Summary
- install uv with Windows PowerShell script in windows-build workflow
- ensure uv bin directory is added to PATH for subsequent steps

## Testing
- `uv run pre-commit run --files .github/workflows/windows-build.yml`
- `uv run pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a8776369c832396b1396ae2387d23