### PR TITLE
Include missing Qt modules in PyInstaller spec

### DIFF
--- a/scripts/bang.spec
+++ b/scripts/bang.spec
@@ -38,6 +38,8 @@ qt_libs = [
             'Qt6Quick',
             'Qt6QuickControls2',
             'Qt6QuickTemplates2',
+            'Qt6QuickLayouts',
+            'Qt6Multimedia',
             'Qt6Qml',
             'Qt6Widgets',
         )
@@ -53,6 +55,8 @@ a = Analysis(
         collect_submodules('PySide6.QtCore')
         + collect_submodules('PySide6.QtGui')
         + collect_submodules('PySide6.QtQuick')
+        + collect_submodules('PySide6.QtQuickLayouts')
+        + collect_submodules('PySide6.QtMultimedia')
         + collect_submodules('PySide6.QtQml')
         + collect_submodules('PySide6.QtWidgets')
         + collect_submodules('websockets')


### PR DESCRIPTION
## Summary
- ensure PyInstaller collects Qt Quick Layouts, Multimedia, and related dependencies
- include PySide6 QuickLayouts and Multimedia hidden imports

## Testing
- `uv run pre-commit run --files scripts/bang.spec`
- `uv run pytest`
- `make build-msi` *(fails: missing libxkbcommon/libpulse and aborted)*
- `QT_QPA_PLATFORM=offscreen BANG_AUTO_CLOSE=1 uv run python pyinstaller_entry.py` *(fails: ImportError: libGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_689c62f4780c832384b43549df13f7d4