### PR TITLE
Fix icon path in Wix installer

### DIFF
--- a/scripts/bang.wxs
+++ b/scripts/bang.wxs
@@ -18,7 +18,7 @@
         <Directory Id="ApplicationProgramsFolder" Name="Bang" />
       </Directory>
     </Directory>
-    <Icon Id="BangIcon" SourceFile="dist/bang/bang.exe" />
+    <Icon Id="BangIcon" SourceFile="bang.exe" />
     <Component Id="BangShortcut" Directory="ApplicationProgramsFolder">
       <Shortcut Id="ApplicationStartMenuShortcut" Name="Bang"
                 Target="[INSTALLDIR]bang.exe" WorkingDirectory="INSTALLDIR"


### PR DESCRIPTION
## Summary
- Point Wix icon to `bang.exe` so the build root resolves to `dist/bang/bang.exe`

## Testing
- `uv run pre-commit run --files scripts/bang.wxs Makefile`
- `uv run pytest`

------
https://chatgpt.com/codex/tasks/task_e_689bb69166348323bf1ee4c82e5748f0