### PR TITLE
Exclude critical DLLs from UPX compression

### DIFF
--- a/scripts/bang.spec
+++ b/scripts/bang.spec
@@ -69,7 +69,7 @@ exe = EXE(
     bootloader_ignore_signals=False,
     strip=True,
     upx=True,
-    upx_exclude=[],
+    upx_exclude=['python*.dll', 'vcruntime140.dll', 'ucrtbase.dll'],
     runtime_tmpdir=None,
     console=False,
     disable_windowed_traceback=False,
@@ -85,6 +85,6 @@ coll = COLLECT(
     a.datas,
     strip=True,
     upx=True,
-    upx_exclude=[],
+    upx_exclude=['python*.dll', 'vcruntime140.dll', 'ucrtbase.dll'],
     name='bang',
 )


### PR DESCRIPTION
## Summary
- prevent UPX from compressing critical Windows runtime DLLs in PyInstaller spec to avoid launch issues

## Testing
- `uv run pre-commit run --files scripts/bang.spec`
- `uv run pytest`
- `make build-msi` *(fails: Resource '/workspace/bang/dist/bang' is not a valid file)*

------
https://chatgpt.com/codex/tasks/task_e_689bf00d8398832387a3bda36e54c560