### PR TITLE
fix wix packaging commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,9 @@ build-exe:
 >uv run pyinstaller scripts/bang.spec
 
 build-msi: build-exe
->heat dir dist/bang -out bang-files.wxs -cg BangFiles -dr INSTALLDIR -gg
->candle bang-files.wxs scripts/bang.wxs
+>heat dir dist/bang -out bang-files.wxs -cg BangFiles -dr INSTALLDIR -gg -srd
+>candle bang-files.wxs -o bang-files.wixobj
+>candle scripts/bang.wxs -o scripts/bang.wixobj
 >light bang-files.wixobj scripts/bang.wixobj -ext WixUIExtension -out dist/bang.msi
 >if [ -n "$$PFX_PATH" ] && [ -n "$$PFX_PASS" ]; then \
 >  signtool sign /fd SHA256 /f "$$PFX_PATH" /p "$$PFX_PASS" dist/bang.msi; \


### PR DESCRIPTION
## Summary
- specify root and suppress root directory when harvesting msi files
- provide explicit output paths for wix `candle` steps

## Testing
- `uv run pre-commit run --files Makefile`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b1cff935c8323aa9b865655cd2ed3