### PR TITLE
Include additional Qt6 libraries in PyInstaller spec

### DIFF
--- a/scripts/bang.spec
+++ b/scripts/bang.spec
@@ -32,7 +32,15 @@ qt_libs = [
     lib
     for lib in collect_dynamic_libs('PySide6')
     if Path(lib[0]).name.startswith(
-        ('Qt6Core', 'Qt6Gui', 'Qt6Quick', 'Qt6Qml', 'Qt6Widgets')
+        (
+            'Qt6Core',
+            'Qt6Gui',
+            'Qt6Quick',
+            'Qt6QuickControls2',
+            'Qt6QuickTemplates2',
+            'Qt6Qml',
+            'Qt6Widgets',
+        )
     )
 ]
 


### PR DESCRIPTION
## Summary
- ensure PyInstaller bundles Qt6QuickControls2 and Qt6QuickTemplates2

## Testing
- `uv run pre-commit run --files scripts/bang.spec`
- `uv run pytest`
- `make build-msi` *(fails: Resource '/workspace/bang/dist/bang' is not a valid file)*

------
https://chatgpt.com/codex/tasks/task_e_689bfe9cb7588323827449d02816acba