### PR TITLE
Add uv availability checks in CI workflows

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -28,6 +28,8 @@ jobs:
         run: echo "$HOME/.local/bin" >> $GITHUB_PATH
       - name: Install dependencies
         run: uv sync --extra dev
+      - name: Verify uv installation
+        run: uv --version
       - name: Run pre-commit
         run: uv run --extra dev pre-commit run --files $(git ls-files '*.py')
       - name: Run mypy

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -22,13 +22,17 @@ jobs:
         shell: bash
         run: curl -LsSf https://astral.sh/uv/install.ps1 | powershell -noprofile -
       - name: Add uv to PATH
-        shell: bash
-        run: echo "$HOME/AppData/Local/uv/bin" >> $GITHUB_PATH
+        shell: pwsh
+        run: |
+          echo "$env:USERPROFILE\AppData\Local\uv\bin" >> $env:GITHUB_PATH
       - name: Install dependencies
         shell: bash
         run: uv sync --extra dev
       - name: Install WiX Toolset
         run: choco install wixtoolset --yes
+      - name: Verify uv installation
+        shell: bash
+        run: uv --version
       - name: Build installer
         shell: bash
         run: make build-msi


### PR DESCRIPTION
## Summary
- verify `uv` is on PATH before using `uv run`
- ensure Windows workflow adds the uv install dir using PowerShell

## Testing
- `uv run --extra dev pre-commit run --files .github/workflows/python-tests.yml .github/workflows/windows-build.yml`
- `uv run --extra dev pytest`


------
https://chatgpt.com/codex/tasks/task_e_689abc9e61208323a1e2e30dedde09a5