### PR TITLE
Include QML files in PyInstaller build

### DIFF
--- a/scripts/bang.spec
+++ b/scripts/bang.spec
@@ -20,11 +20,18 @@ asset_paths = [
     for path in glob(pattern)
 ]
 
+qml_patterns = ('../bang_py/ui/qml/*.qml',)
+qml_paths = [
+    (path, 'bang_py/ui/qml')
+    for pattern in qml_patterns
+    for path in glob(pattern)
+]
+
 a = Analysis(
     ['../pyinstaller_entry.py'],
     pathex=[],
     binaries=collect_dynamic_libs('PySide6'),
-    datas=asset_paths,
+    datas=asset_paths + qml_paths,
     hiddenimports=
         collect_submodules('PySide6')
         + collect_submodules('websockets')


### PR DESCRIPTION
## Summary
- include `bang_py/ui/qml` QML files in PyInstaller data bundle so UI resources are packaged

## Testing
- `uv run pre-commit run --files scripts/bang.spec`
- `uv run pytest`
- `make build-msi` *(fails: ValueError: Resource '/workspace/bang/dist/bang' is not a valid file)*

------
https://chatgpt.com/codex/tasks/task_e_689be1aa3f7883238cf9c77bf50bd720