### PR TITLE
Fix registry path in WiX config

### DIFF
--- a/scripts/bang.wxs
+++ b/scripts/bang.wxs
@@ -24,7 +24,7 @@
                 Target="[INSTALLDIR]bang.exe" WorkingDirectory="INSTALLDIR"
                 Icon="BangIcon" IconIndex="0" />
       <RemoveFolder Id="ApplicationProgramsFolder" On="uninstall" />
-      <RegistryValue Root="HKCU" Key="Software\\Bang"
+      <RegistryValue Root="HKCU" Key="Software\Bang"
                      Name="installed" Type="integer"
                      Value="1" KeyPath="yes" />
     </Component>


### PR DESCRIPTION
## Summary
- fix HKCU registry path to use single backslash in WiX installer script

## Testing
- `uv run pre-commit run --files scripts/bang.wxs`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_689bca03d8748323a679a84c5e7da7eb