### PR TITLE
Include WiX binder base path in MSI build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,9 @@ build-exe:
 
 build-msi: build-exe
 >heat dir dist/bang -out bang-files.wxs -cg BangFiles -dr INSTALLDIR -gg -srd -sw5150
->candle -o bang-files.wixobj bang-files.wxs
->candle -o scripts/bang.wixobj scripts/bang.wxs
->light bang-files.wixobj scripts/bang.wixobj -ext WixUIExtension -out dist/bang.msi
+>candle -b dist/bang -o bang-files.wixobj bang-files.wxs
+>candle -b dist/bang -o scripts/bang.wixobj scripts/bang.wxs
+>light bang-files.wixobj scripts/bang.wixobj -b dist/bang -ext WixUIExtension -out dist/bang.msi
 >if [ -n "$$PFX_PATH" ] && [ -n "$$PFX_PASS" ]; then \
 >  signtool sign /fd SHA256 /f "$$PFX_PATH" /p "$$PFX_PASS" dist/bang.msi; \
 >else \


### PR DESCRIPTION
## Summary
- ensure `candle` and `light` run with `-b dist/bang` so WiX uses the correct binder base path

## Testing
- `uv run pre-commit run --files Makefile`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_689bb24d3a9083239773f27a2668bda8