### PR TITLE
Use DistDir variable for MSI build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,10 @@ build-exe:
 >uv run pyinstaller scripts/bang.spec
 
 build-msi: build-exe
->heat dir dist/bang -out bang-files.wxs -cg BangFiles -dr INSTALLDIR -gg -srd -sw5150
->candle -b dist/bang -o bang-files.wixobj bang-files.wxs
->candle -b dist/bang -o scripts/bang.wixobj scripts/bang.wxs
->light bang-files.wixobj scripts/bang.wixobj -b dist/bang -ext WixUIExtension -out dist/bang.msi
+>heat dir dist/bang -out bang-files.wxs -cg BangFiles -dr INSTALLDIR -gg -srd -sw5150 -var var.DistDir
+>candle -dDistDir=dist/bang -o bang-files.wixobj bang-files.wxs
+>candle -dDistDir=dist/bang -o scripts/bang.wixobj scripts/bang.wxs
+>light bang-files.wixobj scripts/bang.wixobj -dDistDir=dist/bang -ext WixUIExtension -out dist/bang.msi
 >if [ -n "$$PFX_PATH" ] && [ -n "$$PFX_PASS" ]; then \
 >  signtool sign /fd SHA256 /f "$$PFX_PATH" /p "$$PFX_PASS" dist/bang.msi; \
 >else \

--- a/scripts/bang.wxs
+++ b/scripts/bang.wxs
@@ -18,7 +18,7 @@
         <Directory Id="ApplicationProgramsFolder" Name="Bang" />
       </Directory>
     </Directory>
-    <Icon Id="BangIcon" SourceFile="bang.exe" />
+    <Icon Id="BangIcon" SourceFile="$(var.DistDir)\\bang.exe" />
     <Component Id="BangShortcut" Directory="ApplicationProgramsFolder">
       <Shortcut Id="ApplicationStartMenuShortcut" Name="Bang"
                 Target="[INSTALLDIR]bang.exe" WorkingDirectory="INSTALLDIR"


### PR DESCRIPTION
## Summary
- propagate DistDir variable through MSI build steps
- reference DistDir for application icon

## Testing
- `uv run pre-commit run --files Makefile scripts/bang.wxs`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_689bbd1365048323a83bc41f0283283f