### PR TITLE
Embed CAB within MSI

### DIFF
--- a/scripts/bang.wxs
+++ b/scripts/bang.wxs
@@ -3,7 +3,7 @@
   <Product Id="*" Name="Bang" Manufacturer="Bang" Version="0.1.0" Language="1033"
            UpgradeCode="{90c8636b-9051-4fc6-b97d-cffbfd8b9baf}">
     <Package InstallerVersion="500" Compressed="yes" InstallScope="perMachine" />
-    <MediaTemplate />
+    <MediaTemplate EmbedCab="yes" />
     <Feature Id="MainFeature" Title="Bang" Level="1">
       <ComponentGroupRef Id="BangFiles" />
       <ComponentRef Id="BangShortcut" />


### PR DESCRIPTION
## Summary
- Embed cabinet data directly in the MSI by setting `MediaTemplate`'s `EmbedCab` attribute to `yes`

## Testing
- `uv run pre-commit run --files scripts/bang.wxs`
- `uv run pytest`
- `make build-msi` *(fails: ValueError: Resource '/workspace/bang/dist/bang' is not a valid file)*

------
https://chatgpt.com/codex/tasks/task_e_689bd2b867948323b1d089aab53ad1ae