### PR TITLE
feat: add optional windows signing

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -33,6 +33,18 @@ jobs:
       - name: Verify uv installation
         shell: bash
         run: uv --version
+      - name: Import code signing certificate
+        if: ${{ secrets.WINDOWS_PFX && secrets.WINDOWS_PFX_PASS }}
+        env:
+          PFX_B64: ${{ secrets.WINDOWS_PFX }}
+          PFX_PASS: ${{ secrets.WINDOWS_PFX_PASS }}
+        shell: pwsh
+        run: |
+          $pfxPath = "$env:RUNNER_TEMP\cert.pfx"
+          [IO.File]::WriteAllBytes($pfxPath, [Convert]::FromBase64String($env:PFX_B64))
+          certutil -f -p "$env:PFX_PASS" -importpfx "$pfxPath"
+          "PFX_PATH=$pfxPath" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "PFX_PASS=$env:PFX_PASS" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
       - name: Build installer
         shell: bash
         run: make build-msi

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,11 @@ build-msi: build-exe
 >heat dir dist/bang --out bang.wixobj --cg BangFiles
 >candle scripts/bang.wxs
 >light bang.wixobj scripts/bang.wixobj -ext WixUIExtension -out dist/bang.msi
->signtool sign /fd SHA256 /a dist/bang.msi
+>if [ -n "$$PFX_PATH" ] && [ -n "$$PFX_PASS" ]; then \
+>  signtool sign /fd SHA256 /f "$$PFX_PATH" /p "$$PFX_PASS" dist/bang.msi; \
+>else \
+>  echo "Skipping signing"; \
+>fi
 >uv run python scripts/generate_checksums.py
 
 lint:


### PR DESCRIPTION
## Summary
- import PFX certificates in Windows build workflow
- sign MSI only when certificate path and password are available

## Testing
- `uv run pre-commit run --files Makefile .github/workflows/windows-build.yml`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_689acb7b87a08323b3d89396eba18311