### PR TITLE
Include GUID generation in MSI build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ build-exe:
 >uv run pyinstaller scripts/bang.spec
 
 build-msi: build-exe
->heat dir dist/bang -out bang-files.wxs -cg BangFiles
+>heat dir dist/bang -out bang-files.wxs -cg BangFiles -dr INSTALLDIR -gg
 >candle bang-files.wxs scripts/bang.wxs
 >light bang-files.wixobj scripts/bang.wixobj -ext WixUIExtension -out dist/bang.msi
 >if [ -n "$$PFX_PATH" ] && [ -n "$$PFX_PASS" ]; then \


### PR DESCRIPTION
## Summary
- ensure `heat` harvests files under `INSTALLDIR` and generates stable component GUIDs

## Testing
- `uv run pre-commit run --files Makefile`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b0ced4ebc83238256071537f899ae